### PR TITLE
Several fixes found by Codex

### DIFF
--- a/frontend/src/composables/useNotifications.ts
+++ b/frontend/src/composables/useNotifications.ts
@@ -1,11 +1,13 @@
 import { ref, computed, onMounted, onUnmounted } from 'vue'
 import { notificationsApi, type AppNotification } from '@/services/api'
+import { useAuthStore } from '@/stores/auth'
 
 const notifications = ref<AppNotification[]>([])
 const panelOpen = ref(false)
 const loading = ref(false)
 
 export function useNotifications() {
+  const auth = useAuthStore()
   const unreadCount = computed(() => notifications.value.filter((n) => !n.isArchived).length)
 
   async function fetchNotifications() {
@@ -24,6 +26,7 @@ export function useNotifications() {
   }
 
   onMounted(() => {
+    if (!auth.isAuthenticated) return
     fetchNotifications()
     navigator.serviceWorker?.addEventListener('message', onSwMessage)
   })

--- a/frontend/src/stores/vehicle.ts
+++ b/frontend/src/stores/vehicle.ts
@@ -19,10 +19,8 @@ export const useVehicleStore = defineStore('vehicle', () => {
     error.value = null
     try {
       const result = await vehicleApi.list()
-      console.log('[vehicle] fetchVehicles response:', result)
       vehicles.value = result
     } catch (e) {
-      console.error('[vehicle] fetchVehicles error:', e)
       error.value = String(e)
     } finally {
       loadingCount.value--
@@ -54,10 +52,8 @@ export const useVehicleStore = defineStore('vehicle', () => {
     error.value = null
     try {
       const result = await vehicleApi.history(vin, from, to)
-      console.log('[vehicle] fetchHistory result:', result?.length, 'items', 'from=', from)
       history.value = result
     } catch (e) {
-      console.error('[vehicle] fetchHistory error:', e)
       error.value = String(e)
     } finally {
       loadingCount.value--

--- a/src/GarageStack.Api/Endpoints/NotificationEndpoints.cs
+++ b/src/GarageStack.Api/Endpoints/NotificationEndpoints.cs
@@ -11,17 +11,19 @@ public static class NotificationEndpoints
             .WithTags("Notifications")
             .RequireAuthorization();
 
-        group.MapGet("/", async (AppDbContext db, CancellationToken ct) =>
+        group.MapGet("/", async (AppDbContext db, CancellationToken ct, int limit = 100) =>
         {
+            if (limit is < 1 or > 500) limit = 100;
             var notifications = await db.AppNotifications
                 .AsNoTracking()
                 .Where(n => !n.IsDeleted)
                 .OrderByDescending(n => n.CreatedAt)
+                .Take(limit)
                 .Select(n => new NotificationDto(n.Id, n.Title, n.Body, n.CreatedAt, n.IsArchived, n.Category))
                 .ToListAsync(ct);
             return Results.Ok(notifications);
         })
-        .WithSummary("List all non-deleted notifications");
+        .WithSummary("List non-deleted notifications (most recent first, default limit 100)");
 
         group.MapPatch("/{id:int}/archive", async (int id, AppDbContext db, CancellationToken ct) =>
         {

--- a/src/GarageStack.Api/Program.cs
+++ b/src/GarageStack.Api/Program.cs
@@ -134,14 +134,27 @@ try
     {
         ForwardedHeaders = ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto,
     };
-    // Trust RFC 1918 private ranges so nginx running in a Docker network
-    // (typically 172.16-31.x.x) is recognised as a trusted proxy and
-    // X-Forwarded-Proto: https is applied correctly.
+    var trustedProxies = app.Configuration.GetSection("ForwardedHeaders:TrustedProxies").Get<string[]>();
+    if (trustedProxies is { Length: > 0 })
+    {
+        // Prefer explicit proxy IPs to limit header-spoofing surface.
+        foreach (var proxyIp in trustedProxies)
+            if (System.Net.IPAddress.TryParse(proxyIp, out var ip))
+                forwardedOptions.KnownProxies.Add(ip);
+    }
+    else
+    {
+        // Fallback: trust all RFC 1918 ranges so nginx in a Docker network is recognised.
+        // Set ForwardedHeaders:TrustedProxies in production to restrict to the actual proxy IP.
+        if (!app.Environment.IsDevelopment())
+            Log.Warning("ForwardedHeaders:TrustedProxies is not configured — trusting all RFC 1918 ranges. " +
+                        "Set this to your proxy IP(s) to prevent forwarded-header spoofing.");
 #pragma warning disable ASPDEPR005
-    forwardedOptions.KnownNetworks.Add(new IPNetwork(System.Net.IPAddress.Parse("10.0.0.0"), 8));
-    forwardedOptions.KnownNetworks.Add(new IPNetwork(System.Net.IPAddress.Parse("172.16.0.0"), 12));
-    forwardedOptions.KnownNetworks.Add(new IPNetwork(System.Net.IPAddress.Parse("192.168.0.0"), 16));
+        forwardedOptions.KnownNetworks.Add(new IPNetwork(System.Net.IPAddress.Parse("10.0.0.0"), 8));
+        forwardedOptions.KnownNetworks.Add(new IPNetwork(System.Net.IPAddress.Parse("172.16.0.0"), 12));
+        forwardedOptions.KnownNetworks.Add(new IPNetwork(System.Net.IPAddress.Parse("192.168.0.0"), 16));
 #pragma warning restore ASPDEPR005
+    }
     app.UseForwardedHeaders(forwardedOptions);
     app.UseSerilogRequestLogging();
     app.UseCors();


### PR DESCRIPTION
Medium - Notifications API unbounded (NotificationEndpoints.cs): Added a limit query param (default 100, capped at 500) with Take(limit) before the DB fetch.

Medium - Forwarded-header trust (Program.cs): If ForwardedHeaders:TrustedProxies is set in config (comma-separated IPs), only those exact addresses are trusted as proxies. Falls back to the RFC1918 ranges for Docker setups, but now logs a production warning prompting you to set the specific proxy IP.

Low - Console leakage in vehicle.ts (vehicle.ts): Removed the four console.log/console.error calls in fetchVehicles and fetchHistory.

Low - Notifications fetch on login route (useNotifications.ts): onMounted now checks auth.isAuthenticated and returns early if not logged in, so the fetch and SW listener are skipped on the login page.