### PR TITLE
Better way to determine statistics

### DIFF
--- a/src/GarageStack.Data/Repositories/TelemetryRepository.cs
+++ b/src/GarageStack.Data/Repositories/TelemetryRepository.cs
@@ -34,6 +34,19 @@ public class TelemetryRepository(AppDbContext db) : ITelemetryRepository
              s.HeatedSeatFrontLeft != null || s.HeatedSeatFrontRight != null ||
              s.RearWindowDefroster != null;
 
+    // Chart history excludes GPS-only rows: latitude/longitude arrive every minute during driving
+    // and inflate the row count, causing the stride downsampler to skip the sparser fuel/EV/kWh rows.
+    // GPS data for routes belongs to the trips endpoint, not chart history.
+    private static readonly Expression<Func<TelemetrySnapshot, bool>> HasChartData =
+        s => s.FuelLevelPercent != null || s.EvSocPercent != null ||
+             s.PowerUsageOfDay != null || s.BatteryVoltage != null ||
+             s.ClimateOn != null || s.IsCharging != null ||
+             s.TyrePressureFrontLeft != null || s.TyrePressureFrontRight != null ||
+             s.TyrePressureRearLeft != null || s.TyrePressureRearRight != null ||
+             s.MileageOfTheDay != null || s.MileageSinceLastCharge != null ||
+             s.HvSocKwh != null || s.HvTotalCapacityKwh != null ||
+             s.PowerUsageSinceLastCharge != null;
+
     public async Task AddAsync(TelemetrySnapshot snapshot, CancellationToken ct = default)
     {
         db.TelemetrySnapshots.Add(snapshot);
@@ -143,7 +156,7 @@ public class TelemetryRepository(AppDbContext db) : ITelemetryRepository
         var rows = await db.TelemetrySnapshots
             .AsNoTracking()
             .Where(s => s.VehicleId == vehicleId && s.RecordedAt >= from && s.RecordedAt <= to)
-            .Where(HasData)
+            .Where(HasChartData)
             .OrderBy(s => s.RecordedAt)
             .ToListAsync(ct);
 


### PR DESCRIPTION
# Pull Request

## Summary

he MG API publishes GPS coordinates (latitude/longitude) on a very frequent MQTT topic during driving - potentially every 30-60 seconds. Fuel level, EV SOC, and powerUsageOfDay come on separate drivetrain topics at much lower frequency. The GetHistoryAsync method included GPS-only rows via the HasData filter, which inflated the total row count. The stride-based downsampler then picked every Nth row globally - and with a large N (e.g., step=21 for 7000 rows), it could skip all sparse fuel/EV rows from a recent day entirely.

Fix: Added a HasChartData filter in [TelemetryRepository.cs](vscode-webview://0ca6r5jfdo2en7faa1gv5sge0fo55nndntr26smc3trphgu5rra5/src/GarageStack.Data/Repositories/TelemetryRepository.cs) that only keeps rows with at least one chart-relevant field (fuel %, EV SOC, kWh, tyre pressures, battery voltage, climate, etc.) - explicitly excluding pure GPS rows. GPS data for routes is correctly handled by the trips endpoint. This dramatically reduces the row count for the downsampler, so chart-relevant rows are no longer crowded out.

## Type of Change
 Bug fix

