### PR TITLE
Add demo mode with live vehicle state controls

### DIFF
--- a/.env.demo.example
+++ b/.env.demo.example
@@ -1,0 +1,22 @@
+# Copy this file to .env.demo and run:
+#   docker compose -f docker-compose.demo.yml up --build
+#
+# No SAIC credentials, no database, no MQTT required.
+
+# ── Demo toggle ───────────────────────────────────────────────────────────────
+DEMO_MODE=true
+
+# ── Auth ──────────────────────────────────────────────────────────────────────
+AUTH_USERNAME=demo
+AUTH_PASSWORD=demo
+
+# ── JWT ───────────────────────────────────────────────────────────────────────
+# Must be at least 32 characters. Generate with: openssl rand -base64 32
+JWT_SECRET=change-me-to-a-random-32-byte-secret!!
+
+# ── Ports ─────────────────────────────────────────────────────────────────────
+FRONTEND_PORT=8080
+API_PORT=5001
+
+# ── CORS ──────────────────────────────────────────────────────────────────────
+CORS_ORIGIN=http://localhost:8080

--- a/DEMO.md
+++ b/DEMO.md
@@ -1,0 +1,104 @@
+# Demo Mode
+
+Demo mode runs GarageStack with realistic fake data and requires no MG iSmart credentials, no database, and no MQTT broker.
+
+## What you get
+
+- MG ZS EV with 30 days of realistic SOC history, 5 pre-built trips around Amsterdam
+- Dashboard, Statistics, and Map views fully populated
+- A **Demo Controls** panel (bottom-right button) to toggle vehicle states live: doors, windows, lights, lock, engine, charging, SOC, temperature
+- A demo banner across the top reminding you that data is not real
+
+## Docker (quickest start)
+
+```bash
+cp .env.demo.example .env.demo
+# Edit .env.demo and set a real JWT_SECRET (at least 32 characters)
+docker compose -f docker-compose.demo.yml up --build
+```
+
+Open [http://localhost:8080](http://localhost:8080) and log in with **demo / demo**.
+
+The API is available at `http://localhost:5001`. Scalar API docs are not served in production mode — start the API locally (see below) if you need them.
+
+## Local development (no Docker)
+
+### Quick start (Windows Terminal)
+
+```powershell
+.\start-demo.ps1
+```
+
+Opens Windows Terminal with two horizontal panes: API on top, frontend on the bottom. Falls back to two separate windows if Windows Terminal is not installed.
+
+The script auto-creates `frontend/.env.development.local` from the example file on first run.
+
+### Manual start
+
+**Backend:**
+
+```bash
+cd src/GarageStack.Api
+dotnet run --launch-profile Demo
+```
+
+This starts the API at `http://localhost:5000` with `DEMO_MODE=true`, `Auth:Username=demo`, and `Auth:Password=demo` pre-configured. No database or MQTT connection is made.
+
+**Frontend:**
+
+```bash
+cd frontend
+cp .env.development.local.example .env.development.local
+pnpm dev
+```
+
+Open [http://localhost:5173](http://localhost:5173) and log in with **demo / demo**.
+
+The `.env.development.local` file sets `VITE_DEMO_MODE=true` so the demo banner and Demo Controls panel are visible. This file is git-ignored by Vite, so it will not be committed.
+
+## Logging in
+
+| Setup | URL | Username | Password |
+| --- | --- | --- | --- |
+| Docker | [http://localhost:8080](http://localhost:8080) | `demo` | `demo` |
+| Local dev | [http://localhost:5173](http://localhost:5173) | `demo` | `demo` |
+
+The credentials come from `AUTH_USERNAME` / `AUTH_PASSWORD` in `.env.demo` (Docker) or the `Auth__Username` / `Auth__Password` values in the `Demo` launch profile (local). Change them in either place if you want different credentials.
+
+## Demo Controls panel
+
+Click the flask icon in the bottom-right corner to open the panel. Changes take effect immediately and refresh the dashboard. Available controls:
+
+| Section | Controls |
+| --- | --- |
+| Doors / Bonnet / Trunk | Toggle each opening open/closed |
+| Windows | Toggle each window open/closed |
+| Lights | Main beam, dipped beam, sidelights |
+| State | Locked, engine running, climate |
+| Charging | Charger connected, actively charging |
+| Battery SOC | Slider 10-100% |
+| Temperature | Interior and exterior (°C) |
+
+## How it works
+
+`DEMO_MODE=true` swaps in three in-memory implementations at startup:
+
+| Interface | Demo implementation |
+| --- | --- |
+| `IVehicleRepository` | Returns one static MG ZS EV |
+| `ITelemetryRepository` | Serves pre-built snapshots and 5 trips; mutable via `/api/demo/status/{vin}` |
+| `IMqttPublisher` | No-op (vehicle commands are accepted but not sent) |
+
+No PostgreSQL, Mosquitto, Worker, or SAIC gateway containers are started.
+
+## Environment variables
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `DEMO_MODE` | `false` | Set to `true` to activate demo mode |
+| `AUTH_USERNAME` | _(required)_ | Login username |
+| `AUTH_PASSWORD` | _(required)_ | Login password |
+| `JWT_SECRET` | _(required)_ | Min 32 chars, used to sign tokens |
+| `FRONTEND_PORT` | `8080` | Host port for the frontend container |
+| `API_PORT` | `5001` | Host port for the API container |
+| `CORS_ORIGIN` | `http://localhost:8080` | Allowed CORS origin |

--- a/docker-compose.demo.yml
+++ b/docker-compose.demo.yml
@@ -1,0 +1,38 @@
+services:
+  api:
+    build:
+      context: .
+      dockerfile: src/GarageStack.Api/Dockerfile
+    container_name: garagestack-api-demo
+    restart: unless-stopped
+    env_file:
+      - .env.demo
+    environment:
+      ASPNETCORE_ENVIRONMENT: "Production"
+      DEMO_MODE: "true"
+      Cors__Origins__0: "${CORS_ORIGIN:-http://localhost:8080}"
+      Jwt__Secret: "${JWT_SECRET}"
+      Auth__Username: "${AUTH_USERNAME:-demo}"
+      Auth__Password: "${AUTH_PASSWORD:-demo}"
+    ports:
+      - "${API_PORT:-5001}:8080"
+    volumes:
+      - api_demo_logs:/app/logs
+      - api_demo_dataprotection:/root/.aspnet/DataProtection-Keys
+
+  frontend:
+    build:
+      context: ./frontend
+      dockerfile: Dockerfile
+      args:
+        VITE_DEMO_MODE: "true"
+    container_name: garagestack-frontend-demo
+    restart: unless-stopped
+    depends_on:
+      - api
+    ports:
+      - "${FRONTEND_PORT:-8080}:80"
+
+volumes:
+  api_demo_logs:
+  api_demo_dataprotection:

--- a/frontend/.env.development.local.example
+++ b/frontend/.env.development.local.example
@@ -1,0 +1,7 @@
+# Copy this file to .env.development.local to run the frontend in demo mode locally.
+# Vite automatically git-ignores .env.development.local files.
+#
+# Also start the backend with the Demo launch profile:
+#   dotnet run --launch-profile Demo  (from src/GarageStack.Api/)
+
+VITE_DEMO_MODE=true

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,5 +1,7 @@
 FROM node:24-alpine AS build
 WORKDIR /app
+ARG VITE_DEMO_MODE=false
+ENV VITE_DEMO_MODE=$VITE_DEMO_MODE
 RUN apk upgrade --no-cache && corepack enable && corepack prepare pnpm@latest --activate
 COPY package.json pnpm-lock.yaml ./
 RUN pnpm config set minimum-release-age 0 && pnpm install --frozen-lockfile --ignore-scripts

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -7,7 +7,12 @@ import { useAuthStore } from '@/stores/auth'
 import { useVehicleStore } from '@/stores/vehicle'
 import AppFooter from '@/components/AppFooter.vue'
 import NotificationPanel from '@/components/NotificationPanel.vue'
+import DemoBanner from '@/components/DemoBanner.vue'
+import DemoControlPanel from '@/components/DemoControlPanel.vue'
 import { useNotifications } from '@/composables/useNotifications'
+
+const isDemoMode = import.meta.env.VITE_DEMO_MODE === 'true'
+const demoControlsOpen = ref(false)
 
 const { t, locale } = useI18n()
 const route = useRoute()
@@ -107,6 +112,8 @@ watch(
   <RouterView v-if="isLoginRoute" />
 
   <div v-else class="app-layout">
+    <DemoBanner v-if="isDemoMode" />
+
     <!-- Mobile topbar -->
     <header class="mobile-topbar">
       <button class="hamburger" :aria-expanded="menuOpen" aria-label="Menu" @click="toggleMenu">
@@ -206,11 +213,21 @@ watch(
             <font-awesome-icon icon="user" />
             <span class="sidebar-user__email">{{ auth.username }}</span>
           </div>
+          <button
+            v-if="isDemoMode"
+            class="sidebar-demo-btn"
+            :class="{ 'is-active': demoControlsOpen }"
+            @click="demoControlsOpen = !demoControlsOpen"
+          >
+            <font-awesome-icon :icon="['fas', 'flask']" />
+            <span>{{ t('demo.controlPanel') }}</span>
+          </button>
           <button class="sidebar-notif-btn" @click="togglePanel">
             <font-awesome-icon icon="bell" />
             <span>{{ t('notifications.title') }}</span>
             <span v-if="unreadCount > 0" class="notif-bell__badge">{{ unreadCount }}</span>
           </button>
+
           <button class="sidebar-logout-btn" @click="logout">
             <font-awesome-icon icon="arrow-right-from-bracket" />
             <span>{{ t('auth.logout') }}</span>
@@ -235,5 +252,7 @@ watch(
       @delete="deleteNotification"
       @delete-all="deleteAllNotifications"
     />
+
+    <DemoControlPanel v-if="isDemoMode" :open="demoControlsOpen" />
   </div>
 </template>

--- a/frontend/src/assets/main.css
+++ b/frontend/src/assets/main.css
@@ -2495,3 +2495,171 @@ body,
     transform: translateY(-12px) scale(0.97);
   }
 }
+
+.demo-banner {
+  background-color: var(--color-warning);
+  color: #000;
+  text-align: center;
+  padding: 0.4rem 1rem;
+  font-size: 0.8rem;
+  font-weight: 600;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  letter-spacing: 0.02em;
+}
+
+.sidebar-demo-btn {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.5rem 0.75rem;
+  width: 100%;
+  border-radius: var(--radius);
+  font-size: 0.85rem;
+  cursor: pointer;
+  background: var(--color-surface-2);
+  border: 1px solid var(--color-border);
+  color: var(--color-text-muted);
+  text-align: left;
+  transition:
+    background 0.15s,
+    color 0.15s,
+    border-color 0.15s;
+}
+
+.sidebar-demo-btn:hover,
+.sidebar-demo-btn.is-active {
+  background: color-mix(in srgb, var(--color-warning) 12%, var(--color-surface-2));
+  border-color: var(--color-warning);
+  color: var(--color-text);
+}
+
+.demo-panel {
+  position: fixed;
+  bottom: 2rem;
+  left: calc(var(--sidebar-width) + 0.75rem);
+  z-index: 999;
+  width: 320px;
+  max-height: 70vh;
+  overflow-y: auto;
+  background-color: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.5);
+  padding: 1rem;
+}
+
+.demo-panel-title {
+  font-size: 0.85rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--color-warning);
+  margin-bottom: 0.75rem;
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.demo-panel-section {
+  margin-bottom: 0.75rem;
+}
+
+.demo-panel-section-label {
+  font-size: 0.72rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--color-text-muted);
+  margin-bottom: 0.4rem;
+}
+
+.demo-panel-toggles {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+}
+
+.demo-toggle-btn {
+  padding: 0.25rem 0.6rem;
+  font-size: 0.75rem;
+  border-radius: 4px;
+  border: 1px solid var(--color-border);
+  background-color: var(--color-surface-2);
+  color: var(--color-text);
+  cursor: pointer;
+  transition:
+    background-color 0.12s ease,
+    border-color 0.12s ease;
+}
+
+.demo-toggle-btn.is-active {
+  background-color: var(--color-warning);
+  border-color: var(--color-warning);
+  color: #000;
+}
+
+.demo-panel-range {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+}
+
+.demo-panel-range input[type='range'] {
+  flex: 1;
+  accent-color: var(--color-warning);
+}
+
+.demo-panel-range span {
+  font-size: 0.8rem;
+  min-width: 2.5rem;
+  text-align: right;
+  color: var(--color-text);
+}
+
+.demo-panel-inputs {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0.5rem;
+}
+
+.demo-panel-input-group label {
+  font-size: 0.72rem;
+  color: var(--color-text-muted);
+  display: block;
+  margin-bottom: 0.2rem;
+}
+
+.demo-panel-input-group input[type='number'] {
+  width: 100%;
+  padding: 0.3rem 0.5rem;
+  font-size: 0.8rem;
+  border-radius: 4px;
+  border: 1px solid var(--color-border);
+  background-color: var(--color-surface-2);
+  color: var(--color-text);
+}
+
+.demo-panel-enter-active,
+.demo-panel-leave-active {
+  transition:
+    opacity 0.18s ease,
+    transform 0.18s ease;
+}
+
+.demo-panel-enter-from,
+.demo-panel-leave-to {
+  opacity: 0;
+  transform: translateX(-8px);
+}
+
+@media (max-width: 767px) {
+  .demo-panel {
+    left: 1rem;
+    right: 1rem;
+    bottom: 4.5rem;
+    width: auto;
+  }
+}

--- a/frontend/src/components/DemoBanner.vue
+++ b/frontend/src/components/DemoBanner.vue
@@ -1,0 +1,12 @@
+<script setup lang="ts">
+import { useI18n } from 'vue-i18n'
+
+const { t } = useI18n()
+</script>
+
+<template>
+  <div class="demo-banner" role="status">
+    <font-awesome-icon :icon="['fas', 'triangle-exclamation']" />
+    {{ t('demo.banner') }}
+  </div>
+</template>

--- a/frontend/src/components/DemoControlPanel.vue
+++ b/frontend/src/components/DemoControlPanel.vue
@@ -1,0 +1,243 @@
+<script setup lang="ts">
+import { ref, computed } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { demoApi } from '@/services/api'
+import { useVehicleStore } from '@/stores/vehicle'
+
+const props = defineProps<{ open: boolean }>()
+
+const { t } = useI18n()
+const vehicleStore = useVehicleStore()
+
+const vin = computed(() => vehicleStore.vehicles[0]?.vin ?? null)
+const status = computed(() => vehicleStore.currentStatus)
+
+const socValue = ref<number>(78)
+
+async function sendOverride(override: Record<string, boolean | number | null>) {
+  if (!vin.value) return
+  await demoApi.setStatus(vin.value, override)
+  await vehicleStore.fetchStatus(vin.value)
+}
+
+async function toggle(field: string, current: boolean | null | undefined) {
+  await sendOverride({ [field]: !current })
+}
+
+async function applySoc() {
+  await sendOverride({ evSocPercent: socValue.value })
+}
+
+async function applyTemperature(field: string, value: string) {
+  const num = parseFloat(value)
+  if (!isNaN(num)) await sendOverride({ [field]: num })
+}
+
+function bool(val: boolean | null | undefined): boolean {
+  return val === true
+}
+</script>
+
+<template>
+  <Transition name="demo-panel">
+    <div v-if="props.open" class="demo-panel" role="region" :aria-label="t('demo.controlPanel')">
+      <div class="demo-panel-title">
+        <font-awesome-icon :icon="['fas', 'flask']" />
+        {{ t('demo.controlPanel') }}
+      </div>
+
+      <div class="demo-panel-section">
+        <div class="demo-panel-section-label">{{ t('demo.doors') }}</div>
+        <div class="demo-panel-toggles">
+          <button
+            class="demo-toggle-btn"
+            :class="{ 'is-active': bool(status?.driverDoorOpen) }"
+            @click="toggle('driverDoorOpen', status?.driverDoorOpen)"
+          >
+            {{ t('demo.driver') }}
+          </button>
+          <button
+            class="demo-toggle-btn"
+            :class="{ 'is-active': bool(status?.passengerDoorOpen) }"
+            @click="toggle('passengerDoorOpen', status?.passengerDoorOpen)"
+          >
+            {{ t('demo.passenger') }}
+          </button>
+          <button
+            class="demo-toggle-btn"
+            :class="{ 'is-active': bool(status?.rearLeftDoorOpen) }"
+            @click="toggle('rearLeftDoorOpen', status?.rearLeftDoorOpen)"
+          >
+            {{ t('demo.rearLeft') }}
+          </button>
+          <button
+            class="demo-toggle-btn"
+            :class="{ 'is-active': bool(status?.rearRightDoorOpen) }"
+            @click="toggle('rearRightDoorOpen', status?.rearRightDoorOpen)"
+          >
+            {{ t('demo.rearRight') }}
+          </button>
+          <button
+            class="demo-toggle-btn"
+            :class="{ 'is-active': bool(status?.trunkOpen) }"
+            @click="toggle('trunkOpen', status?.trunkOpen)"
+          >
+            {{ t('demo.trunk') }}
+          </button>
+          <button
+            class="demo-toggle-btn"
+            :class="{ 'is-active': bool(status?.bonnetOpen) }"
+            @click="toggle('bonnetOpen', status?.bonnetOpen)"
+          >
+            {{ t('demo.bonnet') }}
+          </button>
+        </div>
+      </div>
+
+      <div class="demo-panel-section">
+        <div class="demo-panel-section-label">{{ t('demo.windows') }}</div>
+        <div class="demo-panel-toggles">
+          <button
+            class="demo-toggle-btn"
+            :class="{ 'is-active': bool(status?.driverWindowOpen) }"
+            @click="toggle('driverWindowOpen', status?.driverWindowOpen)"
+          >
+            {{ t('demo.driver') }}
+          </button>
+          <button
+            class="demo-toggle-btn"
+            :class="{ 'is-active': bool(status?.passengerWindowOpen) }"
+            @click="toggle('passengerWindowOpen', status?.passengerWindowOpen)"
+          >
+            {{ t('demo.passenger') }}
+          </button>
+          <button
+            class="demo-toggle-btn"
+            :class="{ 'is-active': bool(status?.rearLeftWindowOpen) }"
+            @click="toggle('rearLeftWindowOpen', status?.rearLeftWindowOpen)"
+          >
+            {{ t('demo.rearLeft') }}
+          </button>
+          <button
+            class="demo-toggle-btn"
+            :class="{ 'is-active': bool(status?.rearRightWindowOpen) }"
+            @click="toggle('rearRightWindowOpen', status?.rearRightWindowOpen)"
+          >
+            {{ t('demo.rearRight') }}
+          </button>
+        </div>
+      </div>
+
+      <div class="demo-panel-section">
+        <div class="demo-panel-section-label">{{ t('demo.lights') }}</div>
+        <div class="demo-panel-toggles">
+          <button
+            class="demo-toggle-btn"
+            :class="{ 'is-active': bool(status?.lightsMainBeam) }"
+            @click="toggle('lightsMainBeam', status?.lightsMainBeam)"
+          >
+            {{ t('demo.mainBeam') }}
+          </button>
+          <button
+            class="demo-toggle-btn"
+            :class="{ 'is-active': bool(status?.lightsDippedBeam) }"
+            @click="toggle('lightsDippedBeam', status?.lightsDippedBeam)"
+          >
+            {{ t('demo.dippedBeam') }}
+          </button>
+          <button
+            class="demo-toggle-btn"
+            :class="{ 'is-active': bool(status?.lightsSide) }"
+            @click="toggle('lightsSide', status?.lightsSide)"
+          >
+            {{ t('demo.sidelights') }}
+          </button>
+        </div>
+      </div>
+
+      <div class="demo-panel-section">
+        <div class="demo-panel-section-label">{{ t('demo.state') }}</div>
+        <div class="demo-panel-toggles">
+          <button
+            class="demo-toggle-btn"
+            :class="{ 'is-active': bool(status?.isLocked) }"
+            @click="toggle('isLocked', status?.isLocked)"
+          >
+            {{ t('demo.locked') }}
+          </button>
+          <button
+            class="demo-toggle-btn"
+            :class="{ 'is-active': bool(status?.engineRunning) }"
+            @click="toggle('engineRunning', status?.engineRunning)"
+          >
+            {{ t('demo.engine') }}
+          </button>
+          <button
+            class="demo-toggle-btn"
+            :class="{ 'is-active': bool(status?.climateOn) }"
+            @click="toggle('climateOn', status?.climateOn)"
+          >
+            {{ t('demo.climate') }}
+          </button>
+        </div>
+      </div>
+
+      <div class="demo-panel-section">
+        <div class="demo-panel-section-label">{{ t('demo.charging') }}</div>
+        <div class="demo-panel-toggles">
+          <button
+            class="demo-toggle-btn"
+            :class="{ 'is-active': bool(status?.chargerConnected) }"
+            @click="toggle('chargerConnected', status?.chargerConnected)"
+          >
+            {{ t('demo.chargerConnected') }}
+          </button>
+          <button
+            class="demo-toggle-btn"
+            :class="{ 'is-active': bool(status?.isCharging) }"
+            @click="toggle('isCharging', status?.isCharging)"
+          >
+            {{ t('demo.isCharging') }}
+          </button>
+        </div>
+      </div>
+
+      <div class="demo-panel-section">
+        <div class="demo-panel-section-label">{{ t('demo.soc') }}</div>
+        <div class="demo-panel-range">
+          <input v-model.number="socValue" type="range" min="10" max="100" step="1" />
+          <span>{{ socValue }}%</span>
+          <button class="demo-toggle-btn" @click="applySoc">OK</button>
+        </div>
+      </div>
+
+      <div class="demo-panel-section">
+        <div class="demo-panel-section-label">{{ t('demo.temperature') }}</div>
+        <div class="demo-panel-inputs">
+          <div class="demo-panel-input-group">
+            <label>{{ t('demo.interior') }} (°C)</label>
+            <input
+              type="number"
+              :value="status?.interiorTemperature ?? 21"
+              step="0.5"
+              @change="
+                applyTemperature('interiorTemperature', ($event.target as HTMLInputElement).value)
+              "
+            />
+          </div>
+          <div class="demo-panel-input-group">
+            <label>{{ t('demo.exterior') }} (°C)</label>
+            <input
+              type="number"
+              :value="status?.exteriorTemperature ?? 14"
+              step="0.5"
+              @change="
+                applyTemperature('exteriorTemperature', ($event.target as HTMLInputElement).value)
+              "
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  </Transition>
+</template>

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -282,5 +282,32 @@
     "min": "min",
     "fetched": "Fetched",
     "recorded": "Recorded"
+  },
+  "demo": {
+    "banner": "Demo mode - displaying sample data only",
+    "controlPanel": "Demo Controls",
+    "doors": "Doors / Bonnet / Trunk",
+    "windows": "Windows",
+    "lights": "Lights",
+    "state": "State",
+    "charging": "Charging",
+    "soc": "Battery SOC",
+    "temperature": "Temperature",
+    "driver": "Driver",
+    "passenger": "Passenger",
+    "rearLeft": "Rear L",
+    "rearRight": "Rear R",
+    "trunk": "Trunk",
+    "bonnet": "Bonnet",
+    "mainBeam": "Main beam",
+    "dippedBeam": "Dipped",
+    "sidelights": "Side",
+    "locked": "Locked",
+    "engine": "Engine",
+    "climate": "Climate",
+    "chargerConnected": "Connected",
+    "isCharging": "Charging",
+    "interior": "Interior",
+    "exterior": "Exterior"
   }
 }

--- a/frontend/src/locales/nl.json
+++ b/frontend/src/locales/nl.json
@@ -282,5 +282,32 @@
     "min": "min",
     "fetched": "Opgehaald",
     "recorded": "Geregistreerd"
+  },
+  "demo": {
+    "banner": "Demo modus - alleen voorbeelddata wordt getoond",
+    "controlPanel": "Demo Bediening",
+    "doors": "Deuren / Motorkap / Kofferbak",
+    "windows": "Ramen",
+    "lights": "Verlichting",
+    "state": "Status",
+    "charging": "Laden",
+    "soc": "Batterij SOC",
+    "temperature": "Temperatuur",
+    "driver": "Bestuurder",
+    "passenger": "Passagier",
+    "rearLeft": "Achter L",
+    "rearRight": "Achter R",
+    "trunk": "Kofferbak",
+    "bonnet": "Motorkap",
+    "mainBeam": "Groot licht",
+    "dippedBeam": "Dimlicht",
+    "sidelights": "Stadslicht",
+    "locked": "Vergrendeld",
+    "engine": "Motor",
+    "climate": "Klimaat",
+    "chargerConnected": "Verbonden",
+    "isCharging": "Laden",
+    "interior": "Interieur",
+    "exterior": "Exterieur"
   }
 }

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -74,6 +74,7 @@ import {
   faTemperatureArrowUp,
   faCalendarCheck,
   faChargingStation,
+  faFlask,
 } from '@fortawesome/free-solid-svg-icons'
 
 import App from './App.vue'
@@ -152,6 +153,7 @@ library.add(
   faTemperatureArrowUp,
   faCalendarCheck,
   faChargingStation,
+  faFlask,
 )
 
 const i18n = createI18n({

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -185,6 +185,35 @@ export const vehicleApi = {
     send(`/api/vehicles/${vin}/commands/${command}`, 'POST', { value }),
 }
 
+export interface DemoStatusOverride {
+  isLocked?: boolean | null
+  engineRunning?: boolean | null
+  climateOn?: boolean | null
+  driverDoorOpen?: boolean | null
+  passengerDoorOpen?: boolean | null
+  rearLeftDoorOpen?: boolean | null
+  rearRightDoorOpen?: boolean | null
+  trunkOpen?: boolean | null
+  bonnetOpen?: boolean | null
+  driverWindowOpen?: boolean | null
+  passengerWindowOpen?: boolean | null
+  rearLeftWindowOpen?: boolean | null
+  rearRightWindowOpen?: boolean | null
+  chargerConnected?: boolean | null
+  isCharging?: boolean | null
+  lightsMainBeam?: boolean | null
+  lightsDippedBeam?: boolean | null
+  lightsSide?: boolean | null
+  evSocPercent?: number | null
+  interiorTemperature?: number | null
+  exteriorTemperature?: number | null
+}
+
+export const demoApi = {
+  setStatus: (vin: string, override: DemoStatusOverride) =>
+    send(`/api/demo/status/${vin}`, 'POST', override),
+}
+
 export const pushApi = {
   getVapidPublicKey: () => request<{ publicKey: string }>('/api/push/vapid-public-key'),
   subscribe: (endpoint: string, p256DhKey: string, authKey: string) =>

--- a/src/GarageStack.Api/Endpoints/DemoEndpoints.cs
+++ b/src/GarageStack.Api/Endpoints/DemoEndpoints.cs
@@ -1,0 +1,34 @@
+using GarageStack.Core.Interfaces;
+using GarageStack.Core.Models;
+using GarageStack.Data.Demo;
+
+namespace GarageStack.Api.Endpoints;
+
+public static class DemoEndpoints
+{
+    public static IEndpointRouteBuilder MapDemoEndpoints(
+        this IEndpointRouteBuilder app,
+        ITelemetryRepository telemetry)
+    {
+        var demoRepo = (DemoTelemetryRepository)telemetry;
+
+        var group = app.MapGroup("/api/demo")
+            .WithTags("Demo")
+            .RequireAuthorization();
+
+        group.MapPost("/status/{vin}", async (
+            string vin,
+            DemoStatusOverrideDto dto,
+            IVehicleRepository vehicles,
+            CancellationToken ct) =>
+        {
+            var vehicle = await vehicles.GetByVinAsync(vin, ct);
+            if (vehicle is null) return Results.NotFound();
+            demoRepo.ApplyOverride(dto);
+            return Results.NoContent();
+        })
+        .WithSummary("Override demo vehicle status fields");
+
+        return app;
+    }
+}

--- a/src/GarageStack.Api/Program.cs
+++ b/src/GarageStack.Api/Program.cs
@@ -5,6 +5,7 @@ using GarageStack.Api.Endpoints;
 using GarageStack.Api.Services;
 using GarageStack.Core.Interfaces;
 using GarageStack.Data;
+using GarageStack.Data.Demo;
 using GarageStack.Data.Extensions;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.HttpOverrides;
@@ -43,14 +44,25 @@ try
                   .MinimumLevel.Override("System", LogEventLevel.Warning);
     });
 
-    var connectionString = builder.Configuration.GetConnectionString("DefaultConnection")
-        ?? throw new InvalidOperationException("DefaultConnection is not configured.");
+    var isDemoMode = builder.Configuration.GetValue<bool>("DEMO_MODE");
 
     builder.Services.AddLocalization(opts => opts.ResourcesPath = "Resources");
-    builder.Services.AddGarageStackData(connectionString);
-    builder.Services.AddSingleton<MqttPublisher>();
-    builder.Services.AddSingleton<IMqttPublisher>(sp => sp.GetRequiredService<MqttPublisher>());
-    builder.Services.AddHostedService(sp => sp.GetRequiredService<MqttPublisher>());
+
+    if (isDemoMode)
+    {
+        Log.Information("DEMO MODE enabled -- using in-memory fake data, no database or MQTT required");
+        builder.Services.AddDemoServices();
+        builder.Services.AddSingleton<IMqttPublisher, DemoNoOpMqttPublisher>();
+    }
+    else
+    {
+        var connectionString = builder.Configuration.GetConnectionString("DefaultConnection")
+            ?? throw new InvalidOperationException("DefaultConnection is not configured.");
+        builder.Services.AddGarageStackData(connectionString);
+        builder.Services.AddSingleton<MqttPublisher>();
+        builder.Services.AddSingleton<IMqttPublisher>(sp => sp.GetRequiredService<MqttPublisher>());
+        builder.Services.AddHostedService(sp => sp.GetRequiredService<MqttPublisher>());
+    }
     builder.Services.AddOpenApi();
     builder.Services.ConfigureHttpJsonOptions(opts =>
     {
@@ -123,7 +135,19 @@ try
     using (var scope = app.Services.CreateScope())
     {
         var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
-        await db.Database.MigrateAsync();
+        if (isDemoMode)
+        {
+            db.Database.EnsureCreated();
+            if (!db.Vehicles.Any())
+            {
+                db.Vehicles.Add(DemoVehicleRepository.DemoVehicle);
+                await db.SaveChangesAsync();
+            }
+        }
+        else
+        {
+            await db.Database.MigrateAsync();
+        }
     }
 
     app.UseExceptionHandler(errorApp => errorApp.Run(async ctx =>
@@ -207,6 +231,12 @@ try
     app.MapVehicleEndpoints();
     app.MapNotificationEndpoints();
     app.MapWidgetEndpoints();
+
+    if (isDemoMode)
+    {
+        var demoTelemetry = app.Services.GetRequiredService<ITelemetryRepository>();
+        app.MapDemoEndpoints(demoTelemetry);
+    }
 
     app.Run();
 }

--- a/src/GarageStack.Api/Properties/launchSettings.json
+++ b/src/GarageStack.Api/Properties/launchSettings.json
@@ -1,6 +1,20 @@
 ﻿{
   "$schema": "https://json.schemastore.org/launchsettings.json",
   "profiles": {
+    "Demo": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": false,
+      "applicationUrl": "http://localhost:5000",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "DEMO_MODE": "true",
+        "Auth__Username": "demo",
+        "Auth__Password": "demo",
+        "Jwt__Secret": "demo-local-dev-secret-at-least-32-bytes",
+        "Cors__Origins__0": "http://localhost:5173"
+      }
+    },
     "http": {
       "commandName": "Project",
       "dotnetRunMessages": true,

--- a/src/GarageStack.Core/Models/DemoStatusOverrideDto.cs
+++ b/src/GarageStack.Core/Models/DemoStatusOverrideDto.cs
@@ -1,0 +1,25 @@
+namespace GarageStack.Core.Models;
+
+public record DemoStatusOverrideDto(
+    bool? IsLocked,
+    bool? EngineRunning,
+    bool? ClimateOn,
+    bool? DriverDoorOpen,
+    bool? PassengerDoorOpen,
+    bool? RearLeftDoorOpen,
+    bool? RearRightDoorOpen,
+    bool? TrunkOpen,
+    bool? BonnetOpen,
+    bool? DriverWindowOpen,
+    bool? PassengerWindowOpen,
+    bool? RearLeftWindowOpen,
+    bool? RearRightWindowOpen,
+    bool? ChargerConnected,
+    bool? IsCharging,
+    bool? LightsMainBeam,
+    bool? LightsDippedBeam,
+    bool? LightsSide,
+    double? EvSocPercent,
+    double? InteriorTemperature,
+    double? ExteriorTemperature
+);

--- a/src/GarageStack.Data/Demo/DemoNoOpMqttPublisher.cs
+++ b/src/GarageStack.Data/Demo/DemoNoOpMqttPublisher.cs
@@ -1,0 +1,17 @@
+using GarageStack.Core.Interfaces;
+using Microsoft.Extensions.Logging;
+
+namespace GarageStack.Data.Demo;
+
+public sealed class DemoNoOpMqttPublisher : IMqttPublisher
+{
+    private readonly ILogger<DemoNoOpMqttPublisher> _logger;
+
+    public DemoNoOpMqttPublisher(ILogger<DemoNoOpMqttPublisher> logger) => _logger = logger;
+
+    public Task PublishAsync(string topic, string payload, CancellationToken ct = default)
+    {
+        _logger.LogDebug("Demo mode: suppressed MQTT publish to '{Topic}'", topic);
+        return Task.CompletedTask;
+    }
+}

--- a/src/GarageStack.Data/Demo/DemoPushSender.cs
+++ b/src/GarageStack.Data/Demo/DemoPushSender.cs
@@ -1,0 +1,17 @@
+using GarageStack.Core.Interfaces;
+using Microsoft.Extensions.Logging;
+
+namespace GarageStack.Data.Demo;
+
+public sealed class DemoPushSender : IPushSender
+{
+    private readonly ILogger<DemoPushSender> _logger;
+
+    public DemoPushSender(ILogger<DemoPushSender> logger) => _logger = logger;
+
+    public Task SendToAllAsync(string title, string body, CancellationToken ct = default, string? category = null)
+    {
+        _logger.LogDebug("Demo mode: suppressed push notification '{Title}' (category={Category})", title, category);
+        return Task.CompletedTask;
+    }
+}

--- a/src/GarageStack.Data/Demo/DemoTelemetryRepository.cs
+++ b/src/GarageStack.Data/Demo/DemoTelemetryRepository.cs
@@ -1,0 +1,318 @@
+using GarageStack.Core.Interfaces;
+using GarageStack.Core.Models;
+
+namespace GarageStack.Data.Demo;
+
+public sealed class DemoTelemetryRepository : ITelemetryRepository
+{
+    private static long _nextId = 9000;
+    private static readonly object _lock = new();
+
+    private TelemetrySnapshot _current = BuildDefaultSnapshot();
+
+    private static readonly Lazy<IReadOnlyList<TelemetrySnapshot>> _history =
+        new(BuildHistory, LazyThreadSafetyMode.ExecutionAndPublication);
+
+    private static readonly Lazy<IReadOnlyList<TripDto>> _allTrips =
+        new(BuildTrips, LazyThreadSafetyMode.ExecutionAndPublication);
+
+    public Task<long> AddAsync(TelemetrySnapshot snapshot, CancellationToken ct = default) =>
+        Task.FromResult(Interlocked.Increment(ref _nextId));
+
+    public Task MergeIntoAsync(long rowId, TelemetrySnapshot patch, CancellationToken ct = default) =>
+        Task.CompletedTask;
+
+    public Task<TelemetrySnapshot?> GetLatestAsync(int vehicleId, CancellationToken ct = default)
+    {
+        lock (_lock) { return Task.FromResult<TelemetrySnapshot?>(_current); }
+    }
+
+    public Task<TelemetrySnapshot?> GetMergedLatestAsync(int vehicleId, CancellationToken ct = default)
+    {
+        lock (_lock) { return Task.FromResult<TelemetrySnapshot?>(_current); }
+    }
+
+    public Task<IReadOnlyList<TelemetrySnapshot>> GetHistoryAsync(
+        int vehicleId, DateTime from, DateTime to, CancellationToken ct = default) =>
+        Task.FromResult<IReadOnlyList<TelemetrySnapshot>>(
+            _history.Value.Where(s => s.RecordedAt >= from && s.RecordedAt <= to).ToList());
+
+    public Task<IReadOnlyList<TripDto>> GetTripsAsync(
+        int vehicleId, DateTime from, DateTime to, CancellationToken ct = default) =>
+        Task.FromResult<IReadOnlyList<TripDto>>(
+            _allTrips.Value.Where(t => t.StartedAt >= from && t.StartedAt <= to).ToList());
+
+    public void ApplyOverride(DemoStatusOverrideDto dto)
+    {
+        lock (_lock)
+        {
+            if (dto.IsLocked.HasValue) _current.IsLocked = dto.IsLocked;
+            if (dto.EngineRunning.HasValue) _current.EngineRunning = dto.EngineRunning;
+            if (dto.ClimateOn.HasValue) _current.ClimateOn = dto.ClimateOn;
+            if (dto.DriverDoorOpen.HasValue) _current.DriverDoorOpen = dto.DriverDoorOpen;
+            if (dto.PassengerDoorOpen.HasValue) _current.PassengerDoorOpen = dto.PassengerDoorOpen;
+            if (dto.RearLeftDoorOpen.HasValue) _current.RearLeftDoorOpen = dto.RearLeftDoorOpen;
+            if (dto.RearRightDoorOpen.HasValue) _current.RearRightDoorOpen = dto.RearRightDoorOpen;
+            if (dto.TrunkOpen.HasValue) _current.TrunkOpen = dto.TrunkOpen;
+            if (dto.BonnetOpen.HasValue) _current.BonnetOpen = dto.BonnetOpen;
+            if (dto.DriverWindowOpen.HasValue) _current.DriverWindowOpen = dto.DriverWindowOpen;
+            if (dto.PassengerWindowOpen.HasValue) _current.PassengerWindowOpen = dto.PassengerWindowOpen;
+            if (dto.RearLeftWindowOpen.HasValue) _current.RearLeftWindowOpen = dto.RearLeftWindowOpen;
+            if (dto.RearRightWindowOpen.HasValue) _current.RearRightWindowOpen = dto.RearRightWindowOpen;
+            if (dto.ChargerConnected.HasValue) _current.ChargerConnected = dto.ChargerConnected;
+            if (dto.IsCharging.HasValue) _current.IsCharging = dto.IsCharging;
+            if (dto.LightsMainBeam.HasValue) _current.LightsMainBeam = dto.LightsMainBeam;
+            if (dto.LightsDippedBeam.HasValue) _current.LightsDippedBeam = dto.LightsDippedBeam;
+            if (dto.LightsSide.HasValue) _current.LightsSide = dto.LightsSide;
+            if (dto.EvSocPercent.HasValue)
+            {
+                _current.EvSocPercent = dto.EvSocPercent;
+                _current.HvSocKwh = Math.Round(dto.EvSocPercent.Value / 100.0 * 70.0, 1);
+            }
+            if (dto.InteriorTemperature.HasValue) _current.InteriorTemperature = dto.InteriorTemperature;
+            if (dto.ExteriorTemperature.HasValue) _current.ExteriorTemperature = dto.ExteriorTemperature;
+        }
+    }
+
+    private static TelemetrySnapshot BuildDefaultSnapshot() => new()
+    {
+        Id = 1,
+        VehicleId = 1,
+        RecordedAt = DateTime.UtcNow.AddMinutes(-3),
+        EvSocPercent = 78,
+        HvSocKwh = Math.Round(78.0 / 100.0 * 70.0, 1),
+        HvTotalCapacityKwh = 70.0,
+        HvVoltage = 386.0,
+        HvCurrent = 0.0,
+        HvPower = 0.0,
+        HvBatteryActive = true,
+        OdometerKm = 24852,
+        EngineRunning = false,
+        IsCharging = false,
+        ChargerConnected = true,
+        ChargingType = "AC",
+        ChargingCableLock = true,
+        BmsChargeStatus = "FullyCharged",
+        OnboardChargerPlugStatus = 1,
+        OffboardChargerPlugStatus = 0,
+        ObcVoltage = 230.0,
+        ObcCurrent = 0.0,
+        ObcPowerSinglePhase = 0.0,
+        InteriorTemperature = 21.0,
+        ExteriorTemperature = 14.0,
+        RemoteTemperature = 19.5,
+        Speed = 0,
+        Heading = 270,
+        IsLocked = true,
+        ClimateOn = false,
+        BatteryHeating = false,
+        DriverDoorOpen = false,
+        PassengerDoorOpen = false,
+        RearLeftDoorOpen = false,
+        RearRightDoorOpen = false,
+        TrunkOpen = false,
+        BonnetOpen = false,
+        DriverWindowOpen = false,
+        PassengerWindowOpen = false,
+        RearLeftWindowOpen = false,
+        RearRightWindowOpen = false,
+        SunRoofOpen = null,
+        TyrePressureFrontLeft = 2.4,
+        TyrePressureFrontRight = 2.4,
+        TyrePressureRearLeft = 2.3,
+        TyrePressureRearRight = 2.3,
+        Latitude = 52.3676,
+        Longitude = 4.9041,
+        Elevation = 3.0,
+        BatteryVoltage = 12.7,
+        LightsMainBeam = false,
+        LightsDippedBeam = false,
+        LightsSide = false,
+        HeatedSeatFrontLeft = 0,
+        HeatedSeatFrontRight = 0,
+        RearWindowDefroster = false,
+        IsAvailable = true,
+        LastVehicleStateAt = DateTime.UtcNow.AddMinutes(-3),
+        LastChargeStateAt = DateTime.UtcNow.AddHours(-8),
+        MileageSinceLastCharge = 32.4,
+        MileageOfTheDay = 18.2,
+        PowerUsageOfDay = 2950,
+        ChargingScheduleMode = "Immediate",
+        ChargingScheduleStartTime = "00:00",
+        ChargingScheduleEndTime = "07:00",
+    };
+
+    private static IReadOnlyList<TelemetrySnapshot> BuildHistory()
+    {
+        var rng = new Random(42);
+        var snapshots = new List<TelemetrySnapshot>(120);
+        var baseDate = DateTime.UtcNow.Date.AddDays(-30);
+        var odometer = 24300.0;
+        var soc = 88.0;
+        var idCounter = 100L;
+
+        // 4 snapshots per day: depart (7h), midday (12h), return (17h), plug in (22h)
+        var dayHours = new[] { 7, 12, 17, 22 };
+        for (var day = 0; day < 30; day++)
+        {
+            for (var hi = 0; hi < dayHours.Length; hi++)
+            {
+                var hour = dayHours[hi];
+                var ts = baseDate.AddDays(day).AddHours(hour).AddMinutes(rng.Next(0, 30));
+
+                if (hour == 7)
+                {
+                    // after overnight charge
+                    soc = 87 + rng.Next(-2, 8);
+                }
+                else if (hour == 12)
+                {
+                    var consumed = 6 + rng.Next(0, 5);
+                    soc -= consumed;
+                    odometer += consumed * 7.2;
+                }
+                else if (hour == 17)
+                {
+                    var consumed = 5 + rng.Next(0, 5);
+                    soc -= consumed;
+                    odometer += consumed * 7.2;
+                }
+
+                soc = Math.Clamp(soc, 10, 97);
+
+                var isCharging = hour == 22;
+                var extTemp = 13.0 + (rng.NextDouble() - 0.5) * 10.0;
+                var frontPressure = 2.4 + (rng.NextDouble() - 0.5) * 0.06;
+                var rearPressure = 2.3 + (rng.NextDouble() - 0.5) * 0.06;
+
+                snapshots.Add(new TelemetrySnapshot
+                {
+                    Id = idCounter++,
+                    VehicleId = 1,
+                    RecordedAt = ts,
+                    EvSocPercent = Math.Round(soc, 1),
+                    HvSocKwh = Math.Round(soc / 100.0 * 70.0, 1),
+                    HvTotalCapacityKwh = 70.0,
+                    OdometerKm = Math.Round(odometer, 1),
+                    IsCharging = isCharging,
+                    ChargerConnected = isCharging || hour == 7,
+                    ExteriorTemperature = Math.Round(extTemp, 1),
+                    InteriorTemperature = Math.Round(extTemp + rng.NextDouble() * 4.0, 1),
+                    TyrePressureFrontLeft = Math.Round(frontPressure, 2),
+                    TyrePressureFrontRight = Math.Round(frontPressure + (rng.NextDouble() - 0.5) * 0.04, 2),
+                    TyrePressureRearLeft = Math.Round(rearPressure, 2),
+                    TyrePressureRearRight = Math.Round(rearPressure + (rng.NextDouble() - 0.5) * 0.04, 2),
+                    MileageOfTheDay = hour >= 12 ? Math.Round((odometer - 24300 - day * 90) % 200, 1) : 0,
+                    BatteryVoltage = 12.6 + rng.NextDouble() * 0.3,
+                    Latitude = 52.3676 + (rng.NextDouble() - 0.5) * 0.02,
+                    Longitude = 4.9041 + (rng.NextDouble() - 0.5) * 0.02,
+                    Speed = 0,
+                    IsLocked = true,
+                    EngineRunning = false,
+                    HvBatteryActive = true,
+                });
+            }
+        }
+
+        return snapshots;
+    }
+
+    private static IReadOnlyList<TripDto> BuildTrips()
+    {
+        var now = DateTime.UtcNow;
+        return
+        [
+            BuildTrip(0, now.AddDays(-2).AddHours(8), "Amsterdam to Schiphol",
+            [
+                (52.3780, 4.9003, 35),
+                (52.3621, 4.8879, 55),
+                (52.3480, 4.8750, 90),
+                (52.3380, 4.8450, 95),
+                (52.3280, 4.8100, 90),
+                (52.3200, 4.7850, 70),
+                (52.3090, 4.7649, 30),
+            ]),
+            BuildTrip(1, now.AddDays(-5).AddHours(9), "Amsterdam to Haarlem",
+            [
+                (52.3676, 4.9041, 30),
+                (52.3700, 4.8700, 80),
+                (52.3740, 4.8100, 90),
+                (52.3780, 4.7700, 90),
+                (52.3830, 4.7200, 80),
+                (52.3860, 4.6850, 60),
+                (52.3874, 4.6462, 20),
+            ]),
+            BuildTrip(2, now.AddDays(-8).AddHours(14), "City drive",
+            [
+                (52.3676, 4.9041, 25),
+                (52.3710, 4.9150, 30),
+                (52.3740, 4.9220, 25),
+                (52.3750, 4.9100, 20),
+                (52.3730, 4.8960, 25),
+                (52.3700, 4.8980, 20),
+                (52.3676, 4.9041, 10),
+            ]),
+            BuildTrip(3, now.AddDays(-12).AddHours(10), "Amsterdam to Utrecht",
+            [
+                (52.3676, 4.9041, 40),
+                (52.3400, 4.9200, 100),
+                (52.3000, 4.9400, 110),
+                (52.2500, 4.9600, 120),
+                (52.2000, 4.9800, 120),
+                (52.1500, 5.0100, 110),
+                (52.1100, 5.0700, 90),
+                (52.0907, 5.1214, 30),
+            ]),
+            BuildTrip(4, now.AddDays(-18).AddHours(16), "Amsterdam to Almere",
+            [
+                (52.3676, 4.9041, 35),
+                (52.3700, 4.9500, 90),
+                (52.3710, 5.0100, 100),
+                (52.3705, 5.0700, 100),
+                (52.3700, 5.1300, 90),
+                (52.3700, 5.1900, 60),
+                (52.3702, 5.2158, 25),
+            ]),
+        ];
+    }
+
+    private static TripDto BuildTrip(int index, DateTime start, string _,
+        IReadOnlyList<(double Lat, double Lon, double SpeedKmh)> waypoints)
+    {
+        var points = new List<TripPoint>(waypoints.Count);
+        var totalKm = 0.0;
+        var minutesElapsed = 0.0;
+
+        for (var i = 0; i < waypoints.Count; i++)
+        {
+            if (i > 0)
+            {
+                var seg = Haversine(
+                    waypoints[i - 1].Lat, waypoints[i - 1].Lon,
+                    waypoints[i].Lat, waypoints[i].Lon);
+                totalKm += seg;
+                var avgSpeed = (waypoints[i - 1].SpeedKmh + waypoints[i].SpeedKmh) / 2.0;
+                minutesElapsed += avgSpeed > 0 ? seg / avgSpeed * 60.0 : 2.0;
+            }
+            points.Add(new TripPoint(
+                start.AddMinutes(minutesElapsed),
+                waypoints[i].Lat,
+                waypoints[i].Lon,
+                waypoints[i].SpeedKmh));
+        }
+
+        var endedAt = points[^1].RecordedAt;
+        return new TripDto(index, start, endedAt, Math.Round(totalKm, 1), points.Count, points);
+    }
+
+    private static double Haversine(double lat1, double lon1, double lat2, double lon2)
+    {
+        const double R = 6371.0;
+        var dLat = (lat2 - lat1) * Math.PI / 180.0;
+        var dLon = (lon2 - lon1) * Math.PI / 180.0;
+        var a = Math.Sin(dLat / 2) * Math.Sin(dLat / 2) +
+                Math.Cos(lat1 * Math.PI / 180.0) * Math.Cos(lat2 * Math.PI / 180.0) *
+                Math.Sin(dLon / 2) * Math.Sin(dLon / 2);
+        return R * 2.0 * Math.Atan2(Math.Sqrt(a), Math.Sqrt(1.0 - a));
+    }
+}

--- a/src/GarageStack.Data/Demo/DemoVehicleRepository.cs
+++ b/src/GarageStack.Data/Demo/DemoVehicleRepository.cs
@@ -1,0 +1,29 @@
+using GarageStack.Core.Interfaces;
+using GarageStack.Core.Models;
+
+namespace GarageStack.Data.Demo;
+
+public sealed class DemoVehicleRepository : IVehicleRepository
+{
+    public static readonly Vehicle DemoVehicle = new()
+    {
+        Id = 1,
+        Vin = "LSJXXXXXXXXXX12345",
+        Model = "MG ZS EV",
+        Series = "ZS EV",
+        SaicUser = "demo@example.com",
+        CreatedAt = DateTime.UtcNow.AddMonths(-6),
+    };
+
+    public Task<Vehicle?> GetByVinAsync(string vin, CancellationToken ct = default) =>
+        Task.FromResult<Vehicle?>(vin == DemoVehicle.Vin ? DemoVehicle : null);
+
+    public Task<Vehicle> GetOrCreateByVinAsync(string vin, string? saicUser = null, CancellationToken ct = default) =>
+        Task.FromResult(DemoVehicle);
+
+    public Task SetModelAsync(int vehicleId, string model, CancellationToken ct = default) =>
+        Task.CompletedTask;
+
+    public Task SetConfigValueAsync(int vehicleId, string key, string value, CancellationToken ct = default) =>
+        Task.CompletedTask;
+}

--- a/src/GarageStack.Data/Extensions/ServiceCollectionExtensions.cs
+++ b/src/GarageStack.Data/Extensions/ServiceCollectionExtensions.cs
@@ -1,4 +1,5 @@
 using GarageStack.Core.Interfaces;
+using GarageStack.Data.Demo;
 using GarageStack.Data.Repositories;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Diagnostics;
@@ -16,6 +17,18 @@ public static class ServiceCollectionExtensions
 
         services.AddScoped<IVehicleRepository, VehicleRepository>();
         services.AddScoped<ITelemetryRepository, TelemetryRepository>();
+
+        return services;
+    }
+
+    public static IServiceCollection AddDemoServices(this IServiceCollection services)
+    {
+        services.AddDbContext<AppDbContext>(opts =>
+            opts.UseInMemoryDatabase("garagestack-demo"));
+
+        services.AddScoped<IVehicleRepository, DemoVehicleRepository>();
+        services.AddSingleton<ITelemetryRepository, DemoTelemetryRepository>();
+        services.AddSingleton<IPushSender, DemoPushSender>();
 
         return services;
     }

--- a/src/GarageStack.Data/GarageStack.Data.csproj
+++ b/src/GarageStack.Data/GarageStack.Data.csproj
@@ -12,6 +12,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.2" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.8" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/start-demo.ps1
+++ b/start-demo.ps1
@@ -1,0 +1,47 @@
+# Launches GarageStack demo mode in Windows Terminal with two horizontal panes.
+# Top pane: .NET API (demo launch profile)  http://localhost:5000
+# Bottom pane: Vite frontend (demo mode)     http://localhost:5173
+
+$ErrorActionPreference = 'Stop'
+
+$root = $PSScriptRoot
+$apiPath = Join-Path $root 'src\GarageStack.Api'
+$frontendPath = Join-Path $root 'frontend'
+$envLocal = Join-Path $frontendPath '.env.development.local'
+$envLocalExample = Join-Path $frontendPath '.env.development.local.example'
+
+# Auto-create frontend/.env.development.local if absent
+if (-not (Test-Path $envLocal)) {
+    if (Test-Path $envLocalExample) {
+        Copy-Item $envLocalExample $envLocal
+        Write-Host 'Created frontend/.env.development.local from example' -ForegroundColor Green
+    } else {
+        'VITE_DEMO_MODE=true' | Set-Content $envLocal -Encoding UTF8
+        Write-Host 'Created frontend/.env.development.local' -ForegroundColor Green
+    }
+}
+
+Write-Host ''
+Write-Host '  GarageStack Demo' -ForegroundColor Yellow
+Write-Host '  API      -> http://localhost:5000' -ForegroundColor Cyan
+Write-Host '  Frontend -> http://localhost:5173  (login: demo / demo)' -ForegroundColor Cyan
+Write-Host ''
+
+if (-not (Get-Command wt -ErrorAction SilentlyContinue)) {
+    Write-Warning 'Windows Terminal (wt) not found -- opening two separate windows instead.'
+    Start-Process pwsh -ArgumentList '-NoExit', '-Command', "cd '$apiPath'; dotnet run --launch-profile Demo"
+    Start-Process pwsh -ArgumentList '-NoExit', '-Command', "cd '$frontendPath'; pnpm dev"
+    exit 0
+}
+
+$wtArgs = @(
+    'new-tab', '--title', 'GarageStack API (Demo)', '--tabColor', '#f59e0b',
+    '-d', $apiPath,
+    'pwsh', '-NoExit', '-Command', 'dotnet run --launch-profile Demo',
+    ';',
+    'split-pane', '-H', '--title', 'GarageStack Frontend (Demo)', '--tabColor', '#3b82f6',
+    '-d', $frontendPath,
+    'pwsh', '-NoExit', '-Command', 'pnpm dev'
+)
+
+& wt @wtArgs


### PR DESCRIPTION
## Summary

- Adds `DEMO_MODE=true` to run GarageStack with no credentials, database, or MQTT broker — in-memory repositories serve a realistic MG ZS EV with 30 days of SOC history and 5 pre-built trips around Amsterdam
- Introduces a **Demo Controls** panel in the sidebar footer (demo mode only) to live-toggle doors, windows, lights, lock, engine, charging state, SOC, and temperature via `POST /api/demo/status/{vin}`
- Ships a `docker-compose.demo.yml` (API + frontend only), `start-demo.ps1` (Windows Terminal split panes), a `Demo` launch profile for local dev, and `DEMO.md` documentation

## Test plan

- [ ] Copy `.env.demo.example` → `.env.demo`, set `JWT_SECRET`, run `docker compose -f docker-compose.demo.yml up --build`
- [ ] Open `http://localhost:8080`, log in with `demo / demo` — dashboard shows MG ZS EV with SOC 78%, amber demo banner visible
- [ ] Statistics page shows 30-day SOC chart with realistic charge cycles (not flat)
- [ ] Map page shows 5 trip routes around Amsterdam
- [ ] Demo Controls button appears in sidebar footer; toggling driver door open reflects on the vehicle diagram
- [ ] Adjusting SOC slider updates the battery card after refresh
- [ ] Vehicle commands (lock, climate) return 200 with no MQTT errors in logs
- [ ] `docker compose -f docker-compose.demo.yml ps` shows only `api` and `frontend` containers
- [ ] Production `docker-compose.yml` starts cleanly (no `DEMO_MODE` set = production path unchanged)
- [ ] `dotnet test` passes (172 tests)
