### PR TITLE
Remove redundant standalone fuel chart

### DIFF
--- a/frontend/src/stores/settings.ts
+++ b/frontend/src/stores/settings.ts
@@ -32,12 +32,7 @@ export type StatsInsightId =
   | 'parkingLocations'
   | 'electricShare'
 
-export type StatsChartId =
-  | 'fuelChart'
-  | 'evChart'
-  | 'tyreChart'
-  | 'hybridSocChart'
-  | 'dailyKwhChart'
+export type StatsChartId = 'evChart' | 'tyreChart' | 'hybridSocChart' | 'dailyKwhChart'
 
 export interface StatsItemConfig<T extends string> {
   id: T
@@ -55,7 +50,6 @@ const ALL_STATS_INSIGHT_IDS: StatsInsightId[] = [
 ]
 
 const ALL_STATS_CHART_IDS: StatsChartId[] = [
-  'fuelChart',
   'evChart',
   'tyreChart',
   'hybridSocChart',

--- a/frontend/src/views/StatisticsView.vue
+++ b/frontend/src/views/StatisticsView.vue
@@ -95,7 +95,6 @@ const effectiveVehicleType = computed(() => {
   return store.detectedVehicleType
 })
 
-const hasFuel = computed(() => effectiveVehicleType.value !== 'bev')
 const hasLargeEv = computed(
   () =>
     effectiveVehicleType.value === 'phev' ||
@@ -120,7 +119,6 @@ const INSIGHT_ICONS: Record<StatsInsightId, string> = {
 }
 
 const CHART_ICONS: Record<StatsChartId, string> = {
-  fuelChart: 'gas-pump',
   evChart: 'bolt',
   tyreChart: 'gauge',
   hybridSocChart: 'wave-square',
@@ -365,23 +363,6 @@ const insightDefMap = computed(() => new Map(insightDefs.value.map((d) => [d.id,
 
 // ── Chart data ────────────────────────────────────────────────
 
-const fuelChartData = computed(() => ({
-  labels: chartLabels(),
-  datasets: [
-    {
-      label: `${t('vehicle.fuel')} (%)`,
-      data: groupedHistory.value.map((d) => avg(d.snapshots.map((s) => s.fuelLevelPercent))),
-      borderColor: '#3b82f6',
-      backgroundColor: 'rgba(59,130,246,0.1)',
-      fill: true,
-      tension: 0.3,
-      spanGaps: true,
-      pointRadius: 2,
-      pointHoverRadius: 4,
-    },
-  ],
-}))
-
 const evChartData = computed(() => ({
   labels: chartLabels(),
   datasets: [
@@ -563,16 +544,6 @@ const kwhOptions = {
 // ── Chart definitions ─────────────────────────────────────────
 
 const chartDefs = computed(() => [
-  {
-    id: 'fuelChart' as StatsChartId,
-    icon: CHART_ICONS.fuelChart,
-    title: t('vehicle.fuel'),
-    vehicleApplicable: hasFuel.value,
-    applicable: hasFuel.value && store.history.length > 0,
-    isBar: false,
-    data: fuelChartData.value,
-    options: percentOptions,
-  },
   {
     id: 'evChart' as StatsChartId,
     icon: CHART_ICONS.evChart,


### PR DESCRIPTION
## Summary

- The standalone Fuel % line chart duplicated data already shown in the "EV & Fuel Levels" hybrid chart
- Removed `fuelChart` from `StatsChartId` type, `ALL_STATS_CHART_IDS`, icon map, `hasFuel` computed, `fuelChartData` computed, and `chartDefs`
- No behaviour change for non-hybrid vehicles -- the hybrid chart remains

## Test plan

- [ ] Open Statistics view on a fuel/hybrid vehicle -- only the EV & Fuel Levels chart shows fuel data, no duplicate fuel chart
- [ ] Confirm edit-mode drag list no longer includes a fuel chart slot
- [ ] Verify type-check passes (`pnpm exec vue-tsc --noEmit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)