### PR TITLE
Fix SkeletonCarDiagram height to match CarDiagram

### DIFF
--- a/frontend/src/components/SkeletonCarDiagram.vue
+++ b/frontend/src/components/SkeletonCarDiagram.vue
@@ -4,19 +4,35 @@
     <div class="tyre-diagram__wrap">
       <div class="tyre-skel__car skeleton"></div>
     </div>
+    <div class="tyre-skel__legend">
+      <div class="skeleton skeleton--text tyre-skel__legend-item"></div>
+      <div class="skeleton skeleton--text tyre-skel__legend-item"></div>
+      <div class="skeleton skeleton--text tyre-skel__legend-item"></div>
+    </div>
   </div>
 </template>
 
 <style scoped>
 .tyre-skel__title {
   height: 0.85rem;
-  margin-bottom: 0.75rem;
+  margin-bottom: 1rem;
   max-width: 5rem;
 }
 .tyre-skel__car {
-  width: 200px;
+  width: 220px;
   max-width: 100%;
   aspect-ratio: 340 / 480;
   border-radius: var(--radius);
+}
+.tyre-skel__legend {
+  display: flex;
+  gap: 1rem;
+  margin-top: 1rem;
+  flex-wrap: wrap;
+}
+.tyre-skel__legend-item {
+  height: 0.9rem;
+  width: 5rem;
+  border-radius: 4px;
 }
 </style>


### PR DESCRIPTION
## Summary

- Car skeleton width changed from 200px to 220px to match `.tyre-car-wrap` in the real diagram
- Title margin-bottom corrected from 0.75rem to 1rem
- Added a skeleton legend row to mirror the tyre pressure legend that renders below the real `CarDiagram`

## Test plan

- [ ] On a slow network / empty cache, confirm the skeleton car diagram height matches the real car overview when it loads in

🤖 Generated with [Claude Code](https://claude.com/claude-code)