### PR TITLE
Fix available/offline bool parsing and store missing charge fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,6 +263,14 @@ The endpoint returns a flat JSON object. Numeric fields are `null` when the vehi
 | `batteryHeatingScheduleMode` | string | Battery heating schedule mode (e.g. `"off"`) |
 | `batteryHeatingScheduleStartTime` | string | Battery heating schedule start time (HH:MM) |
 | `elevation` | number | Vehicle elevation above sea level (m) |
+| `bmsChargeStatus` | string | BMS charge status string (e.g. `"UNPLUGGED"`, `"CHARGING"`) |
+| `lastChargeEndingPower` | number | State of charge (%) when the last charge session ended |
+| `chargingLastEndAt` | string (ISO 8601) | Timestamp the last charge session ended |
+| `chargingScheduleMode` | string | Scheduled charging mode (e.g. `"DISABLED"`, `"UNTIL_CONFIGURED_TIME"`) |
+| `chargingScheduleStartTime` | string | Scheduled charge start time (HH:MM) |
+| `chargingScheduleEndTime` | string | Scheduled charge end time (HH:MM) |
+| `onboardChargerPlugStatus` | number | Onboard charger plug presence status (raw integer) |
+| `offboardChargerPlugStatus` | number | Offboard (DC) charger plug presence status (raw integer) |
 
 ---
 

--- a/frontend/src/components/ChargingSessionCard.vue
+++ b/frontend/src/components/ChargingSessionCard.vue
@@ -13,6 +13,12 @@ const props = defineProps<{
   obcPowerSinglePhase: number | null
   obcPowerThreePhase: number | null
   remainingChargingTime: number | null
+  bmsChargeStatus: string | null
+  lastChargeEndingPower: number | null
+  chargingLastEndAt: string | null
+  chargingScheduleMode: string | null
+  chargingScheduleStartTime: string | null
+  chargingScheduleEndTime: string | null
 }>()
 
 const { isOpen: modalOpen, open: openModal, close: closeModal } = useModal()
@@ -38,8 +44,18 @@ const hasAnyData = computed(
     obcPower.value !== null ||
     props.chargingType !== null ||
     props.chargingCableLock !== null ||
-    props.remainingChargingTime !== null,
+    props.remainingChargingTime !== null ||
+    props.bmsChargeStatus !== null,
 )
+
+const lastEndFormatted = computed((): string | null => {
+  if (!props.chargingLastEndAt) return null
+  try {
+    return new Date(props.chargingLastEndAt).toLocaleString()
+  } catch {
+    return null
+  }
+})
 </script>
 
 <template>
@@ -101,6 +117,40 @@ const hasAnyData = computed(
         </span>
         <span class="detail-list__item-sep">-</span>
         <span class="detail-list__item-label">{{ t('vehicle.chargingSession.cableLock') }}</span>
+      </div>
+      <div v-if="bmsChargeStatus" class="detail-list__item">
+        <font-awesome-icon icon="battery-half" class="detail-list__item-icon" />
+        <span class="badge badge-secondary">{{ bmsChargeStatus }}</span>
+        <span class="detail-list__item-sep">-</span>
+        <span class="detail-list__item-label">{{ t('vehicle.chargingSession.bmsStatus') }}</span>
+      </div>
+      <div v-if="lastChargeEndingPower !== null" class="detail-list__item">
+        <font-awesome-icon icon="percent" class="detail-list__item-icon" />
+        <span class="detail-list__item-value">{{ lastChargeEndingPower.toFixed(1) }}%</span>
+        <span class="detail-list__item-sep">-</span>
+        <span class="detail-list__item-label">{{ t('vehicle.chargingSession.lastEndSoc') }}</span>
+      </div>
+      <div v-if="lastEndFormatted" class="detail-list__item">
+        <font-awesome-icon icon="calendar-check" class="detail-list__item-icon" />
+        <span class="detail-list__item-value">{{ lastEndFormatted }}</span>
+        <span class="detail-list__item-sep">-</span>
+        <span class="detail-list__item-label">{{ t('vehicle.chargingSession.lastEnd') }}</span>
+      </div>
+      <div
+        v-if="chargingScheduleMode && chargingScheduleMode !== 'DISABLED'"
+        class="detail-list__item"
+      >
+        <font-awesome-icon icon="clock" class="detail-list__item-icon" />
+        <span class="badge badge-info">{{ chargingScheduleMode }}</span>
+        <template v-if="chargingScheduleStartTime">
+          <span class="detail-list__item-value">{{ chargingScheduleStartTime }}</span>
+          <template v-if="chargingScheduleEndTime">
+            <span class="detail-list__item-sep">-</span>
+            <span class="detail-list__item-value">{{ chargingScheduleEndTime }}</span>
+          </template>
+        </template>
+        <span class="detail-list__item-sep">-</span>
+        <span class="detail-list__item-label">{{ t('vehicle.chargingSession.schedule') }}</span>
       </div>
     </div>
   </DetailModal>

--- a/frontend/src/components/DashboardCardContent.vue
+++ b/frontend/src/components/DashboardCardContent.vue
@@ -300,6 +300,12 @@ const supportsExternalCharge = computed(
       :obc-power-single-phase="status.obcPowerSinglePhase"
       :obc-power-three-phase="status.obcPowerThreePhase"
       :remaining-charging-time="status.remainingChargingTime"
+      :bms-charge-status="status.bmsChargeStatus"
+      :last-charge-ending-power="status.lastChargeEndingPower"
+      :charging-last-end-at="status.chargingLastEndAt"
+      :charging-schedule-mode="status.chargingScheduleMode"
+      :charging-schedule-start-time="status.chargingScheduleStartTime"
+      :charging-schedule-end-time="status.chargingScheduleEndTime"
     />
 
     <!-- batteryHeating -->

--- a/frontend/src/composables/__tests__/useVehicleAlerts.spec.ts
+++ b/frontend/src/composables/__tests__/useVehicleAlerts.spec.ts
@@ -71,6 +71,14 @@ function makeSnapshot(overrides: Partial<TelemetrySnapshot> = {}): TelemetrySnap
     batteryHeatingScheduleMode: null,
     batteryHeatingScheduleStartTime: null,
     elevation: null,
+    bmsChargeStatus: null,
+    lastChargeEndingPower: null,
+    chargingLastEndAt: null,
+    chargingScheduleMode: null,
+    chargingScheduleStartTime: null,
+    chargingScheduleEndTime: null,
+    onboardChargerPlugStatus: null,
+    offboardChargerPlugStatus: null,
     ...overrides,
   }
 }

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -151,7 +151,11 @@
       "type": "Charging type",
       "cableLock": "Cable lock",
       "locked": "Locked",
-      "unlocked": "Unlocked"
+      "unlocked": "Unlocked",
+      "bmsStatus": "BMS status",
+      "lastEndSoc": "Last charge ended at",
+      "lastEnd": "Last charge session",
+      "schedule": "Charge schedule"
     },
     "batteryHeating": {
       "title": "Battery heating",

--- a/frontend/src/locales/nl.json
+++ b/frontend/src/locales/nl.json
@@ -151,7 +151,11 @@
       "type": "Laadtype",
       "cableLock": "Kabelslot",
       "locked": "Vergrendeld",
-      "unlocked": "Ontgrendeld"
+      "unlocked": "Ontgrendeld",
+      "bmsStatus": "BMS-status",
+      "lastEndSoc": "Laatste laadbeurt gestopt op",
+      "lastEnd": "Laatste laadsessie",
+      "schedule": "Laadschema"
     },
     "batteryHeating": {
       "title": "Accuverwarming",

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -132,6 +132,14 @@ export interface TelemetrySnapshot {
   batteryHeatingScheduleMode: string | null
   batteryHeatingScheduleStartTime: string | null
   elevation: number | null
+  bmsChargeStatus: string | null
+  lastChargeEndingPower: number | null
+  chargingLastEndAt: string | null
+  chargingScheduleMode: string | null
+  chargingScheduleStartTime: string | null
+  chargingScheduleEndTime: string | null
+  onboardChargerPlugStatus: number | null
+  offboardChargerPlugStatus: number | null
 }
 
 export interface TripPoint {

--- a/src/GarageStack.Api/Endpoints/WidgetEndpoints.cs
+++ b/src/GarageStack.Api/Endpoints/WidgetEndpoints.cs
@@ -119,7 +119,16 @@ public record WidgetStatusDto(
     string? BatteryHeatingScheduleMode,
     string? BatteryHeatingScheduleStartTime,
     // Location extras
-    double? Elevation
+    double? Elevation,
+    // Extended charge session
+    string? BmsChargeStatus,
+    double? LastChargeEndingPower,
+    DateTime? ChargingLastEndAt,
+    string? ChargingScheduleMode,
+    string? ChargingScheduleStartTime,
+    string? ChargingScheduleEndTime,
+    int? OnboardChargerPlugStatus,
+    int? OffboardChargerPlugStatus
 )
 {
     public static WidgetStatusDto FromSnapshot(TelemetrySnapshot s, IStringLocalizer<WidgetStrings> l)
@@ -200,7 +209,15 @@ public record WidgetStatusDto(
             BatteryHeating: Loc(s.BatteryHeating, "On", "Off", l),
             BatteryHeatingScheduleMode: s.BatteryHeatingScheduleMode,
             BatteryHeatingScheduleStartTime: s.BatteryHeatingScheduleStartTime,
-            Elevation: s.Elevation
+            Elevation: s.Elevation,
+            BmsChargeStatus: s.BmsChargeStatus,
+            LastChargeEndingPower: s.LastChargeEndingPower,
+            ChargingLastEndAt: s.ChargingLastEndAt,
+            ChargingScheduleMode: s.ChargingScheduleMode,
+            ChargingScheduleStartTime: s.ChargingScheduleStartTime,
+            ChargingScheduleEndTime: s.ChargingScheduleEndTime,
+            OnboardChargerPlugStatus: s.OnboardChargerPlugStatus,
+            OffboardChargerPlugStatus: s.OffboardChargerPlugStatus
         );
     }
 }

--- a/src/GarageStack.Core/Models/TelemetrySnapshot.cs
+++ b/src/GarageStack.Core/Models/TelemetrySnapshot.cs
@@ -84,6 +84,14 @@ public class TelemetrySnapshot
     public string? ChargingType { get; set; }
     public bool? ChargingCableLock { get; set; }
     public int? RemainingChargingTime { get; set; }
+    public string? BmsChargeStatus { get; set; }
+    public int? OnboardChargerPlugStatus { get; set; }
+    public int? OffboardChargerPlugStatus { get; set; }
+    public double? LastChargeEndingPower { get; set; }
+    public DateTime? ChargingLastEndAt { get; set; }
+    public string? ChargingScheduleMode { get; set; }
+    public string? ChargingScheduleStartTime { get; set; }
+    public string? ChargingScheduleEndTime { get; set; }
 
     // OBC (onboard charger)
     public double? ObcCurrent { get; set; }

--- a/src/GarageStack.Data/Migrations/20260603101745_AddChargeSessionFields.Designer.cs
+++ b/src/GarageStack.Data/Migrations/20260603101745_AddChargeSessionFields.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using GarageStack.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace GarageStack.Data.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260603101745_AddChargeSessionFields")]
+    partial class AddChargeSessionFields
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/GarageStack.Data/Migrations/20260603101745_AddChargeSessionFields.cs
+++ b/src/GarageStack.Data/Migrations/20260603101745_AddChargeSessionFields.cs
@@ -1,0 +1,99 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace GarageStack.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddChargeSessionFields : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "BmsChargeStatus",
+                table: "TelemetrySnapshots",
+                type: "text",
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "ChargingLastEndAt",
+                table: "TelemetrySnapshots",
+                type: "timestamp with time zone",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "ChargingScheduleEndTime",
+                table: "TelemetrySnapshots",
+                type: "text",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "ChargingScheduleMode",
+                table: "TelemetrySnapshots",
+                type: "text",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "ChargingScheduleStartTime",
+                table: "TelemetrySnapshots",
+                type: "text",
+                nullable: true);
+
+            migrationBuilder.AddColumn<double>(
+                name: "LastChargeEndingPower",
+                table: "TelemetrySnapshots",
+                type: "double precision",
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "OffboardChargerPlugStatus",
+                table: "TelemetrySnapshots",
+                type: "integer",
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "OnboardChargerPlugStatus",
+                table: "TelemetrySnapshots",
+                type: "integer",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "BmsChargeStatus",
+                table: "TelemetrySnapshots");
+
+            migrationBuilder.DropColumn(
+                name: "ChargingLastEndAt",
+                table: "TelemetrySnapshots");
+
+            migrationBuilder.DropColumn(
+                name: "ChargingScheduleEndTime",
+                table: "TelemetrySnapshots");
+
+            migrationBuilder.DropColumn(
+                name: "ChargingScheduleMode",
+                table: "TelemetrySnapshots");
+
+            migrationBuilder.DropColumn(
+                name: "ChargingScheduleStartTime",
+                table: "TelemetrySnapshots");
+
+            migrationBuilder.DropColumn(
+                name: "LastChargeEndingPower",
+                table: "TelemetrySnapshots");
+
+            migrationBuilder.DropColumn(
+                name: "OffboardChargerPlugStatus",
+                table: "TelemetrySnapshots");
+
+            migrationBuilder.DropColumn(
+                name: "OnboardChargerPlugStatus",
+                table: "TelemetrySnapshots");
+        }
+    }
+}

--- a/src/GarageStack.Worker/Mqtt/TelemetryMapper.cs
+++ b/src/GarageStack.Worker/Mqtt/TelemetryMapper.cs
@@ -16,8 +16,8 @@ public static class TelemetryMapper
 
         bool? asBool = payload switch
         {
-            "true" or "True" or "1" or "on" or "open" or "unlocked" or "front" or "blowingonly" => true,
-            "false" or "False" or "0" or "off" or "closed" or "locked" => false,
+            "true" or "True" or "1" or "on" or "open" or "unlocked" or "front" or "blowingonly" or "online" => true,
+            "false" or "False" or "0" or "off" or "closed" or "locked" or "offline" => false,
             _ => null
         };
 
@@ -266,6 +266,42 @@ public static class TelemetryMapper
 
             case "drivetrain/remainingChargingTime":
                 snapshot.RemainingChargingTime = double.IsFinite(numeric) ? (int)numeric : (int?)null;
+                break;
+
+            case "drivetrain/lastChargeEndingPower":
+                snapshot.LastChargeEndingPower = N(numeric);
+                break;
+
+            case "drivetrain/charging/lastEnd":
+                // Unix epoch seconds
+                if (double.IsFinite(numeric))
+                    snapshot.ChargingLastEndAt = DateTimeOffset.FromUnixTimeSeconds((long)numeric).UtcDateTime;
+                break;
+
+            case "drivetrain/chargingSchedule":
+                try
+                {
+                    using var csDoc = JsonDocument.Parse(payload);
+                    if (csDoc.RootElement.TryGetProperty("mode", out var csm)) snapshot.ChargingScheduleMode = csm.GetString();
+                    if (csDoc.RootElement.TryGetProperty("startTime", out var css)) snapshot.ChargingScheduleStartTime = css.GetString();
+                    if (csDoc.RootElement.TryGetProperty("endTime", out var cse)) snapshot.ChargingScheduleEndTime = cse.GetString();
+                }
+                catch
+                {
+                    return false;
+                }
+                break;
+
+            case "bms/chargeStatus":
+                snapshot.BmsChargeStatus = payload;
+                break;
+
+            case "ccu/onboardChargerPlugStatus":
+                snapshot.OnboardChargerPlugStatus = double.IsFinite(numeric) ? (int)numeric : (int?)null;
+                break;
+
+            case "ccu/offboardChargerPlugStatus":
+                snapshot.OffboardChargerPlugStatus = double.IsFinite(numeric) ? (int)numeric : (int?)null;
                 break;
 
             // OBC (onboard charger)


### PR DESCRIPTION
# Pull Request

## Summary

Fix IsAvailable always being null: the gateway publishes "online"/"offline"
payloads, which were not in the asBool lookup.

Add BmsChargeStatus, OnboardChargerPlugStatus, OffboardChargerPlugStatus,
LastChargeEndingPower, ChargingLastEndAt, and ChargingSchedule
(mode/startTime/endTime) fields with mapper cases and EF migration.
Surface all new fields in the ChargingSessionCard detail modal.

## Type of Change

- [X] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] Dependency update
- [ ] Other

## Related Issues

Closes #

## Checklist

- [X] Tests added or updated
- [X] Linting passes (`pnpm lint` / `dotnet build`)
- [X] No secrets or personal data committed
- [X] Responsive on mobile
- [X] i18n keys added for any new UI strings
