### PR TITLE
Add setting to hide card info icons

### DIFF
--- a/frontend/src/components/AppFooter.vue
+++ b/frontend/src/components/AppFooter.vue
@@ -120,6 +120,32 @@ async function refresh() {
       </div>
     </div>
 
+    <!-- Dashboard -->
+    <div class="detail-modal__section">
+      <div class="detail-modal__section-title">{{ t('settings.dashboard.title') }}</div>
+      <div class="settings-toggles">
+        <div class="settings-toggle">
+          <div class="settings-toggle__info">
+            <span class="settings-toggle__label">{{ t('settings.dashboard.cardInfoIcons') }}</span>
+            <span class="settings-toggle__desc text-muted">{{
+              t('settings.dashboard.cardInfoIconsDesc')
+            }}</span>
+          </div>
+          <div class="settings-toggle__control">
+            <div class="form-check form-switch mb-0">
+              <input
+                id="footer-toggle-card-info-icons"
+                v-model="settings.showCardInfoIcons"
+                class="form-check-input"
+                type="checkbox"
+                role="switch"
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
     <!-- Language -->
     <div class="detail-modal__section">
       <div class="detail-modal__section-title">{{ t('settings.language.title') }}</div>

--- a/frontend/src/components/CardInfoWrap.vue
+++ b/frontend/src/components/CardInfoWrap.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { ref } from 'vue'
 import { useI18n } from 'vue-i18n'
+import { useSettingsStore } from '@/stores/settings'
 
 defineProps<{
   title: string
@@ -9,12 +10,14 @@ defineProps<{
 
 const { t } = useI18n()
 const showInfo = ref(false)
+const settings = useSettingsStore()
 </script>
 
 <template>
   <div class="card-info-wrap">
     <slot />
     <button
+      v-if="settings.showCardInfoIcons"
       class="card-info-btn"
       :aria-label="t('dashboard.cardInfoBtn')"
       @click.stop="showInfo = true"

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -252,6 +252,11 @@
       "chargingSession": "Charging Session",
       "batteryHeating": "Battery Heating"
     },
+    "dashboard": {
+      "title": "Dashboard",
+      "cardInfoIcons": "Show info icons",
+      "cardInfoIconsDesc": "Show the info button on each card"
+    },
     "vehicleType": {
       "title": "Vehicle type",
       "detected": "Detected",

--- a/frontend/src/locales/nl.json
+++ b/frontend/src/locales/nl.json
@@ -252,6 +252,11 @@
       "chargingSession": "Laadsessie",
       "batteryHeating": "Accuverwarming"
     },
+    "dashboard": {
+      "title": "Dashboard",
+      "cardInfoIcons": "Info-iconen tonen",
+      "cardInfoIconsDesc": "Toon de info-knop op elke kaart"
+    },
     "vehicleType": {
       "title": "Voertuigtype",
       "detected": "Gedetecteerd",

--- a/frontend/src/stores/settings.ts
+++ b/frontend/src/stores/settings.ts
@@ -133,6 +133,7 @@ export interface AppSettings {
   statsInsights: StatsItemConfig<StatsInsightId>[]
   statsCharts: StatsItemConfig<StatsChartId>[]
   showTyreDiagram: boolean
+  showCardInfoIcons: boolean
   vehicleTypeOverride: VehicleTypeOverride
   theme: Theme
   locale: Locale
@@ -183,6 +184,7 @@ const defaults: AppSettings = {
   statsInsights: defaultStatsInsights(),
   statsCharts: defaultStatsCharts(),
   showTyreDiagram: true,
+  showCardInfoIcons: true,
   vehicleTypeOverride: 'auto',
   theme: osPreferredTheme(),
   locale: browserLocale(),
@@ -279,6 +281,7 @@ function loadFromKey(key: string): AppSettings {
           statsInsights: defaultStatsInsights(),
           statsCharts: defaultStatsCharts(),
           showTyreDiagram: true,
+          showCardInfoIcons: parsed.showCardInfoIcons !== false,
           vehicleTypeOverride: parsed.vehicleTypeOverride ?? defaults.vehicleTypeOverride,
           theme: parsed.theme ?? defaults.theme,
           locale: parsed.locale ?? defaults.locale,
@@ -292,6 +295,7 @@ function loadFromKey(key: string): AppSettings {
           statsInsights: loadStatsItems(parsed.statsInsights, ALL_STATS_INSIGHT_IDS),
           statsCharts: loadStatsItems(parsed.statsCharts, ALL_STATS_CHART_IDS),
           showTyreDiagram: parsed.showTyreDiagram !== false,
+          showCardInfoIcons: parsed.showCardInfoIcons !== false,
           vehicleTypeOverride: parsed.vehicleTypeOverride ?? defaults.vehicleTypeOverride,
           theme: parsed.theme ?? defaults.theme,
           locale: parsed.locale ?? defaults.locale,
@@ -325,6 +329,7 @@ export const useSettingsStore = defineStore('settings', () => {
   const statsInsights = ref<StatsItemConfig<StatsInsightId>[]>(loaded.statsInsights)
   const statsCharts = ref<StatsItemConfig<StatsChartId>[]>(loaded.statsCharts)
   const showTyreDiagram = ref<boolean>(loaded.showTyreDiagram)
+  const showCardInfoIcons = ref<boolean>(loaded.showCardInfoIcons)
 
   document.documentElement.dataset.theme = theme.value
 
@@ -336,6 +341,7 @@ export const useSettingsStore = defineStore('settings', () => {
         statsInsights: statsInsights.value,
         statsCharts: statsCharts.value,
         showTyreDiagram: showTyreDiagram.value,
+        showCardInfoIcons: showCardInfoIcons.value,
         vehicleTypeOverride: vehicleTypeOverride.value,
         theme: theme.value,
         locale: locale.value,
@@ -348,6 +354,7 @@ export const useSettingsStore = defineStore('settings', () => {
   watch(statsInsights, save, { deep: true })
   watch(statsCharts, save, { deep: true })
   watch(showTyreDiagram, save)
+  watch(showCardInfoIcons, save)
   watch(vehicleTypeOverride, save)
   watch(locale, save)
   watch(filterDays, save)
@@ -365,6 +372,7 @@ export const useSettingsStore = defineStore('settings', () => {
     statsInsights,
     statsCharts,
     showTyreDiagram,
+    showCardInfoIcons,
     vehicleTypeOverride,
     theme,
     locale,


### PR DESCRIPTION
## Summary
- Adds `showCardInfoIcons` boolean setting (defaults to `true`) to the settings store
- Conditionally hides the info button on cards via `v-if` when the setting is off
- Adds a Dashboard section in the settings modal with a toggle for this option
- Adds translations for both English and Dutch

## Test plan
- [ ] Toggle the setting off in Settings -- info icons disappear from all cards
- [ ] Toggle back on -- info icons reappear
- [ ] Existing users without the key in localStorage default to icons shown
- [ ] Setting persists across page reloads
- [ ] Docker build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)