### PR TITLE
Add drag handle to edit-mode cards

### DIFF
--- a/frontend/src/assets/main.css
+++ b/frontend/src/assets/main.css
@@ -1479,8 +1479,8 @@ body,
 .card-slot {
   position: relative;
   animation: card-wiggle 0.22s ease-in-out infinite alternate;
-  cursor: grab;
-  touch-action: none;
+  cursor: default;
+  touch-action: auto;
   user-select: none;
 }
 
@@ -1498,15 +1498,45 @@ body,
 }
 
 .card-slot--static {
-  cursor: default;
-  touch-action: auto;
   animation: none;
+}
+
+.card-slot__handle {
+  position: absolute;
+  top: -9px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  border: 2.5px solid var(--color-bg);
+  background: var(--color-surface);
+  color: var(--color-text-muted);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.6rem;
+  cursor: grab;
+  touch-action: none;
+  z-index: 2;
+  line-height: 1;
+  transition:
+    background 0.15s,
+    color 0.15s;
+}
+
+.card-slot__handle:hover {
+  background: var(--color-surface-2);
+  color: var(--color-text);
 }
 
 .card-slot--chosen {
   animation: none;
-  cursor: grabbing;
   opacity: 0.9;
+}
+
+.card-slot--chosen .card-slot__handle {
+  cursor: grabbing;
 }
 
 .card-slot--ghost {

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -75,6 +75,7 @@ import {
   faCalendarCheck,
   faChargingStation,
   faFlask,
+  faGripLines,
 } from '@fortawesome/free-solid-svg-icons'
 
 import App from './App.vue'
@@ -154,6 +155,7 @@ library.add(
   faCalendarCheck,
   faChargingStation,
   faFlask,
+  faGripLines,
 )
 
 const i18n = createI18n({

--- a/frontend/src/views/DashboardView.vue
+++ b/frontend/src/views/DashboardView.vue
@@ -203,6 +203,7 @@ onUnmounted(() => {
         :animation="200"
         ghost-class="card-slot--ghost"
         chosen-class="card-slot--chosen"
+        handle=".card-slot__handle"
       >
         <div
           v-for="card in settings.cards"
@@ -210,6 +211,9 @@ onUnmounted(() => {
           class="card-slot"
           :class="{ 'card-slot--hidden': !card.visible }"
         >
+          <div class="card-slot__handle">
+            <font-awesome-icon icon="grip-lines" />
+          </div>
           <div class="card-slot__content">
             <DashboardCardContent
               v-if="card.visible && status && cardHasData(card.id)"

--- a/frontend/src/views/StatisticsView.vue
+++ b/frontend/src/views/StatisticsView.vue
@@ -701,6 +701,7 @@ const skeletonChartCount = computed(
             :animation="200"
             ghost-class="card-slot--ghost"
             chosen-class="card-slot--chosen"
+            handle=".card-slot__handle"
           >
             <div
               v-for="item in settings.statsInsights"
@@ -709,6 +710,9 @@ const skeletonChartCount = computed(
               class="card-slot"
               :class="{ 'card-slot--hidden': !item.visible }"
             >
+              <div class="card-slot__handle">
+                <font-awesome-icon icon="grip-lines" />
+              </div>
               <div class="card-slot__content">
                 <template
                   v-if="
@@ -808,6 +812,7 @@ const skeletonChartCount = computed(
             :animation="200"
             ghost-class="card-slot--ghost"
             chosen-class="card-slot--chosen"
+            handle=".card-slot__handle"
           >
             <div
               v-for="item in settings.statsCharts"
@@ -816,6 +821,9 @@ const skeletonChartCount = computed(
               class="card-slot card-slot--chart"
               :class="{ 'card-slot--hidden': !item.visible }"
             >
+              <div class="card-slot__handle">
+                <font-awesome-icon icon="grip-lines" />
+              </div>
               <div class="card-slot__content">
                 <div
                   v-if="chartDefMap.get(item.id)?.applicable && store.history.length"


### PR DESCRIPTION
## Summary

- Adds a dedicated grip-lines drag handle centred at the top of every draggable card slot in edit mode (Dashboard and Statistics views)
- Restricts `VueDraggable` to initiate drags only via the handle (`handle=".card-slot__handle"`), restoring native touch-scroll behaviour on the rest of the card body
- Removes `touch-action: none` and `cursor: grab` from `.card-slot` and moves them to `.card-slot__handle` only
- Registers `faGripLines` in the Font Awesome library
- Show/hide badge remains at the top-right corner, unchanged

## Test plan

- [ ] Open the Dashboard on mobile (or DevTools touch emulation) in edit mode — verify the page scrolls normally when touching card content
- [ ] Drag a card via the centre-top grip handle — verify it reorders correctly
- [ ] Repeat on the Statistics view for both insight cards and chart cards
- [ ] Verify the show/hide badge (×/+) still appears at the top-right of each card
- [ ] Confirm the grip-lines icon renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)