### PR TITLE
Session verification cannot actually restore authenticated state when…

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -26,8 +26,12 @@ const {
   deleteNotification,
 } = useNotifications()
 
-onMounted(() => {
-  auth.verifySession()
+onMounted(async () => {
+  await auth.verifySession()
+  if (auth.isAuthenticated && route.name === 'login') {
+    const redirect = route.query.redirect as string | undefined
+    router.replace(redirect ?? '/')
+  }
 })
 
 const carModel = computed(() => vehicleStore.vehicles[0]?.model ?? null)

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -179,6 +179,7 @@ export const notificationsApi = {
 
 export interface MeResponse {
   username: string
+  expiresAtUtc: string | null
 }
 
 export const authApi = {

--- a/frontend/src/stores/auth.ts
+++ b/frontend/src/stores/auth.ts
@@ -33,6 +33,11 @@ export const useAuthStore = defineStore('auth', () => {
     try {
       const result = await authApi.me()
       username.value = result.username
+      if (result.expiresAtUtc) {
+        expiresAtUtc.value = result.expiresAtUtc
+        localStorage.setItem(AUTH_USERNAME_KEY, result.username)
+        localStorage.setItem(AUTH_EXPIRES_KEY, result.expiresAtUtc)
+      }
     } catch {
       username.value = ''
       expiresAtUtc.value = ''

--- a/src/GarageStack.Api/Endpoints/AuthEndpoints.cs
+++ b/src/GarageStack.Api/Endpoints/AuthEndpoints.cs
@@ -24,7 +24,14 @@ public static class AuthEndpoints
         {
             var username = httpContext.User.FindFirst(ClaimTypes.Name)?.Value
                 ?? httpContext.User.FindFirst(JwtRegisteredClaimNames.Sub)?.Value;
-            return string.IsNullOrEmpty(username) ? Results.Unauthorized() : Results.Ok(new { username });
+            if (string.IsNullOrEmpty(username)) return Results.Unauthorized();
+
+            DateTime? expiresAtUtc = null;
+            var expClaim = httpContext.User.FindFirst(JwtRegisteredClaimNames.Exp)?.Value;
+            if (long.TryParse(expClaim, out var expUnix))
+                expiresAtUtc = DateTimeOffset.FromUnixTimeSeconds(expUnix).UtcDateTime;
+
+            return Results.Ok(new MeResponse(username, expiresAtUtc));
         })
         .RequireAuthorization()
         .WithSummary("Get current authenticated user");
@@ -135,3 +142,4 @@ public static class AuthEndpoints
 
 public sealed record LoginRequest(string Username, string Password, bool RememberMe = false);
 public sealed record LoginResponse(string Username, DateTime ExpiresAtUtc);
+public sealed record MeResponse(string Username, DateTime? ExpiresAtUtc);


### PR DESCRIPTION
… local expiry is missing or stale.

a user with a valid auth cookie can still be treated as logged out after reload if local expiry is absent/expired, so the new me flow does not fully solve client-side auth truth.