### PR TITLE
When there's no active trip show last trip

### DIFF
--- a/frontend/src/components/DashboardCardContent.vue
+++ b/frontend/src/components/DashboardCardContent.vue
@@ -229,14 +229,21 @@ const supportsExternalCharge = computed(
     <StatusCard
       v-else-if="cardId === 'activeTrip'"
       icon="location-arrow"
-      :label="t('vehicle.activeTrip')"
+      :label="
+        status.currentJourneyDistance !== null && status.currentJourneyDistance > 0
+          ? t('vehicle.activeTrip')
+          : t('vehicle.lastTrip')
+      "
       :value="
         status.currentJourneyDistance !== null && status.currentJourneyDistance > 0
           ? status.currentJourneyDistance.toFixed(1)
-          : t('vehicle.noActiveTrip')
+          : store.lastTrip
+            ? store.lastTrip.distanceKm.toFixed(1)
+            : t('vehicle.noTrips')
       "
       :unit="
-        status.currentJourneyDistance !== null && status.currentJourneyDistance > 0
+        (status.currentJourneyDistance !== null && status.currentJourneyDistance > 0) ||
+        store.lastTrip !== null
           ? t('common.km')
           : undefined
       "

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -32,7 +32,7 @@
       "efficiencyCharge": "Distance driven since the last charge session.",
       "efficiencyRatio": "Energy today divided by distance today (Wh/km). Lower is better. On a BEV or PHEV in EV mode this translates directly to electricity cost per km. On an HEV it shows how efficiently the hybrid system ran - motorway driving gives a lower figure than stop-start city traffic.",
       "speed": "Current vehicle speed as reported by the gateway.",
-      "activeTrip": "Distance covered in the current trip. Only shown while a journey is active.",
+      "activeTrip": "Distance covered in the current trip while active, or the distance of the last completed trip when parked.",
       "onlineStatus": "Whether the car is currently reachable via the SAIC cloud. Goes offline when the car is parked and the gateway stops polling.",
       "remainingCharge": "Estimated minutes remaining until the battery reaches the configured charge limit. Only relevant for PHEV and BEV while charging.",
       "chargingSession": "Live onboard-charger data: AC power (single or three-phase), cable lock status and charging type. Only relevant for PHEV and BEV.",
@@ -123,7 +123,8 @@
     },
     "speed": "Speed",
     "activeTrip": "Active trip",
-    "noActiveTrip": "No active trip",
+    "lastTrip": "Last trip",
+    "noTrips": "No trips",
     "remainingCharge": "Charge time",
     "chargingSession": {
       "title": "Charging session",

--- a/frontend/src/locales/nl.json
+++ b/frontend/src/locales/nl.json
@@ -32,7 +32,7 @@
       "efficiencyCharge": "Afstand gereden sinds de laatste laadsessie.",
       "efficiencyRatio": "Energie vandaag gedeeld door afstand vandaag (Wh/km). Lager is beter. Op een BEV of PHEV in EV-modus vertaalt dit zich direct naar elektriciteitskosten per km. Op een HEV toont het hoe efficiënt het hybridesysteem werkte -- snelwegrijden geeft een lagere waarde dan stop-and-go stadsverkeer.",
       "speed": "Actuele rijsnelheid zoals gerapporteerd door de gateway.",
-      "activeTrip": "Afstand afgelegd in de huidige rit. Alleen zichtbaar als een rit actief is.",
+      "activeTrip": "Afstand afgelegd tijdens de huidige rit, of de afstand van de laatste afgesloten rit als de auto geparkeerd staat.",
       "onlineStatus": "Of de auto momenteel bereikbaar is via de SAIC-cloud. Gaat offline als de auto geparkeerd staat en de gateway stopt met polling.",
       "remainingCharge": "Geschatte resterende laadtijd in minuten tot de accu de ingestelde limiet bereikt. Alleen relevant voor PHEV en BEV tijdens het laden.",
       "chargingSession": "Live gegevens van de boordlader: AC-vermogen (één of driefasig), kabelslot en laadtype. Alleen relevant voor PHEV en BEV.",
@@ -123,7 +123,8 @@
     },
     "speed": "Snelheid",
     "activeTrip": "Actieve rit",
-    "noActiveTrip": "Geen actieve rit",
+    "lastTrip": "Laatste rit",
+    "noTrips": "Geen ritten",
     "remainingCharge": "Laadtijd",
     "chargingSession": {
       "title": "Laadsessie",

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -158,9 +158,15 @@ export interface Trip {
   points: TripPoint[]
 }
 
+export interface LastTripSummary {
+  distanceKm: number
+  recordedAt: string
+}
+
 export const vehicleApi = {
   list: () => request<Vehicle[]>('/api/vehicles'),
   status: (vin: string) => request<TelemetrySnapshot>(`/api/vehicles/${vin}/status`),
+  lastTrip: (vin: string) => request<LastTripSummary | undefined>(`/api/vehicles/${vin}/trips/last`),
   config: (vin: string) => request<Record<string, string>>(`/api/vehicles/${vin}/config`),
   history: (vin: string, from?: string, to?: string) => {
     const params = new URLSearchParams()

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -166,7 +166,8 @@ export interface LastTripSummary {
 export const vehicleApi = {
   list: () => request<Vehicle[]>('/api/vehicles'),
   status: (vin: string) => request<TelemetrySnapshot>(`/api/vehicles/${vin}/status`),
-  lastTrip: (vin: string) => request<LastTripSummary | undefined>(`/api/vehicles/${vin}/trips/last`),
+  lastTrip: (vin: string) =>
+    request<LastTripSummary | undefined>(`/api/vehicles/${vin}/trips/last`),
   config: (vin: string) => request<Record<string, string>>(`/api/vehicles/${vin}/config`),
   history: (vin: string, from?: string, to?: string) => {
     const params = new URLSearchParams()

--- a/frontend/src/stores/vehicle.ts
+++ b/frontend/src/stores/vehicle.ts
@@ -1,6 +1,12 @@
 import { defineStore } from 'pinia'
 import { ref, computed } from 'vue'
-import { vehicleApi, type Vehicle, type TelemetrySnapshot, type Trip, type LastTripSummary } from '@/services/api'
+import {
+  vehicleApi,
+  type Vehicle,
+  type TelemetrySnapshot,
+  type Trip,
+  type LastTripSummary,
+} from '@/services/api'
 
 export type VehicleType = 'hev' | 'phev' | 'bev' | 'unknown'
 

--- a/frontend/src/stores/vehicle.ts
+++ b/frontend/src/stores/vehicle.ts
@@ -1,6 +1,6 @@
 import { defineStore } from 'pinia'
 import { ref, computed } from 'vue'
-import { vehicleApi, type Vehicle, type TelemetrySnapshot, type Trip } from '@/services/api'
+import { vehicleApi, type Vehicle, type TelemetrySnapshot, type Trip, type LastTripSummary } from '@/services/api'
 
 export type VehicleType = 'hev' | 'phev' | 'bev' | 'unknown'
 
@@ -10,6 +10,7 @@ export const useVehicleStore = defineStore('vehicle', () => {
   const vehicleConfig = ref<Record<string, string>>({})
   const history = ref<TelemetrySnapshot[]>([])
   const trips = ref<Trip[]>([])
+  const lastTrip = ref<LastTripSummary | null>(null)
   const loadingCount = ref(0)
   const loading = computed(() => loadingCount.value > 0)
   const error = ref<string | null>(null)
@@ -62,6 +63,14 @@ export const useVehicleStore = defineStore('vehicle', () => {
     }
   }
 
+  async function fetchLastTrip(vin: string) {
+    try {
+      lastTrip.value = (await vehicleApi.lastTrip(vin)) ?? null
+    } catch {
+      // non-critical, leave stale value
+    }
+  }
+
   async function fetchTrips(vin: string, from?: string, to?: string) {
     loadingCount.value++
     error.value = null
@@ -91,6 +100,7 @@ export const useVehicleStore = defineStore('vehicle', () => {
     detectedVehicleType,
     history,
     trips,
+    lastTrip,
     loading,
     error,
     lastUpdated,
@@ -99,5 +109,6 @@ export const useVehicleStore = defineStore('vehicle', () => {
     fetchConfig,
     fetchHistory,
     fetchTrips,
+    fetchLastTrip,
   }
 })

--- a/frontend/src/views/DashboardView.vue
+++ b/frontend/src/views/DashboardView.vue
@@ -117,6 +117,7 @@ async function refresh() {
   if (vin.value) {
     await store.fetchStatus(vin.value)
     await store.fetchConfig(vin.value)
+    store.fetchLastTrip(vin.value)
   }
 }
 

--- a/src/GarageStack.Api/Endpoints/VehicleEndpoints.cs
+++ b/src/GarageStack.Api/Endpoints/VehicleEndpoints.cs
@@ -85,6 +85,22 @@ public static class VehicleEndpoints
         })
         .WithSummary("Get telemetry history for a vehicle");
 
+        group.MapGet("/{vin}/trips/last", async (string vin, IVehicleRepository vehicles, AppDbContext db, CancellationToken ct) =>
+        {
+            var resolved = await ResolveVehicleAsync(vin, vehicles, ct);
+            if (resolved.NotFound is not null) return resolved.NotFound;
+            var vehicle = resolved.Vehicle!;
+
+            var row = await db.TelemetrySnapshots
+                .Where(s => s.VehicleId == vehicle.Id && s.CurrentJourneyDistance > 0)
+                .OrderByDescending(s => s.RecordedAt)
+                .Select(s => new { distanceKm = s.CurrentJourneyDistance!.Value, recordedAt = s.RecordedAt })
+                .FirstOrDefaultAsync(ct);
+
+            return row is null ? Results.NoContent() : Results.Ok(row);
+        })
+        .WithSummary("Get last trip summary (distance and timestamp of most recent journey)");
+
         group.MapGet("/{vin}/trips", async (
             string vin,
             ITelemetryRepository telemetry,


### PR DESCRIPTION
# Pull Request

## Summary

Show the last trip when there's no current active trip

## Type of Change

- [ ] Bug fix
- [X] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] Dependency update
- [ ] Other

## Checklist

- [X] Tests added or updated
- [X] Linting passes (`pnpm lint` / `dotnet build`)
- [X] No secrets or personal data committed
- [X] Responsive on mobile
- [X] i18n keys added for any new UI strings
