### PR TITLE
Fix statistics charts showing only 1-2 days; reduce telemetry row count ~9x

### DIFF
--- a/frontend/src/views/StatisticsView.vue
+++ b/frontend/src/views/StatisticsView.vue
@@ -61,7 +61,13 @@ async function load() {
   try {
     await store.fetchVehicles()
     if (!vin.value) return
-    const from = new Date(Date.now() - days.value * 86_400_000).toISOString()
+    const startDay = new Date()
+    startDay.setDate(startDay.getDate() - days.value)
+    const from = new Date(
+      startDay.getFullYear(),
+      startDay.getMonth(),
+      startDay.getDate(),
+    ).toISOString()
     await Promise.all([
       store.fetchHistory(vin.value, from),
       store.fetchTrips(vin.value, from),

--- a/src/GarageStack.Core/Interfaces/ITelemetryRepository.cs
+++ b/src/GarageStack.Core/Interfaces/ITelemetryRepository.cs
@@ -4,7 +4,8 @@ namespace GarageStack.Core.Interfaces;
 
 public interface ITelemetryRepository
 {
-    Task AddAsync(TelemetrySnapshot snapshot, CancellationToken ct = default);
+    Task<long> AddAsync(TelemetrySnapshot snapshot, CancellationToken ct = default);
+    Task MergeIntoAsync(long rowId, TelemetrySnapshot patch, CancellationToken ct = default);
     Task<TelemetrySnapshot?> GetLatestAsync(int vehicleId, CancellationToken ct = default);
     Task<TelemetrySnapshot?> GetMergedLatestAsync(int vehicleId, CancellationToken ct = default);
     Task<IReadOnlyList<TelemetrySnapshot>> GetHistoryAsync(int vehicleId, DateTime from, DateTime to, CancellationToken ct = default);

--- a/src/GarageStack.Data/AppDbContext.cs
+++ b/src/GarageStack.Data/AppDbContext.cs
@@ -23,6 +23,8 @@ public class AppDbContext(DbContextOptions<AppDbContext> options) : DbContext(op
         {
             e.HasKey(s => s.Id);
             e.HasIndex(s => new { s.VehicleId, s.RecordedAt });
+            // IX_TelemetrySnapshots_VehicleId_RecordedAt_Chart is a partial index
+            // managed via raw SQL in the AddChartIndex migration.
             e.HasIndex(s => new { s.VehicleId, s.RawTopic })
              .HasFilter("\"RawTopic\" IS NOT NULL");
             e.HasIndex(s => new { s.VehicleId, s.Latitude, s.Longitude, s.RecordedAt })

--- a/src/GarageStack.Data/Migrations/20260604201139_AddChartIndex.Designer.cs
+++ b/src/GarageStack.Data/Migrations/20260604201139_AddChartIndex.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using GarageStack.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace GarageStack.Data.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260604201139_AddChartIndex")]
+    partial class AddChartIndex
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/GarageStack.Data/Migrations/20260604201139_AddChartIndex.cs
+++ b/src/GarageStack.Data/Migrations/20260604201139_AddChartIndex.cs
@@ -1,0 +1,45 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace GarageStack.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddChartIndex : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            // Partial index covering only chart-relevant rows; the general
+            // IX_TelemetrySnapshots_VehicleId_RecordedAt index is kept for
+            // GetLatestAsync / GetMergedLatestAsync which have no field filter.
+            migrationBuilder.Sql("""
+                CREATE INDEX "IX_TelemetrySnapshots_VehicleId_RecordedAt_Chart"
+                    ON "TelemetrySnapshots" ("VehicleId", "RecordedAt")
+                    WHERE "FuelLevelPercent"        IS NOT NULL
+                       OR "EvSocPercent"            IS NOT NULL
+                       OR "PowerUsageOfDay"         IS NOT NULL
+                       OR "BatteryVoltage"          IS NOT NULL
+                       OR "ClimateOn"               IS NOT NULL
+                       OR "IsCharging"              IS NOT NULL
+                       OR "TyrePressureFrontLeft"   IS NOT NULL
+                       OR "TyrePressureFrontRight"  IS NOT NULL
+                       OR "TyrePressureRearLeft"    IS NOT NULL
+                       OR "TyrePressureRearRight"   IS NOT NULL
+                       OR "MileageOfTheDay"         IS NOT NULL
+                       OR "MileageSinceLastCharge"  IS NOT NULL
+                       OR "HvSocKwh"               IS NOT NULL
+                       OR "HvTotalCapacityKwh"      IS NOT NULL
+                       OR "PowerUsageSinceLastCharge" IS NOT NULL;
+                """);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql("""
+                DROP INDEX IF EXISTS "IX_TelemetrySnapshots_VehicleId_RecordedAt_Chart";
+                """);
+        }
+    }
+}

--- a/src/GarageStack.Data/Repositories/TelemetryRepository.cs
+++ b/src/GarageStack.Data/Repositories/TelemetryRepository.cs
@@ -56,9 +56,96 @@ public class TelemetryRepository(AppDbContext db) : ITelemetryRepository
              s.HvSocKwh != null || s.HvTotalCapacityKwh != null ||
              s.PowerUsageSinceLastCharge != null;
 
-    public async Task AddAsync(TelemetrySnapshot snapshot, CancellationToken ct = default)
+    public async Task<long> AddAsync(TelemetrySnapshot snapshot, CancellationToken ct = default)
     {
         db.TelemetrySnapshots.Add(snapshot);
+        await db.SaveChangesAsync(ct);
+        return snapshot.Id;
+    }
+
+    public async Task MergeIntoAsync(long rowId, TelemetrySnapshot patch, CancellationToken ct = default)
+    {
+        var existing = await db.TelemetrySnapshots.FindAsync([rowId], ct);
+        if (existing is null)
+        {
+            db.TelemetrySnapshots.Add(patch);
+            await db.SaveChangesAsync(ct);
+            return;
+        }
+
+        // Last-write-wins per field: overwrite with any non-null value from the patch.
+        if (patch.FuelLevelPercent != null) existing.FuelLevelPercent = patch.FuelLevelPercent;
+        if (patch.FuelRangeKm != null) existing.FuelRangeKm = patch.FuelRangeKm;
+        if (patch.OdometerKm != null) existing.OdometerKm = patch.OdometerKm;
+        if (patch.IsLocked != null) existing.IsLocked = patch.IsLocked;
+        if (patch.EngineRunning != null) existing.EngineRunning = patch.EngineRunning;
+        if (patch.ClimateOn != null) existing.ClimateOn = patch.ClimateOn;
+        if (patch.DriverDoorOpen != null) existing.DriverDoorOpen = patch.DriverDoorOpen;
+        if (patch.PassengerDoorOpen != null) existing.PassengerDoorOpen = patch.PassengerDoorOpen;
+        if (patch.RearLeftDoorOpen != null) existing.RearLeftDoorOpen = patch.RearLeftDoorOpen;
+        if (patch.RearRightDoorOpen != null) existing.RearRightDoorOpen = patch.RearRightDoorOpen;
+        if (patch.TrunkOpen != null) existing.TrunkOpen = patch.TrunkOpen;
+        if (patch.BonnetOpen != null) existing.BonnetOpen = patch.BonnetOpen;
+        if (patch.DriverWindowOpen != null) existing.DriverWindowOpen = patch.DriverWindowOpen;
+        if (patch.PassengerWindowOpen != null) existing.PassengerWindowOpen = patch.PassengerWindowOpen;
+        if (patch.RearLeftWindowOpen != null) existing.RearLeftWindowOpen = patch.RearLeftWindowOpen;
+        if (patch.RearRightWindowOpen != null) existing.RearRightWindowOpen = patch.RearRightWindowOpen;
+        if (patch.SunRoofOpen != null) existing.SunRoofOpen = patch.SunRoofOpen;
+        if (patch.Latitude != null) existing.Latitude = patch.Latitude;
+        if (patch.Longitude != null) existing.Longitude = patch.Longitude;
+        if (patch.Speed != null) existing.Speed = patch.Speed;
+        if (patch.Heading != null) existing.Heading = patch.Heading;
+        if (patch.BatteryVoltage != null) existing.BatteryVoltage = patch.BatteryVoltage;
+        if (patch.InteriorTemperature != null) existing.InteriorTemperature = patch.InteriorTemperature;
+        if (patch.ExteriorTemperature != null) existing.ExteriorTemperature = patch.ExteriorTemperature;
+        if (patch.RemoteTemperature != null) existing.RemoteTemperature = patch.RemoteTemperature;
+        if (patch.EvSocPercent != null) existing.EvSocPercent = patch.EvSocPercent;
+        if (patch.IsCharging != null) existing.IsCharging = patch.IsCharging;
+        if (patch.TyrePressureFrontLeft != null) existing.TyrePressureFrontLeft = patch.TyrePressureFrontLeft;
+        if (patch.TyrePressureFrontRight != null) existing.TyrePressureFrontRight = patch.TyrePressureFrontRight;
+        if (patch.TyrePressureRearLeft != null) existing.TyrePressureRearLeft = patch.TyrePressureRearLeft;
+        if (patch.TyrePressureRearRight != null) existing.TyrePressureRearRight = patch.TyrePressureRearRight;
+        if (patch.MileageOfTheDay != null) existing.MileageOfTheDay = patch.MileageOfTheDay;
+        if (patch.PowerUsageOfDay != null) existing.PowerUsageOfDay = patch.PowerUsageOfDay;
+        if (patch.MileageSinceLastCharge != null) existing.MileageSinceLastCharge = patch.MileageSinceLastCharge;
+        if (patch.HvVoltage != null) existing.HvVoltage = patch.HvVoltage;
+        if (patch.HvCurrent != null) existing.HvCurrent = patch.HvCurrent;
+        if (patch.HvPower != null) existing.HvPower = patch.HvPower;
+        if (patch.HvSocKwh != null) existing.HvSocKwh = patch.HvSocKwh;
+        if (patch.HvTotalCapacityKwh != null) existing.HvTotalCapacityKwh = patch.HvTotalCapacityKwh;
+        if (patch.PowerUsageSinceLastCharge != null) existing.PowerUsageSinceLastCharge = patch.PowerUsageSinceLastCharge;
+        if (patch.ChargerConnected != null) existing.ChargerConnected = patch.ChargerConnected;
+        if (patch.HvBatteryActive != null) existing.HvBatteryActive = patch.HvBatteryActive;
+        if (patch.LightsMainBeam != null) existing.LightsMainBeam = patch.LightsMainBeam;
+        if (patch.LightsDippedBeam != null) existing.LightsDippedBeam = patch.LightsDippedBeam;
+        if (patch.LightsSide != null) existing.LightsSide = patch.LightsSide;
+        if (patch.HeatedSeatFrontLeft != null) existing.HeatedSeatFrontLeft = patch.HeatedSeatFrontLeft;
+        if (patch.HeatedSeatFrontRight != null) existing.HeatedSeatFrontRight = patch.HeatedSeatFrontRight;
+        if (patch.RearWindowDefroster != null) existing.RearWindowDefroster = patch.RearWindowDefroster;
+        if (patch.IsAvailable != null) existing.IsAvailable = patch.IsAvailable;
+        if (patch.LastVehicleStateAt != null) existing.LastVehicleStateAt = patch.LastVehicleStateAt;
+        if (patch.LastChargeStateAt != null) existing.LastChargeStateAt = patch.LastChargeStateAt;
+        if (patch.CurrentJourneyDistance != null) existing.CurrentJourneyDistance = patch.CurrentJourneyDistance;
+        if (patch.Elevation != null) existing.Elevation = patch.Elevation;
+        if (patch.ChargingType != null) existing.ChargingType = patch.ChargingType;
+        if (patch.ChargingCableLock != null) existing.ChargingCableLock = patch.ChargingCableLock;
+        if (patch.RemainingChargingTime != null) existing.RemainingChargingTime = patch.RemainingChargingTime;
+        if (patch.BmsChargeStatus != null) existing.BmsChargeStatus = patch.BmsChargeStatus;
+        if (patch.OnboardChargerPlugStatus != null) existing.OnboardChargerPlugStatus = patch.OnboardChargerPlugStatus;
+        if (patch.OffboardChargerPlugStatus != null) existing.OffboardChargerPlugStatus = patch.OffboardChargerPlugStatus;
+        if (patch.LastChargeEndingPower != null) existing.LastChargeEndingPower = patch.LastChargeEndingPower;
+        if (patch.ChargingLastEndAt != null) existing.ChargingLastEndAt = patch.ChargingLastEndAt;
+        if (patch.ChargingScheduleMode != null) existing.ChargingScheduleMode = patch.ChargingScheduleMode;
+        if (patch.ChargingScheduleStartTime != null) existing.ChargingScheduleStartTime = patch.ChargingScheduleStartTime;
+        if (patch.ChargingScheduleEndTime != null) existing.ChargingScheduleEndTime = patch.ChargingScheduleEndTime;
+        if (patch.ObcCurrent != null) existing.ObcCurrent = patch.ObcCurrent;
+        if (patch.ObcVoltage != null) existing.ObcVoltage = patch.ObcVoltage;
+        if (patch.ObcPowerSinglePhase != null) existing.ObcPowerSinglePhase = patch.ObcPowerSinglePhase;
+        if (patch.ObcPowerThreePhase != null) existing.ObcPowerThreePhase = patch.ObcPowerThreePhase;
+        if (patch.BatteryHeating != null) existing.BatteryHeating = patch.BatteryHeating;
+        if (patch.BatteryHeatingScheduleMode != null) existing.BatteryHeatingScheduleMode = patch.BatteryHeatingScheduleMode;
+        if (patch.BatteryHeatingScheduleStartTime != null) existing.BatteryHeatingScheduleStartTime = patch.BatteryHeatingScheduleStartTime;
+
         await db.SaveChangesAsync(ct);
     }
 
@@ -245,12 +332,34 @@ public class TelemetryRepository(AppDbContext db) : ITelemetryRepository
 
         if (rows.Count <= maxPoints) return rows;
 
-        // Ceiling division ensures step >= 2 whenever rows.Count > maxPoints,
-        // so the result never exceeds maxPoints.
-        var step = (rows.Count + maxPoints - 1) / maxPoints;
-        var result = new List<TelemetrySnapshot>(maxPoints + 1);
-        for (var i = 0; i < rows.Count; i += step)
-            result.Add(rows[i]);
+        // Per-day downsampling: each calendar day gets its own stride so that
+        // the sampler cannot systematically skip a particular MQTT field type.
+        // (A global stride whose step aligns with the per-poll batch size causes
+        // every sample to land on the same field type, e.g. always batteryVoltage,
+        // leaving fuelLevelPercent/evSocPercent blank for most days.)
+        var dayGroups = rows
+            .GroupBy(r => r.RecordedAt.Date)
+            .OrderBy(g => g.Key)
+            .ToList();
+
+        var targetPerDay = Math.Max(1, maxPoints / dayGroups.Count);
+        var result = new List<TelemetrySnapshot>(maxPoints + dayGroups.Count);
+        foreach (var dayGroup in dayGroups)
+        {
+            var dayRows = dayGroup.ToList();
+            if (dayRows.Count <= targetPerDay)
+            {
+                result.AddRange(dayRows);
+                continue;
+            }
+            // Even floating-point spacing avoids GCD aliasing: an integer stride
+            // whose GCD with the MQTT batch cycle size (typically 9 rows/poll) is
+            // > 1 causes the sampler to systematically skip certain field types
+            // (e.g. always landing on batteryVoltage, never on fuelLevelPercent).
+            var spacing = (double)dayRows.Count / targetPerDay;
+            for (var k = 0; k < targetPerDay; k++)
+                result.Add(dayRows[(int)(k * spacing)]);
+        }
         return result;
     }
 

--- a/src/GarageStack.Tests/TelemetryRepositoryTests.cs
+++ b/src/GarageStack.Tests/TelemetryRepositoryTests.cs
@@ -366,3 +366,83 @@ public class TelemetryRepositoryTests
         Assert.Equal("06:30", result.BatteryHeatingScheduleStartTime);
     }
 }
+
+// ── MergeIntoAsync tests ─────────────────────────────────────────────────────
+
+public class TelemetryRepositoryMergeTests
+{
+    private static async Task<(AppDbContext db, TelemetryRepository repo, Vehicle vehicle)> SetupAsync()
+    {
+        var db = new AppDbContext(new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options);
+        var vehicle = new Vehicle { Vin = "MERGE0000000000001" };
+        db.Vehicles.Add(vehicle);
+        await db.SaveChangesAsync();
+        return (db, new TelemetryRepository(db), vehicle);
+    }
+
+    [Fact]
+    public async Task AddAsync_ReturnsNewRowId()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var (_, repo, vehicle) = await SetupAsync();
+
+        var id = await repo.AddAsync(new TelemetrySnapshot { VehicleId = vehicle.Id, FuelLevelPercent = 60 }, ct);
+
+        Assert.True(id > 0);
+    }
+
+    [Fact]
+    public async Task MergeIntoAsync_MergesFieldsIntoExistingRow()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var (db, repo, vehicle) = await SetupAsync();
+
+        var id = await repo.AddAsync(new TelemetrySnapshot { VehicleId = vehicle.Id, FuelLevelPercent = 60 }, ct);
+        await repo.MergeIntoAsync(id, new TelemetrySnapshot { VehicleId = vehicle.Id, EvSocPercent = 80 }, ct);
+
+        var row = await db.TelemetrySnapshots.FindAsync(id);
+        Assert.Equal(60, row!.FuelLevelPercent);
+        Assert.Equal(80, row.EvSocPercent);
+    }
+
+    [Fact]
+    public async Task MergeIntoAsync_LastWriteWins_OverwritesExistingField()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var (db, repo, vehicle) = await SetupAsync();
+
+        var id = await repo.AddAsync(new TelemetrySnapshot { VehicleId = vehicle.Id, FuelLevelPercent = 60 }, ct);
+        await repo.MergeIntoAsync(id, new TelemetrySnapshot { VehicleId = vehicle.Id, FuelLevelPercent = 55 }, ct);
+
+        var row = await db.TelemetrySnapshots.FindAsync(id);
+        Assert.Equal(55, row!.FuelLevelPercent);
+    }
+
+    [Fact]
+    public async Task MergeIntoAsync_NullFieldInPatch_LeavesExistingValueUnchanged()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var (db, repo, vehicle) = await SetupAsync();
+
+        var id = await repo.AddAsync(new TelemetrySnapshot { VehicleId = vehicle.Id, FuelLevelPercent = 60, EvSocPercent = 80 }, ct);
+        await repo.MergeIntoAsync(id, new TelemetrySnapshot { VehicleId = vehicle.Id, BatteryVoltage = 12.8 }, ct);
+
+        var row = await db.TelemetrySnapshots.FindAsync(id);
+        Assert.Equal(60, row!.FuelLevelPercent);
+        Assert.Equal(80, row.EvSocPercent);
+        Assert.Equal(12.8, row.BatteryVoltage);
+    }
+
+    [Fact]
+    public async Task MergeIntoAsync_MissingRow_InsertsNewRow()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var (db, repo, vehicle) = await SetupAsync();
+
+        await repo.MergeIntoAsync(99999, new TelemetrySnapshot { VehicleId = vehicle.Id, FuelLevelPercent = 70 }, ct);
+
+        Assert.Equal(1, await db.TelemetrySnapshots.CountAsync(ct));
+    }
+}

--- a/src/GarageStack.Worker/Mqtt/MqttConsumerService.cs
+++ b/src/GarageStack.Worker/Mqtt/MqttConsumerService.cs
@@ -24,6 +24,13 @@ public class MqttConsumerService(
     // notification, preventing bogus "engine started" alerts after a deploy or crash.
     private readonly HashSet<string> _engineStateSeeded = new();
 
+    // MQTT polling cycles emit several messages within ~2 seconds (one per topic).
+    // Messages arriving within this window are merged into the same DB row so that
+    // each row represents a complete poll rather than a single field, reducing row
+    // count by ~9x and ensuring all chart fields land in the same sample.
+    private static readonly TimeSpan MergeWindow = TimeSpan.FromSeconds(15);
+    internal readonly Dictionary<int, (long RowId, DateTime RecordedAt)> _mergeState = new();
+
     protected virtual IMqttClient CreateMqttClient() => new MqttClientFactory().CreateMqttClient();
     protected virtual TimeSpan RetryDelay => TimeSpan.FromSeconds(5);
 
@@ -157,17 +164,27 @@ public class MqttConsumerService(
         {
             var vehicle = await vehicleRepoMain.GetOrCreateByVinAsync(vin, saicUser, ct);
 
-            var snapshot = new TelemetrySnapshot
+            var patch = new TelemetrySnapshot
             {
                 VehicleId = vehicle.Id,
                 RecordedAt = DateTime.UtcNow,
-                RawTopic = topic,
             };
+            TelemetryMapper.ApplyMessage(patch, subtopic, payload);
 
-            TelemetryMapper.ApplyMessage(snapshot, subtopic, payload);
-            await telemetryRepo.AddAsync(snapshot, ct);
+            if (_mergeState.TryGetValue(vehicle.Id, out var last) &&
+                patch.RecordedAt - last.RecordedAt <= MergeWindow)
+            {
+                await telemetryRepo.MergeIntoAsync(last.RowId, patch, ct);
+                _mergeState[vehicle.Id] = (last.RowId, patch.RecordedAt);
+            }
+            else
+            {
+                patch.RawTopic = topic;
+                var newId = await telemetryRepo.AddAsync(patch, ct);
+                _mergeState[vehicle.Id] = (newId, patch.RecordedAt);
+            }
 
-            await CheckEngineStartAsync(vin, snapshot, ct);
+            await CheckEngineStartAsync(vin, patch, ct);
         }
         catch (Exception ex)
         {


### PR DESCRIPTION
## Summary

Three root causes diagnosed from live API response data and a full DB export (110,279 rows over 14 days).

- **Frontend date alignment**: `from` was `Date.now() - N*86400000` (exact wall-clock time), but the chart bucket loop starts at local midnight of the start day. At 21:46 UTC with a 7-day filter, the cutoff landed at 19:46 UTC — after all that day's telemetry had already been recorded (07:35–15:11 UTC), silently excluding the entire first day from the API response while still rendering its empty bucket on the chart.

- **Downsampler GCD aliasing**: the global stride downsampler had a systematic flaw with batched MQTT data. Each polling cycle writes ~9 chart-eligible rows at nearly the same timestamp (one per topic: climateOn, batteryVoltage, fuelLevelPercent, evSocPercent, tyrePressure\*, …). With step=48 for a 7-day range, gcd(48, 9)=3, so the sampler always landed on the same 3 of 9 field-type positions and completely skipped fuelLevelPercent — confirmed in the live API response where every May 29 sample had `fuelLevelPercent: null` despite 310 fuel rows that day. Replaced with per-day even-spaced sampling (floating-point step) so consecutive indices alternate floor/ceil, eliminating GCD alignment and hitting all field types.

- **Merge at ingestion**: MQTT polling emits ~9 messages per cycle within ~2 seconds, each stored as a separate DB row (contributing to the 110K rows / 14 days problem and making the downsampler lottery worse). `MqttConsumerService` now keeps an in-memory `vehicleId → (rowId, recordedAt)` map; messages arriving within a 15-second window are merged into the existing row via `MergeIntoAsync` (last-write-wins per field). A new row is only inserted when the window expires. This cuts row count ~9x going forward and ensures every sampled row contains all chart fields together.

- **Partial chart index**: adds `IX_TelemetrySnapshots_VehicleId_RecordedAt_Chart`, a partial index over `(VehicleId, RecordedAt)` filtered to the 15 `HasChartData` fields, so `GetHistoryAsync` skips GPS, door, availability and other non-chart rows at the index level. The existing unfiltered index is preserved for `GetLatestAsync` / `GetMergedLatestAsync`.

## Test plan

- [ ] 7-day fuel chart shows a continuous line across all days with driving activity (was: only 2 days visible)
- [ ] 30-day chart shows all days with recorded data instead of ~2
- [ ] Switching between 7 / 30 / 90 day filters reloads and all active days appear
- [ ] EV SOC and tyre pressure charts similarly populated across all days
- [ ] New data written after deploy produces ~1 DB row per polling cycle instead of ~9
- [ ] 172 backend unit tests pass (5 new `TelemetryRepositoryMergeTests`)
- [ ] Run `dotnet ef database update` to apply `AddChartIndex` migration

🤖 Generated with [Claude Code](https://claude.com/claude-code)