### PR TITLE
Fix PWA notifications tag

### DIFF
--- a/frontend/src/sw.ts
+++ b/frontend/src/sw.ts
@@ -13,7 +13,7 @@ self.addEventListener('activate', (event) => event.waitUntil(self.clients.claim(
 self.addEventListener('push', (event) => {
   if (!event.data) return
 
-  let payload: { title?: string; body?: string; url?: string } = {}
+  let payload: { title?: string; body?: string; url?: string; category?: string } = {}
   try {
     payload = event.data.json() as typeof payload
   } catch {
@@ -21,11 +21,13 @@ self.addEventListener('push', (event) => {
   }
 
   const title = payload.title ?? 'GarageStack'
+  const tag = payload.category ?? 'garagestack-notification'
   const options: NotificationOptions = {
     body: payload.body ?? '',
     icon: '/pwa-192x192.png',
     badge: '/pwa-64x64.png',
-    tag: 'garagestack-notification',
+    tag,
+    renotify: true,
     data: { url: payload.url ?? '/' },
   }
 


### PR DESCRIPTION
Every push notification was sent with tag: 'garagestack-notification'. When engine-start and windows-open (or any two alerts) arrived close together, the second one silently replaced the first in the OS tray because browsers deduplicate notifications by tag without alerting the user. Since engine-start fires via MQTT (real-time) and the checker runs every 5 minutes, whichever push you saw depended on delivery order.

The fix uses payload.category as the tag (e.g. 'engine-start', 'windows-open-parked'), so each alert type gets its own slot in the notification tray. renotify: true is added so if the same category fires again after the cooldown expires, the OS actually shows the alert sound/banner again rather than silently refreshing the existing one.