### PR TITLE
Fixed trip cards display, fixed statisticsview loading behaviour

### DIFF
--- a/frontend/src/assets/main.css
+++ b/frontend/src/assets/main.css
@@ -847,29 +847,35 @@ body,
   display: flex;
   flex-direction: column;
   gap: 0.1rem;
+  flex: 1;
+  min-width: 0;
+}
+
+.trip-list__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 0.5rem;
 }
 
 .trip-list__name {
   font-size: 0.85rem;
   font-weight: 600;
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.trip-list__time {
+  font-size: 0.85rem;
+  flex-shrink: 0;
 }
 
 .trip-list__meta {
   font-size: 0.75rem;
   color: var(--color-text-muted);
-}
-
-.trip-list__date {
-  font-size: 0.7rem;
-  color: var(--color-text-muted);
-}
-
-/* ── Inline trip detail (shown inside active card) ───────────── */
-
-.trip-detail__dl--card {
-  margin-top: 0.5rem;
-  padding-top: 0.5rem;
-  border-top: 1px solid var(--color-border);
 }
 
 .trip-pagination {
@@ -936,16 +942,6 @@ body,
   white-space: nowrap;
 }
 
-.trip-detail__dl {
-  display: grid;
-  grid-template-columns: auto 1fr;
-  gap: 0.25rem 0.75rem;
-  font-size: 0.8rem;
-}
-
-.trip-detail__dl dt {
-  color: var(--color-text-muted);
-}
 
 /* ── Control panel ────────────────────────────────────────── */
 

--- a/frontend/src/assets/main.css
+++ b/frontend/src/assets/main.css
@@ -942,7 +942,6 @@ body,
   white-space: nowrap;
 }
 
-
 /* ── Control panel ────────────────────────────────────────── */
 
 .control-grid {

--- a/frontend/src/views/MapView.vue
+++ b/frontend/src/views/MapView.vue
@@ -23,6 +23,7 @@ const settingsStore = useSettingsStore()
 
 const vin = computed(() => store.vehicles[0]?.vin ?? null)
 const status = computed(() => store.currentStatus)
+const displayLocale = computed(() => (settingsStore.locale === 'nl' ? 'nl-NL' : 'en-US'))
 const selectedTripIndex = ref<number | null>(null)
 const heatmapEnabled = ref(true)
 
@@ -387,29 +388,22 @@ onUnmounted(() => {
                 :class="tripColorClass(realIndex(pageOffset + displayIdx))"
               />
               <div class="trip-list__info">
-                <span class="trip-list__name">{{
-                  new Date(trip.startedAt).toLocaleDateString()
-                }}</span>
+                <div class="trip-list__header">
+                  <span class="trip-list__name">{{
+                    new Date(trip.startedAt).toLocaleDateString(displayLocale)
+                  }}</span>
+                  <span class="trip-list__time">{{
+                    new Date(trip.startedAt).toLocaleTimeString(displayLocale, {
+                      hour: '2-digit',
+                      minute: '2-digit',
+                    })
+                  }}</span>
+                </div>
                 <span class="trip-list__meta">
                   {{ trip.distanceKm }} {{ t('common.km') }} &middot;
-                  {{ formatDuration(trip.startedAt, trip.endedAt) }}
+                  {{ formatDuration(trip.startedAt, trip.endedAt) }} &middot;
+                  {{ trip.pointCount }}
                 </span>
-                <dl
-                  v-if="selectedTripIndex === realIndex(pageOffset + displayIdx)"
-                  class="trip-detail__dl trip-detail__dl--card"
-                >
-                  <dt>{{ t('trips.started') }}</dt>
-                  <dd>
-                    {{
-                      new Date(trip.startedAt).toLocaleTimeString([], {
-                        hour: '2-digit',
-                        minute: '2-digit',
-                      })
-                    }}
-                  </dd>
-                  <dt>{{ t('trips.points') }}</dt>
-                  <dd>{{ trip.pointCount }}</dd>
-                </dl>
               </div>
             </li>
           </ul>

--- a/frontend/src/views/StatisticsView.vue
+++ b/frontend/src/views/StatisticsView.vue
@@ -42,6 +42,7 @@ const store = useVehicleStore()
 const settings = useSettingsStore()
 
 const editMode = ref(false)
+const loading = ref(false)
 
 const days = computed({
   get: () => settings.filterDays,
@@ -54,15 +55,20 @@ const vin = computed(() => store.vehicles[0]?.vin ?? null)
 const status = computed(() => store.currentStatus)
 
 async function load() {
-  await store.fetchVehicles()
-  if (!vin.value) return
-  const from = new Date(Date.now() - days.value * 86_400_000).toISOString()
-  await Promise.all([
-    store.fetchHistory(vin.value, from),
-    store.fetchTrips(vin.value, from),
-    store.fetchStatus(vin.value),
-    store.fetchConfig(vin.value),
-  ])
+  loading.value = true
+  try {
+    await store.fetchVehicles()
+    if (!vin.value) return
+    const from = new Date(Date.now() - days.value * 86_400_000).toISOString()
+    await Promise.all([
+      store.fetchHistory(vin.value, from),
+      store.fetchTrips(vin.value, from),
+      store.fetchStatus(vin.value),
+      store.fetchConfig(vin.value),
+    ])
+  } finally {
+    loading.value = false
+  }
 }
 
 onMounted(load)
@@ -592,7 +598,7 @@ function resetStatsLayout() {
       </div>
     </div>
 
-    <div v-if="store.loading && !status && !store.history.length" class="loading-state">
+    <div v-if="loading" class="loading-state">
       <font-awesome-icon icon="spinner" spin />
       {{ t('common.loading') }}
     </div>


### PR DESCRIPTION
- The trip display now longer expands when clicked but shows all information on the card directly
- The statisticsview cards no longer jump on load, but the loader stays spinning until everything is ready 