### PR TITLE
Make last trip card clickable, opens map with trip selected

### DIFF
--- a/frontend/src/components/DashboardCardContent.vue
+++ b/frontend/src/components/DashboardCardContent.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
+import { useRouter } from 'vue-router'
 import { useVehicleStore } from '@/stores/vehicle'
 import { useSettingsStore } from '@/stores/settings'
 import type { CardId } from '@/stores/settings'
@@ -18,6 +19,7 @@ import BatteryHeatingCard from './BatteryHeatingCard.vue'
 defineProps<{ cardId: CardId }>()
 
 const { t } = useI18n()
+const router = useRouter()
 const store = useVehicleStore()
 const settings = useSettingsStore()
 
@@ -267,6 +269,11 @@ const supportsExternalCharge = computed(
           ? 'info'
           : undefined
       "
+      :clickable="
+        !(status.currentJourneyDistance !== null && status.currentJourneyDistance > 0) &&
+        store.lastTrip !== null
+      "
+      @click="router.push({ name: 'map', query: { selectLatest: '1' } })"
     />
 
     <!-- remainingCharge -->

--- a/frontend/src/views/MapView.vue
+++ b/frontend/src/views/MapView.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { onMounted, onUnmounted, computed, ref, shallowRef, watch, nextTick } from 'vue'
 import { useI18n } from 'vue-i18n'
+import { useRoute, useRouter } from 'vue-router'
 import { useVehicleStore } from '@/stores/vehicle'
 import { useSettingsStore } from '@/stores/settings'
 import { LMap, LTileLayer, LMarker, LPopup } from '@vue-leaflet/vue-leaflet'
@@ -18,6 +19,8 @@ const L = ((LModule as unknown as { default?: typeof LModule }).default ??
   LModule) as typeof LModule
 
 const { t } = useI18n()
+const route = useRoute()
+const router = useRouter()
 const store = useVehicleStore()
 const settingsStore = useSettingsStore()
 
@@ -26,6 +29,7 @@ const status = computed(() => store.currentStatus)
 const displayLocale = computed(() => (settingsStore.locale === 'nl' ? 'nl-NL' : 'en-US'))
 const selectedTripIndex = ref<number | null>(null)
 const heatmapEnabled = ref(true)
+let shouldSelectLatest = route.query.selectLatest === '1'
 
 const dateRangeDays = computed({
   get: () => settingsStore.filterDays,
@@ -232,7 +236,12 @@ watch(allPoints, async (pts) => {
   await nextTick()
   buildHeatLayer()
   buildRouteLines()
-  fitAll()
+  if (shouldSelectLatest) {
+    shouldSelectLatest = false
+    selectTrip(store.trips.length - 1)
+  } else {
+    fitAll()
+  }
 })
 
 // Trip selection drives map display and popover position.
@@ -295,6 +304,9 @@ function selectTrip(realIdx: number) {
 }
 
 onMounted(async () => {
+  if (route.query.selectLatest) {
+    router.replace({ name: 'map' })
+  }
   await store.fetchVehicles()
   if (vin.value) {
     await Promise.all([


### PR DESCRIPTION
## Summary

- The last trip card on the dashboard is now clickable when showing a past trip (not an active journey)
- Clicking navigates to the map view with the most recent trip automatically selected and highlighted
- The `selectLatest` query param is cleaned from the URL immediately after the map mounts

## Test plan

- [ ] With a vehicle that has trip history, confirm the last trip card shows a chevron and cursor pointer
- [ ] Click the card and verify the map opens with the newest trip selected and its route highlighted
- [ ] Confirm the URL does not retain `?selectLatest=1` after navigation
- [ ] Confirm the card is NOT clickable during an active journey (variant `info`)
- [ ] Confirm the card is NOT clickable when there is no trip history

🤖 Generated with [Claude Code](https://claude.com/claude-code)