### PR TITLE
Fix efficiency card for HEV and add fuel economy fallback

### DIFF
--- a/frontend/src/components/DashboardCardContent.vue
+++ b/frontend/src/components/DashboardCardContent.vue
@@ -202,7 +202,7 @@ const supportsExternalCharge = computed(
       :unit="t('common.km')"
     />
 
-    <!-- efficiencyRatio -->
+    <!-- efficiencyRatio - Wh/km when driving data is available -->
     <StatusCard
       v-else-if="
         cardId === 'efficiencyRatio' &&
@@ -214,6 +214,21 @@ const supportsExternalCharge = computed(
       :label="t('vehicle.efficiency.efficiency')"
       :value="(status.powerUsageOfDay / status.mileageOfTheDay).toFixed(0)"
       :unit="`${t('common.wh')}/${t('common.km')}`"
+    />
+
+    <!-- efficiencyRatio - fuel economy estimate for HEV/PHEV from range computer -->
+    <StatusCard
+      v-else-if="
+        cardId === 'efficiencyRatio' &&
+        (isHev || vehicleType === 'phev') &&
+        status.fuelRangeKm !== null &&
+        status.fuelLevelPercent !== null &&
+        status.fuelLevelPercent > 0
+      "
+      icon="gas-pump"
+      :label="t('vehicle.efficiency.fuelEconomy')"
+      :value="(status.fuelRangeKm / (status.fuelLevelPercent / 100) / 100).toFixed(1)"
+      unit="km/%"
     />
 
     <!-- speed -->

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -30,7 +30,7 @@
       "efficiencyDistance": "Total distance driven so far today.",
       "efficiencyEnergy": "Total electrical energy that passed through the high-voltage battery since midnight, in watt-hours. On a BEV this equals battery charge consumed. On a PHEV it covers both grid charge and regeneration. On an HEV it reflects the energy cycled through the small hybrid battery.",
       "efficiencyCharge": "Distance driven since the last charge session.",
-      "efficiencyRatio": "Energy today divided by distance today (Wh/km). Lower is better. On a BEV or PHEV in EV mode this translates directly to electricity cost per km. On an HEV it shows how efficiently the hybrid system ran - motorway driving gives a lower figure than stop-start city traffic.",
+      "efficiencyRatio": "Energy today divided by distance today (Wh/km). Lower is better. On a BEV or PHEV in EV mode this translates directly to electricity cost per km. On an HEV it shows how efficiently the hybrid system ran - motorway driving gives a lower figure than stop-start city traffic. When no driving data is available yet, HEV and PHEV fall back to showing estimated fuel economy (km/%) derived from the car's own range computer: higher is more efficient.",
       "speed": "Current vehicle speed as reported by the gateway.",
       "activeTrip": "Distance covered in the current trip while active, or the distance of the last completed trip when parked.",
       "onlineStatus": "Whether the car is currently reachable via the SAIC cloud. Goes offline when the car is parked and the gateway stops polling.",
@@ -109,7 +109,8 @@
       "todayDistance": "Dist. today",
       "todayEnergy": "Energy today",
       "sinceCharge": "Since charge",
-      "efficiency": "Efficiency"
+      "efficiency": "Efficiency",
+      "fuelEconomy": "Fuel economy (est.)"
     },
     "hvBattery": {
       "title": "HV Battery",

--- a/frontend/src/locales/nl.json
+++ b/frontend/src/locales/nl.json
@@ -30,7 +30,7 @@
       "efficiencyDistance": "Totale afstand gereden vandaag.",
       "efficiencyEnergy": "Totale elektrische energie die sinds middernacht door de hoogspanningsaccu is gegaan, in wattuur. Op een BEV staat dit gelijk aan verbruikt accuvermogen. Op een PHEV omvat het zowel netlaadvermogen als regeneratie. Op een HEV weerspiegelt het de energie die door de kleine hybride accu is gegaan.",
       "efficiencyCharge": "Afstand gereden sinds de laatste laadsessie.",
-      "efficiencyRatio": "Energie vandaag gedeeld door afstand vandaag (Wh/km). Lager is beter. Op een BEV of PHEV in EV-modus vertaalt dit zich direct naar elektriciteitskosten per km. Op een HEV toont het hoe efficiënt het hybridesysteem werkte -- snelwegrijden geeft een lagere waarde dan stop-and-go stadsverkeer.",
+      "efficiencyRatio": "Energie vandaag gedeeld door afstand vandaag (Wh/km). Lager is beter. Op een BEV of PHEV in EV-modus vertaalt dit zich direct naar elektriciteitskosten per km. Op een HEV toont het hoe efficiënt het hybridesysteem werkte -- snelwegrijden geeft een lagere waarde dan stop-and-go stadsverkeer. Als er nog geen rijgegevens beschikbaar zijn, vallen HEV en PHEV terug op een geschat brandstofverbruik (km/%) afgeleid van de rangecalculator van de auto: hoger is zuiniger.",
       "speed": "Actuele rijsnelheid zoals gerapporteerd door de gateway.",
       "activeTrip": "Afstand afgelegd tijdens de huidige rit, of de afstand van de laatste afgesloten rit als de auto geparkeerd staat.",
       "onlineStatus": "Of de auto momenteel bereikbaar is via de SAIC-cloud. Gaat offline als de auto geparkeerd staat en de gateway stopt met polling.",
@@ -109,7 +109,8 @@
       "todayDistance": "Afst. vandaag",
       "todayEnergy": "Energie vandaag",
       "sinceCharge": "Sinds lading",
-      "efficiency": "Verbruik"
+      "efficiency": "Verbruik",
+      "fuelEconomy": "Brandstofverbruik (schatting)"
     },
     "hvBattery": {
       "title": "HV Accu",

--- a/frontend/src/views/DashboardView.vue
+++ b/frontend/src/views/DashboardView.vue
@@ -110,7 +110,13 @@ function cardHasData(id: CardId): boolean {
     case 'efficiencyCharge':
       return s.mileageSinceLastCharge !== null && !isHev.value && vehicleType.value !== 'unknown'
     case 'efficiencyRatio':
-      return s.powerUsageOfDay !== null && s.mileageOfTheDay !== null && s.mileageOfTheDay > 0
+      return (
+        (s.powerUsageOfDay !== null && s.mileageOfTheDay !== null && s.mileageOfTheDay > 0) ||
+        ((isHev.value || vehicleType.value === 'phev') &&
+          s.fuelRangeKm !== null &&
+          s.fuelLevelPercent !== null &&
+          s.fuelLevelPercent > 0)
+      )
     case 'remainingCharge':
       return s.remainingChargingTime !== null
     case 'chargingSession':
@@ -335,19 +341,6 @@ onUnmounted(() => {
       </div>
 
       <template v-else>
-        <div class="status-grid">
-          <template v-for="card in settings.cards" :key="card.id">
-            <template v-if="card.visible && cardHasData(card.id)">
-              <CardInfoWrap
-                :title="t(`settings.cards.${card.id}`)"
-                :description="t(`dashboard.cardDesc.${card.id}`)"
-              >
-                <DashboardCardContent :card-id="card.id" />
-              </CardInfoWrap>
-            </template>
-          </template>
-        </div>
-
         <CarDiagram
           v-if="settings.showTyreDiagram"
           :front-left="status.tyrePressureFrontLeft"
@@ -367,8 +360,21 @@ onUnmounted(() => {
           :fuel-level-percent="status.fuelLevelPercent"
           :charger-connected="status.chargerConnected"
           :is-charging="status.isCharging"
-          class="mt-4"
+          class="mb-4"
         />
+
+        <div class="status-grid">
+          <template v-for="card in settings.cards" :key="card.id">
+            <template v-if="card.visible && cardHasData(card.id)">
+              <CardInfoWrap
+                :title="t(`settings.cards.${card.id}`)"
+                :description="t(`dashboard.cardDesc.${card.id}`)"
+              >
+                <DashboardCardContent :card-id="card.id" />
+              </CardInfoWrap>
+            </template>
+          </template>
+        </div>
       </template>
     </template>
   </div>


### PR DESCRIPTION
## Summary

- Fixes the efficiency ratio card disappearing in display mode for HEV/PHEV when no driving has happened yet today (`mileageOfTheDay = 0`)
- Adds a fuel economy fallback metric (km/% of fuel tank) derived from the car's own range computer, shown for HEV and PHEV when no driving data is available
- The existing Wh/km metric still takes priority when driving data is present
- Fixes dashboard normal-mode layout so the car diagram renders above the card grid, matching edit-mode order
- Updated info modal descriptions in both EN and NL to explain the fuel economy fallback

## Test plan

- [ ] Verify efficiency card shows in display mode when `mileageOfTheDay = 0` but fuel data is present (HEV/PHEV)
- [ ] Verify Wh/km still shows when driving data is available
- [ ] Verify BEV is unaffected (no fuel fallback)
- [ ] Check info modal shows updated description for efficiency card
- [ ] Check Dutch locale renders correctly
- [ ] All 125 unit tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)