### PR TITLE
Hide car position marker while a trip is selected

### DIFF
--- a/frontend/src/views/MapView.vue
+++ b/frontend/src/views/MapView.vue
@@ -228,6 +228,7 @@ function flyToStatus() {
   const map = mapInstance.value
   const s = status.value
   if (map && s?.latitude != null && s?.longitude != null) {
+    selectedTripIndex.value = null
     map.setView([s.latitude, s.longitude], 14, { animate: false })
   }
 }
@@ -468,9 +469,11 @@ onUnmounted(() => {
             attribution="© OpenStreetMap contributors"
           />
 
-          <!-- Current position marker -->
+          <!-- Current position marker: hidden while a trip is selected -->
           <LMarker
-            v-if="status?.latitude != null && status?.longitude != null"
+            v-if="
+              status?.latitude != null && status?.longitude != null && selectedTripIndex === null
+            "
             :lat-lng="[status.latitude!, status.longitude!]"
           >
             <LPopup>{{ store.vehicles[0]?.model ?? store.vehicles[0]?.vin }}</LPopup>


### PR DESCRIPTION
## Summary

- The current-location marker is now hidden whenever a trip is selected, keeping the map focused on the trip route
- Clicking **Find my car** deselects the active trip before flying to the car's position, so the marker reappears naturally
- When no trip is selected the marker behaves exactly as before

## Test plan

- [ ] Select a trip -- car position marker disappears
- [ ] Deselect the trip -- car position marker reappears
- [ ] With a trip selected, click **Find my car** -- trip deselects, map flies to car, marker is visible
- [ ] With no trips loaded, car marker still shows as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)