### PR TITLE
Fix four telemetry and notification bugs found in code review

### DIFF
--- a/frontend/src/composables/__tests__/useNotifications.spec.ts
+++ b/frontend/src/composables/__tests__/useNotifications.spec.ts
@@ -1,6 +1,7 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { nextTick } from 'vue'
 import { setActivePinia, createPinia } from 'pinia'
-import { notificationsApi } from '@/services/api'
+import { notificationsApi, authApi } from '@/services/api'
 import type { AppNotification } from '@/services/api'
 
 vi.mock('@/services/api', () => ({
@@ -35,10 +36,77 @@ function makeNotification(overrides: Partial<AppNotification> = {}): AppNotifica
 describe('useNotifications', () => {
   beforeEach(() => {
     vi.resetModules()
+    localStorage.clear()
     setActivePinia(createPinia())
     vi.mocked(notificationsApi.list).mockReset()
     vi.mocked(notificationsApi.archive).mockReset()
     vi.mocked(notificationsApi.delete).mockReset()
+  })
+
+  afterEach(() => {
+    localStorage.clear()
+  })
+
+  it('does not auto-fetch when not authenticated', async () => {
+    vi.mocked(notificationsApi.list).mockResolvedValue([])
+
+    const { useNotifications } = await import('@/composables/useNotifications')
+    useNotifications()
+
+    expect(vi.mocked(notificationsApi.list)).not.toHaveBeenCalled()
+  })
+
+  it('auto-fetches immediately when already authenticated', async () => {
+    // Simulate a stored session so isAuthenticated is true on composable init.
+    localStorage.setItem('garagestack-auth-username', 'testuser')
+    localStorage.setItem('garagestack-auth-expires', new Date(Date.now() + 3_600_000).toISOString())
+    vi.mocked(notificationsApi.list).mockResolvedValue([])
+
+    const { useNotifications } = await import('@/composables/useNotifications')
+    useNotifications()
+
+    expect(vi.mocked(notificationsApi.list)).toHaveBeenCalledOnce()
+  })
+
+  it('auto-fetches when auth state changes to authenticated after login', async () => {
+    vi.mocked(notificationsApi.list).mockResolvedValue([])
+    vi.mocked(authApi.login).mockResolvedValue({
+      username: 'testuser',
+      expiresAtUtc: new Date(Date.now() + 3_600_000).toISOString(),
+    })
+
+    const { useNotifications } = await import('@/composables/useNotifications')
+    const { useAuthStore } = await import('@/stores/auth')
+
+    const auth = useAuthStore()
+    useNotifications()
+
+    expect(vi.mocked(notificationsApi.list)).not.toHaveBeenCalled()
+
+    await auth.login('testuser', 'password')
+    await nextTick()
+
+    expect(vi.mocked(notificationsApi.list)).toHaveBeenCalledOnce()
+  })
+
+  it('clears notifications when auth state changes to unauthenticated', async () => {
+    localStorage.setItem('garagestack-auth-username', 'testuser')
+    localStorage.setItem('garagestack-auth-expires', new Date(Date.now() + 3_600_000).toISOString())
+    vi.mocked(notificationsApi.list).mockResolvedValue([makeNotification({ id: 1 })])
+    vi.mocked(authApi.logout).mockResolvedValue(undefined)
+
+    const { useNotifications } = await import('@/composables/useNotifications')
+    const { useAuthStore } = await import('@/stores/auth')
+
+    const auth = useAuthStore()
+    const { notifications } = useNotifications()
+    await vi.mocked(notificationsApi.list).mock.results[0]?.value
+    await nextTick()
+
+    await auth.logout()
+    await nextTick()
+
+    expect(notifications.value).toHaveLength(0)
   })
 
   it('unreadCount counts non-archived notifications', async () => {

--- a/frontend/src/composables/useNotifications.ts
+++ b/frontend/src/composables/useNotifications.ts
@@ -1,4 +1,4 @@
-import { ref, computed, onMounted, onUnmounted } from 'vue'
+import { ref, computed, watch, onUnmounted } from 'vue'
 import { notificationsApi, type AppNotification } from '@/services/api'
 import { useAuthStore } from '@/stores/auth'
 
@@ -25,11 +25,22 @@ export function useNotifications() {
     }
   }
 
-  onMounted(() => {
-    if (!auth.isAuthenticated) return
-    fetchNotifications()
-    navigator.serviceWorker?.addEventListener('message', onSwMessage)
-  })
+  // Use a watch instead of onMounted so initialization also fires when the user
+  // logs in from the login page (App.vue stays mounted throughout; onMounted would
+  // only run once, before auth is established on a cold start on /login).
+  watch(
+    () => auth.isAuthenticated,
+    (authenticated) => {
+      if (authenticated) {
+        fetchNotifications()
+        navigator.serviceWorker?.addEventListener('message', onSwMessage)
+      } else {
+        navigator.serviceWorker?.removeEventListener('message', onSwMessage)
+        notifications.value = []
+      }
+    },
+    { immediate: true },
+  )
 
   onUnmounted(() => {
     navigator.serviceWorker?.removeEventListener('message', onSwMessage)

--- a/src/GarageStack.Api/Endpoints/WidgetEndpoints.cs
+++ b/src/GarageStack.Api/Endpoints/WidgetEndpoints.cs
@@ -79,14 +79,14 @@ public record WidgetStatusDto(
     string? RearRightDoorOpen,
     string? TrunkOpen,
     string? BonnetOpen,
-    string AnyDoorOpen,
+    string? AnyDoorOpen,
     // Windows
     string? DriverWindowOpen,
     string? PassengerWindowOpen,
     string? RearLeftWindowOpen,
     string? RearRightWindowOpen,
     string? SunRoofOpen,
-    string AnyWindowOpen,
+    string? AnyWindowOpen,
     // 12V battery
     double? BatteryVoltage,
     // Temperature
@@ -136,20 +136,23 @@ public record WidgetStatusDto(
         static string? Loc(bool? v, string trueKey, string falseKey, IStringLocalizer<WidgetStrings> l) =>
             v is null ? null : l[v.Value ? trueKey : falseKey].Value;
 
-        static string LocBool(bool v, string trueKey, string falseKey, IStringLocalizer<WidgetStrings> l) =>
-            l[v ? trueKey : falseKey].Value;
+        // Returns true if any value is true, null if all values are null, false otherwise.
+        static bool? AnyOf(params bool?[] vals)
+        {
+            if (vals.Any(v => v == true)) return true;
+            if (vals.All(v => v == null)) return null;
+            return false;
+        }
 
         double? electricShare = s.MileageSinceLastCharge.HasValue && s.MileageOfTheDay is > 0
             ? Math.Min(100, Math.Round(s.MileageSinceLastCharge.Value / s.MileageOfTheDay!.Value * 100))
             : null;
 
-        var anyDoorOpen = s.DriverDoorOpen == true || s.PassengerDoorOpen == true
-            || s.RearLeftDoorOpen == true || s.RearRightDoorOpen == true
-            || s.TrunkOpen == true || s.BonnetOpen == true;
+        var anyDoorOpen = AnyOf(s.DriverDoorOpen, s.PassengerDoorOpen,
+            s.RearLeftDoorOpen, s.RearRightDoorOpen, s.TrunkOpen, s.BonnetOpen);
 
-        var anyWindowOpen = s.DriverWindowOpen == true || s.PassengerWindowOpen == true
-            || s.RearLeftWindowOpen == true || s.RearRightWindowOpen == true
-            || s.SunRoofOpen == true;
+        var anyWindowOpen = AnyOf(s.DriverWindowOpen, s.PassengerWindowOpen,
+            s.RearLeftWindowOpen, s.RearRightWindowOpen, s.SunRoofOpen);
 
         return new WidgetStatusDto(
             RecordedAt: s.RecordedAt,
@@ -179,13 +182,13 @@ public record WidgetStatusDto(
             RearRightDoorOpen: Loc(s.RearRightDoorOpen, "Open", "Closed", l),
             TrunkOpen: Loc(s.TrunkOpen, "Open", "Closed", l),
             BonnetOpen: Loc(s.BonnetOpen, "Open", "Closed", l),
-            AnyDoorOpen: LocBool(anyDoorOpen, "Open", "Closed", l),
+            AnyDoorOpen: Loc(anyDoorOpen, "Open", "Closed", l),
             DriverWindowOpen: Loc(s.DriverWindowOpen, "Open", "Closed", l),
             PassengerWindowOpen: Loc(s.PassengerWindowOpen, "Open", "Closed", l),
             RearLeftWindowOpen: Loc(s.RearLeftWindowOpen, "Open", "Closed", l),
             RearRightWindowOpen: Loc(s.RearRightWindowOpen, "Open", "Closed", l),
             SunRoofOpen: Loc(s.SunRoofOpen, "Open", "Closed", l),
-            AnyWindowOpen: LocBool(anyWindowOpen, "Open", "Closed", l),
+            AnyWindowOpen: Loc(anyWindowOpen, "Open", "Closed", l),
             BatteryVoltage: s.BatteryVoltage,
             InteriorTemperature: s.InteriorTemperature,
             ExteriorTemperature: s.ExteriorTemperature,

--- a/src/GarageStack.Data/Repositories/TelemetryRepository.cs
+++ b/src/GarageStack.Data/Repositories/TelemetryRepository.cs
@@ -193,6 +193,35 @@ public class TelemetryRepository(AppDbContext db) : ITelemetryRepository
             }
         }
 
+        // Charging/heating schedule fields are set only when the user changes a schedule
+        // and may not appear in the most-recent 200 rows. Fall back to the last row
+        // that holds any scheduling data so the dashboard keeps showing those cards.
+        if (merged.ChargingScheduleMode == null && merged.ChargingScheduleStartTime == null
+            && merged.BatteryHeatingScheduleMode == null && merged.BatteryHeatingScheduleStartTime == null)
+        {
+            var sched = await db.TelemetrySnapshots
+                .Where(s => s.VehicleId == vehicleId
+                    && (s.ChargingScheduleMode != null || s.ChargingScheduleStartTime != null
+                        || s.ChargingScheduleEndTime != null || s.BatteryHeatingScheduleMode != null
+                        || s.BatteryHeatingScheduleStartTime != null))
+                .OrderByDescending(s => s.RecordedAt)
+                .Select(s => new
+                {
+                    s.ChargingScheduleMode, s.ChargingScheduleStartTime, s.ChargingScheduleEndTime,
+                    s.BatteryHeatingScheduleMode, s.BatteryHeatingScheduleStartTime,
+                })
+                .FirstOrDefaultAsync(ct);
+
+            if (sched != null)
+            {
+                merged.ChargingScheduleMode ??= sched.ChargingScheduleMode;
+                merged.ChargingScheduleStartTime ??= sched.ChargingScheduleStartTime;
+                merged.ChargingScheduleEndTime ??= sched.ChargingScheduleEndTime;
+                merged.BatteryHeatingScheduleMode ??= sched.BatteryHeatingScheduleMode;
+                merged.BatteryHeatingScheduleStartTime ??= sched.BatteryHeatingScheduleStartTime;
+            }
+        }
+
         return merged;
     }
 
@@ -248,7 +277,9 @@ public class TelemetryRepository(AppDbContext db) : ITelemetryRepository
 
         foreach (var p in points)
         {
-            var isParked = p.Speed.HasValue && p.Speed.Value <= 0;
+            // Null speed (GPS-only row) is treated as stationary: no speed data means
+            // no evidence of movement, so the 5-minute parking split can still fire.
+            var isParked = !p.Speed.HasValue || p.Speed.Value <= 0;
 
             // Hard gap: no data at all - always start a new trip.
             if (lastSeen.HasValue && p.RecordedAt - lastSeen.Value > gapThreshold)

--- a/src/GarageStack.Tests/TelemetryRepositoryTests.cs
+++ b/src/GarageStack.Tests/TelemetryRepositoryTests.cs
@@ -74,6 +74,63 @@ public class TelemetryRepositoryTests
         Assert.Single(result);
     }
 
+    [Fact]
+    public async Task GetTrips_NullSpeedParkingGap_SplitsIntoTwoTrips()
+    {
+        // GPS-only rows (Speed = null) between two trips must still trigger the
+        // 5-minute parking split. Previously null Speed was treated as "moving".
+        var ct = TestContext.Current.CancellationToken;
+        await using var db = CreateDb();
+        var vehicle = new Vehicle { Vin = "TRIP00000000000003" };
+        db.Vehicles.Add(vehicle);
+        await db.SaveChangesAsync(ct);
+
+        var t0 = new DateTime(2026, 1, 1, 10, 0, 0, DateTimeKind.Utc);
+        db.TelemetrySnapshots.AddRange(
+            MakePoint(vehicle.Id, t0.AddMinutes(0),  51.50, 0.0, 50),
+            MakePoint(vehicle.Id, t0.AddMinutes(5),  51.55, 0.0, 50),
+            MakePoint(vehicle.Id, t0.AddMinutes(10), 51.60, 0.0, 50),
+            // Gateway sends GPS-only updates (no speed topic) while parked.
+            MakePoint(vehicle.Id, t0.AddMinutes(11), 51.60, 0.0, null),
+            MakePoint(vehicle.Id, t0.AddMinutes(15), 51.60, 0.0, null),
+            MakePoint(vehicle.Id, t0.AddMinutes(20), 51.60, 0.0, null),
+            // Second trip starts after >5 min of null-speed points.
+            MakePoint(vehicle.Id, t0.AddMinutes(21), 51.60, 0.0, 50),
+            MakePoint(vehicle.Id, t0.AddMinutes(25), 51.55, 0.0, 50),
+            MakePoint(vehicle.Id, t0.AddMinutes(30), 51.50, 0.0, 50)
+        );
+        await db.SaveChangesAsync(ct);
+
+        var result = await new TelemetryRepository(db).GetTripsAsync(vehicle.Id, t0.AddHours(-1), t0.AddHours(1), ct);
+
+        Assert.Equal(2, result.Count);
+    }
+
+    [Fact]
+    public async Task GetTrips_BriefNullSpeedBlip_DoesNotSplitTrip()
+    {
+        // A single null-speed GPS update mid-trip (< 5 min) must not split the trip.
+        var ct = TestContext.Current.CancellationToken;
+        await using var db = CreateDb();
+        var vehicle = new Vehicle { Vin = "TRIP00000000000004" };
+        db.Vehicles.Add(vehicle);
+        await db.SaveChangesAsync(ct);
+
+        var t0 = new DateTime(2026, 1, 1, 10, 0, 0, DateTimeKind.Utc);
+        db.TelemetrySnapshots.AddRange(
+            MakePoint(vehicle.Id, t0.AddMinutes(0), 51.50, 0.0, 50),
+            MakePoint(vehicle.Id, t0.AddMinutes(5), 51.55, 0.0, 50),
+            MakePoint(vehicle.Id, t0.AddMinutes(6), 51.55, 0.0, null), // brief null-speed blip
+            MakePoint(vehicle.Id, t0.AddMinutes(7), 51.56, 0.0, 50),
+            MakePoint(vehicle.Id, t0.AddMinutes(12), 51.60, 0.0, 50)
+        );
+        await db.SaveChangesAsync(ct);
+
+        var result = await new TelemetryRepository(db).GetTripsAsync(vehicle.Id, t0.AddHours(-1), t0.AddHours(1), ct);
+
+        Assert.Single(result);
+    }
+
     // ── RemoteTemperature regression tests ──────────────────────────────────
     // These cover the two-part bug: (1) HasData must not filter out rows whose
     // only non-null field is RemoteTemperature, and (2) the merge loop must
@@ -260,5 +317,52 @@ public class TelemetryRepositoryTests
         Assert.NotNull(result);
         Assert.Equal(80, result.FuelLevelPercent);   // from newer row
         Assert.Equal(22.0, result.RemoteTemperature); // merged from older row
+    }
+
+    [Fact]
+    public async Task GetMergedLatest_ScheduleFieldsSurviveSaturatedMergeWindow()
+    {
+        // ChargingScheduleMode lives in an older row that sits beyond the 200-row
+        // Take window. The fallback query must recover it.
+        var ct = TestContext.Current.CancellationToken;
+        await using var db = CreateDb();
+        var vehicle = new Vehicle { Vin = "TEST00000000000008" };
+        db.Vehicles.Add(vehicle);
+        await db.SaveChangesAsync(ct);
+
+        var baseTime = DateTime.UtcNow.AddDays(-1);
+
+        // Row with schedule data, older than the 200-row window.
+        db.TelemetrySnapshots.Add(new TelemetrySnapshot
+        {
+            VehicleId = vehicle.Id,
+            RecordedAt = baseTime,
+            ChargingScheduleMode = "Timed",
+            ChargingScheduleStartTime = "07:00",
+            ChargingScheduleEndTime = "09:00",
+            BatteryHeatingScheduleMode = "On",
+            BatteryHeatingScheduleStartTime = "06:30",
+        });
+
+        // 201 newer rows that all lack scheduling fields, saturating the merge window.
+        for (var i = 1; i <= 201; i++)
+        {
+            db.TelemetrySnapshots.Add(new TelemetrySnapshot
+            {
+                VehicleId = vehicle.Id,
+                RecordedAt = baseTime.AddMinutes(i),
+                EvSocPercent = 80,
+            });
+        }
+        await db.SaveChangesAsync(ct);
+
+        var result = await new TelemetryRepository(db).GetMergedLatestAsync(vehicle.Id, ct);
+
+        Assert.NotNull(result);
+        Assert.Equal("Timed", result.ChargingScheduleMode);
+        Assert.Equal("07:00", result.ChargingScheduleStartTime);
+        Assert.Equal("09:00", result.ChargingScheduleEndTime);
+        Assert.Equal("On", result.BatteryHeatingScheduleMode);
+        Assert.Equal("06:30", result.BatteryHeatingScheduleStartTime);
     }
 }


### PR DESCRIPTION
# Pull Request

## Summary

- **Trip split regression (High):** `TelemetryRepository.GetTripsAsync` treated
  `null` Speed as "moving", so GPS-only rows emitted while parked prevented the
  5-minute soft-gap from firing and collapsed back-to-back trips into one.
  Fixed by inverting the guard: `!p.Speed.HasValue || p.Speed.Value <= 0`.

- **Notification cold-start bug (Medium):** `useNotifications` used `onMounted`
  with an `isAuthenticated` guard. Because `App.vue` stays mounted across the
  login route, `onMounted` ran once (before auth) and never again. Replaced
  with `watch(() => auth.isAuthenticated, ..., { immediate: true })` so setup
  runs on login and cleans up on logout.

- **Sparse-field merge window (Medium):** `GetMergedLatestAsync` limits its scan
  to the 200 most-recent rows. Charging and heating schedule fields are set
  infrequently and can fall outside that window. Added a targeted fallback query
  for those fields, matching the existing GPS fallback pattern.

- **Widget aggregate state (Medium):** `AnyDoorOpen` / `AnyWindowOpen` used a
  plain boolean OR over nullable bools, collapsing all-null input to `false` and
  localizing it as "Closed". Introduced a nullable `AnyOf` helper and changed
  both DTO fields to `string?`.

## Type of Change

- [ ] Bug fix
- [X] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] Dependency update
- [ ] Other
