### PR TITLE
Potential fix for code scanning alert no. 44: Log entries created from user input

### DIFF
--- a/src/GarageStack.Data/Demo/DemoNoOpMqttPublisher.cs
+++ b/src/GarageStack.Data/Demo/DemoNoOpMqttPublisher.cs
@@ -11,7 +11,8 @@ public sealed class DemoNoOpMqttPublisher : IMqttPublisher
 
     public Task PublishAsync(string topic, string payload, CancellationToken ct = default)
     {
-        _logger.LogDebug("Demo mode: suppressed MQTT publish to '{Topic}'", topic);
+        var safeTopicForLog = topic.Replace("\r", string.Empty).Replace("\n", string.Empty);
+        _logger.LogDebug("Demo mode: suppressed MQTT publish to '{Topic}'", safeTopicForLog);
         return Task.CompletedTask;
     }
 }


### PR DESCRIPTION
Potential fix for [https://github.com/joszz/GarageStack/security/code-scanning/44](https://github.com/joszz/GarageStack/security/code-scanning/44)

Sanitize `topic` before writing it to logs by removing newline/control characters that can forge additional log lines. Keep MQTT publishing behavior unchanged (this class is no-op anyway) and only alter the logged representation.

Best fix in the shown code: in `src/GarageStack.Data/Demo/DemoNoOpMqttPublisher.cs`, update `PublishAsync` to derive a safe log string from `topic` (e.g., replace `\r` and `\n` with empty string) and log that sanitized value instead of raw `topic`. No new dependencies are required; use `string.Replace`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
