### PR TITLE
Fix statistics skeleton showing vehicle-inapplicable cards

### DIFF
--- a/frontend/src/views/StatisticsView.vue
+++ b/frontend/src/views/StatisticsView.vue
@@ -575,8 +575,17 @@ function resetStatsLayout() {
   settings.statsCharts = defaultStatsCharts()
 }
 
-const skeletonInsights = computed(() => settings.statsInsights.filter((i) => i.visible))
-const skeletonChartCount = computed(() => settings.statsCharts.filter((c) => c.visible).length || 3)
+const skeletonInsights = computed(() =>
+  settings.statsInsights.filter(
+    (i) => i.visible && insightDefMap.value.get(i.id)?.vehicleApplicable !== false,
+  ),
+)
+const skeletonChartCount = computed(
+  () =>
+    settings.statsCharts.filter(
+      (c) => c.visible && chartDefMap.value.get(c.id)?.vehicleApplicable !== false,
+    ).length || 3,
+)
 </script>
 
 <template>


### PR DESCRIPTION
## Summary
- `skeletonInsights` and `skeletonChartCount` previously filtered only by `visible`, ignoring `vehicleApplicable`
- This caused PHEV-only cards (e.g. electric share with the leaf icon) to flash as skeleton loaders for HEV/BEV/unknown vehicle types, then disappear after data loaded
- Both computeds now consult `insightDefMap`/`chartDefMap` so the skeleton count matches what will actually render

## Test plan
- [ ] Load Statistics view on a HEV -- confirm no leaf/electric-share skeleton appears
- [ ] Load Statistics view on a PHEV -- confirm electric share skeleton does appear
- [ ] Verify skeleton card count matches final rendered card count for all vehicle types

🤖 Generated with [Claude Code](https://claude.com/claude-code)