### PR TITLE
Fix skeleton loader order to match normal dashboard layout

### DIFF
--- a/frontend/src/views/DashboardView.vue
+++ b/frontend/src/views/DashboardView.vue
@@ -325,10 +325,10 @@ onUnmounted(() => {
     <!-- Normal mode -->
     <template v-else>
       <template v-if="store.loading && !status">
+        <SkeletonCarDiagram v-if="settings.showTyreDiagram" class="mb-4" />
         <div class="status-grid">
           <SkeletonCard v-for="card in skeletonCards" :key="card.id" :icon="CARD_ICONS[card.id]" />
         </div>
-        <SkeletonCarDiagram v-if="settings.showTyreDiagram" class="mt-4" />
       </template>
 
       <div v-else-if="store.error && !status" class="error-state">


### PR DESCRIPTION
## Summary

- `SkeletonCarDiagram` was rendered below the skeleton cards, but in normal mode the car overview appears above the cards grid
- Swapped the order so the skeleton loading state matches the real layout
- Changed spacing class from `mt-4` to `mb-4` to keep the gap in the right place

## Test plan

- [ ] Load the dashboard with a slow network / empty cache and confirm the skeleton car diagram appears at the top, above the skeleton cards

🤖 Generated with [Claude Code](https://claude.com/claude-code)