### PR TITLE
Range limiting, Secure cookies

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, ref, watch } from 'vue'
+import { computed, onMounted, ref, watch } from 'vue'
 import { RouterLink, RouterView, useRoute, useRouter } from 'vue-router'
 import { useI18n } from 'vue-i18n'
 import { useSettingsStore } from '@/stores/settings'
@@ -25,6 +25,10 @@ const {
   archiveNotification,
   deleteNotification,
 } = useNotifications()
+
+onMounted(() => {
+  auth.verifySession()
+})
 
 const carModel = computed(() => vehicleStore.vehicles[0]?.model ?? null)
 const menuOpen = ref(false)

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -177,6 +177,10 @@ export const notificationsApi = {
   delete: (id: number) => send(`/api/notifications/${id}`, 'DELETE'),
 }
 
+export interface MeResponse {
+  username: string
+}
+
 export const authApi = {
   login: (username: string, password: string, rememberMe = false) =>
     request<LoginResponse>('/api/auth/login', {
@@ -185,4 +189,5 @@ export const authApi = {
       body: JSON.stringify({ username, password, rememberMe }),
     }),
   logout: () => send('/api/auth/logout', 'POST'),
+  me: () => request<MeResponse>('/api/auth/me'),
 }

--- a/frontend/src/stores/auth.ts
+++ b/frontend/src/stores/auth.ts
@@ -29,5 +29,17 @@ export const useAuthStore = defineStore('auth', () => {
     await authApi.logout()
   }
 
-  return { username, isAuthenticated, login, logout }
+  async function verifySession(): Promise<void> {
+    try {
+      const result = await authApi.me()
+      username.value = result.username
+    } catch {
+      username.value = ''
+      expiresAtUtc.value = ''
+      localStorage.removeItem(AUTH_USERNAME_KEY)
+      localStorage.removeItem(AUTH_EXPIRES_KEY)
+    }
+  }
+
+  return { username, isAuthenticated, login, logout, verifySession }
 })

--- a/src/GarageStack.Api/Endpoints/AuthEndpoints.cs
+++ b/src/GarageStack.Api/Endpoints/AuthEndpoints.cs
@@ -20,7 +20,16 @@ public static class AuthEndpoints
         })
         .WithSummary("Clear the authentication cookie");
 
-        group.MapPost("/login", (LoginRequest req, IConfiguration config, HttpContext httpContext, ILoggerFactory loggerFactory) =>
+        group.MapGet("/me", (HttpContext httpContext) =>
+        {
+            var username = httpContext.User.FindFirst(ClaimTypes.Name)?.Value
+                ?? httpContext.User.FindFirst(JwtRegisteredClaimNames.Sub)?.Value;
+            return string.IsNullOrEmpty(username) ? Results.Unauthorized() : Results.Ok(new { username });
+        })
+        .RequireAuthorization()
+        .WithSummary("Get current authenticated user");
+
+        group.MapPost("/login", (LoginRequest req, IConfiguration config, HttpContext httpContext, IWebHostEnvironment env, ILoggerFactory loggerFactory) =>
         {
             var logger = loggerFactory.CreateLogger("AuthLogin");
 
@@ -90,7 +99,7 @@ public static class AuthEndpoints
             httpContext.Response.Cookies.Append("garagestack-auth", tokenString, new CookieOptions
             {
                 HttpOnly = true,
-                Secure = httpContext.Request.IsHttps,
+                Secure = !env.IsDevelopment() || httpContext.Request.IsHttps,
                 SameSite = SameSiteMode.Strict,
                 Expires = expires,
                 Path = "/",

--- a/src/GarageStack.Api/Endpoints/VehicleEndpoints.cs
+++ b/src/GarageStack.Api/Endpoints/VehicleEndpoints.cs
@@ -75,6 +75,11 @@ public static class VehicleEndpoints
 
             var start = from?.UtcDateTime ?? DateTime.UtcNow.AddDays(-7);
             var end = to?.UtcDateTime ?? DateTime.UtcNow;
+            if (start >= end)
+                return Results.BadRequest(new { error = "from must be before to" });
+            var maxRange = TimeSpan.FromDays(90);
+            if (end - start > maxRange)
+                start = end - maxRange;
             var history = await telemetry.GetHistoryAsync(vehicle.Id, start, end, ct);
             return Results.Ok(history);
         })
@@ -94,6 +99,11 @@ public static class VehicleEndpoints
 
             var start = from?.UtcDateTime ?? DateTime.UtcNow.AddDays(-30);
             var end = to?.UtcDateTime ?? DateTime.UtcNow;
+            if (start >= end)
+                return Results.BadRequest(new { error = "from must be before to" });
+            var maxRange = TimeSpan.FromDays(90);
+            if (end - start > maxRange)
+                start = end - maxRange;
             var trips = await telemetry.GetTripsAsync(vehicle.Id, start, end, ct);
             return Results.Ok(trips);
         })


### PR DESCRIPTION
High -- [AuthEndpoints.cs:93]

Secure is now !env.IsDevelopment() || httpContext.Request.IsHttps -- always true outside dev, regardless of proxy TLS termination
Added GET /api/auth/me endpoint (needed for fix 3)
Medium -- [VehicleEndpoints.cs]

Both /history and /trips now reject from >= to with 400
Both cap the window to 90 days (silently adjusting start rather than rejecting, to keep the UI smooth for overly broad defaults)
Low -- [auth.ts], [api.ts]

authApi.me() calls the new /api/auth/me endpoint
verifySession() in the store hits the server on startup; any 401 clears localStorage and signs the user out
App.vue calls verifySession() on mount so stale or tampered localStorage is corrected within the first round-trip