### PR TITLE
Notification enhancements

### DIFF
--- a/frontend/src/stores/auth.ts
+++ b/frontend/src/stores/auth.ts
@@ -1,4 +1,4 @@
-import { computed, ref } from 'vue'
+import { computed, onScopeDispose, ref } from 'vue'
 import { defineStore } from 'pinia'
 import { authApi } from '@/services/api'
 
@@ -9,8 +9,12 @@ export const useAuthStore = defineStore('auth', () => {
   const username = ref<string>(localStorage.getItem(AUTH_USERNAME_KEY) ?? '')
   const expiresAtUtc = ref<string>(localStorage.getItem(AUTH_EXPIRES_KEY) ?? '')
 
+  const now = ref(Date.now())
+  const clockInterval = setInterval(() => { now.value = Date.now() }, 60_000)
+  onScopeDispose(() => clearInterval(clockInterval))
+
   const isAuthenticated = computed(
-    () => !!username.value && !!expiresAtUtc.value && new Date(expiresAtUtc.value) > new Date(),
+    () => !!username.value && !!expiresAtUtc.value && new Date(expiresAtUtc.value).getTime() > now.value,
   )
 
   // Cached promise so the server round-trip happens exactly once per page load.

--- a/frontend/src/stores/auth.ts
+++ b/frontend/src/stores/auth.ts
@@ -10,11 +10,16 @@ export const useAuthStore = defineStore('auth', () => {
   const expiresAtUtc = ref<string>(localStorage.getItem(AUTH_EXPIRES_KEY) ?? '')
 
   const now = ref(Date.now())
-  const clockInterval = setInterval(() => { now.value = Date.now() }, 60_000)
+  const clockInterval = setInterval(() => {
+    now.value = Date.now()
+  }, 60_000)
   onScopeDispose(() => clearInterval(clockInterval))
 
   const isAuthenticated = computed(
-    () => !!username.value && !!expiresAtUtc.value && new Date(expiresAtUtc.value).getTime() > now.value,
+    () =>
+      !!username.value &&
+      !!expiresAtUtc.value &&
+      new Date(expiresAtUtc.value).getTime() > now.value,
   )
 
   // Cached promise so the server round-trip happens exactly once per page load.

--- a/src/GarageStack.Api/Endpoints/NotificationEndpoints.cs
+++ b/src/GarageStack.Api/Endpoints/NotificationEndpoints.cs
@@ -17,7 +17,7 @@ public static class NotificationEndpoints
                 .AsNoTracking()
                 .Where(n => !n.IsDeleted)
                 .OrderByDescending(n => n.CreatedAt)
-                .Select(n => new NotificationDto(n.Id, n.Title, n.Body, n.CreatedAt, n.IsArchived))
+                .Select(n => new NotificationDto(n.Id, n.Title, n.Body, n.CreatedAt, n.IsArchived, n.Category))
                 .ToListAsync(ct);
             return Results.Ok(notifications);
         })
@@ -47,4 +47,4 @@ public static class NotificationEndpoints
     }
 }
 
-public record NotificationDto(int Id, string Title, string Body, DateTime CreatedAt, bool IsArchived);
+public record NotificationDto(int Id, string Title, string Body, DateTime CreatedAt, bool IsArchived, string? Category);

--- a/src/GarageStack.Api/Endpoints/VehicleEndpoints.cs
+++ b/src/GarageStack.Api/Endpoints/VehicleEndpoints.cs
@@ -203,8 +203,14 @@ public static class VehicleEndpoints
                     P256DhKey = req.P256DhKey,
                     AuthKey = req.AuthKey,
                 });
-                await db.SaveChangesAsync(ct);
             }
+            else if (existing.P256DhKey != req.P256DhKey || existing.AuthKey != req.AuthKey)
+            {
+                existing.P256DhKey = req.P256DhKey;
+                existing.AuthKey = req.AuthKey;
+            }
+
+            await db.SaveChangesAsync(ct);
 
             return Results.Ok();
         })

--- a/src/GarageStack.Worker/Services/PushNotificationCheckService.cs
+++ b/src/GarageStack.Worker/Services/PushNotificationCheckService.cs
@@ -63,6 +63,14 @@ public class PushNotificationCheckService(
                 if (_lastNotified.TryGetValue(notifKey, out var last) && DateTime.UtcNow - last < _cooldown)
                     continue;
 
+                // Cross-service dedup: check DB so MQTT-emitted notifications suppress repeated checker alerts.
+                var cutoff = DateTime.UtcNow - _cooldown;
+                if (await db.AppNotifications.AnyAsync(n => n.Category == key && n.CreatedAt > cutoff, ct))
+                {
+                    _lastNotified[notifKey] = DateTime.UtcNow;
+                    continue;
+                }
+
                 _lastNotified[notifKey] = DateTime.UtcNow;
                 await pushSender.SendToAllAsync(title, body, ct, key);
                 logger.LogInformation("Push sent: {Key} - {Title}", notifKey, title);

--- a/src/GarageStack.Worker/Services/PushSenderService.cs
+++ b/src/GarageStack.Worker/Services/PushSenderService.cs
@@ -88,7 +88,9 @@ public sealed class PushSenderService : IPushSender, IDisposable
             {
                 await _pushClient.RequestPushMessageDeliveryAsync(pushSub, message, ct);
             }
-            catch (PushServiceClientException ex) when (ex.StatusCode == System.Net.HttpStatusCode.Gone)
+            catch (PushServiceClientException ex) when (
+                ex.StatusCode == System.Net.HttpStatusCode.Gone ||
+                ex.StatusCode == System.Net.HttpStatusCode.NotFound)
             {
                 dead.Add(sub);
             }


### PR DESCRIPTION
High - Double engine-start notification (PushNotificationCheckService.cs): Before sending any alert, the checker now queries AppNotifications for a recent record with the same Category within the cooldown window. A notification already emitted by the MQTT path will be found there, preventing the duplicate. The local _lastNotified cache is updated on a skip so subsequent polls don't hit the DB unnecessarily.

Medium - Category missing from API response (NotificationEndpoints.cs): Added string? Category to NotificationDto and included n.Category in the Select projection.

Medium - Stale push subscription keys (VehicleEndpoints.cs): When the endpoint already exists, the subscribe handler now checks whether P256DhKey or AuthKey differ and updates them if so. SaveChangesAsync is now called unconditionally (EF change tracking makes the insert/update call redundant when nothing changed).

Low - 404 not cleaning expired subscriptions (PushSenderService.cs): Added HttpStatusCode.NotFound to the dead-subscription catch alongside the existing 410.

Low - Stale authenticated state (auth.ts): Added a now ref ticking every 60 seconds; isAuthenticated compares against now.value so it reacts to expiry without needing a network failure. The interval is cleaned up via onScopeDispose.
