### PR TITLE
Improve README: features section, MG/SAIC clarification, remove stale scaffold

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,20 @@
 # GarageStack
 
-GarageStack is a free, open-source vehicle monitoring dashboard for MG / SAIC cars. It connects to the SAIC iSmart API (the same backend as the official MG iSmart app) and presents your car's live telemetry in a clean, self-hosted web app. The project is designed to work across HEV, PHEV, and BEV variants of the MG lineup - cards that are not relevant to your vehicle type are automatically hidden or adapted.
+GarageStack is a free, open-source vehicle monitoring dashboard for **modern MG cars** -- vehicles manufactured by SAIC Motor (China) such as the MG4, MG5, ZS EV, HS PHEV, and similar models. It connects to the SAIC iSmart API (the same backend as the official MG iSmart app) and presents your car's live telemetry in a clean, self-hosted web app. The project is designed to work across HEV, PHEV, and BEV variants of the MG lineup - cards that are not relevant to your vehicle type are automatically hidden or adapted.
 
-Features include a live dashboard, trip history with map and heatmap visualisation, energy statistics, and remote commands (climate, lock/unlock, find-my-car). The app is a PWA, so it can be installed on your phone or desktop and receives push notifications.
+> **Note:** GarageStack only works with the current MG brand owned by SAIC Motor. It is **not** compatible with classic British-built MG cars (MGB, Midget, MGF, etc.) produced before SAIC's acquisition of the brand. If your car does not use the MG iSmart app, GarageStack will not work with it.
+
+## Features
+
+- **Live dashboard** -- Real-time vehicle telemetry displayed as configurable cards. Cards are automatically shown or hidden based on your vehicle type (HEV, PHEV, BEV) and can be reordered or toggled individually in the dashboard's edit mode.
+- **Trip history** -- Browse past journeys on an interactive map with route playback and heatmap visualisation to identify frequently driven roads.
+- **Energy statistics** -- Track daily energy consumption, efficiency (Wh/km), fuel use, and electric share over time.
+- **Remote commands** -- Trigger climate pre-conditioning, lock or unlock the car, and activate the horn and lights remotely from the dashboard.
+- **Push notifications** -- Browser and in-app alerts for key events: engine started, low tyre pressure, low EV battery, car left unlocked, and doors or windows left open.
+- **Homepage widget** -- A read-only API endpoint for the [gethomepage.dev](https://gethomepage.dev) Custom API widget, exposing key vehicle stats at a glance.
+- **Progressive Web App (PWA)** -- Installable on mobile or desktop for a native app-like experience, complete with a home screen icon and push notification support.
+- **Multi-language support** -- Interface available in English and Dutch, with locale resolved from query string, cookie, or browser preference.
+- **Self-hosted** -- Runs entirely on your own infrastructure via Docker (all-in-one container or Docker Compose). No cloud account or subscription required beyond the SAIC iSmart API.
 
 ### Dashboard cards
 
@@ -296,43 +308,3 @@ Add them under **Settings > Secrets and variables > Actions** in your fork. A fr
 ---
 
 > **Development note:** This project was built with AI-assisted development (Claude Code). All code was reviewed, directed, and validated by a human developer throughout - AI acted as a coding assistant, not an autonomous agent.
-
----
-
-## Type Support for `.vue` Imports in TS
-
-TypeScript cannot handle type information for `.vue` imports by default, so we replace the `tsc` CLI with `vue-tsc` for type checking. In editors, we need [Volar](https://marketplace.visualstudio.com/items?itemName=Vue.volar) to make the TypeScript language service aware of `.vue` types.
-
-## Customize configuration
-
-See [Vite Configuration Reference](https://vite.dev/config/).
-
-## Project Setup
-
-```sh
-pnpm install
-```
-
-### Compile and Hot-Reload for Development
-
-```sh
-pnpm run dev
-```
-
-### Type-Check, Compile and Minify for Production
-
-```sh
-pnpm run build
-```
-
-### Run Unit Tests with [Vitest](https://vitest.dev/)
-
-```sh
-pnpm run test:unit
-```
-
-### Lint with [ESLint](https://eslint.org/)
-
-```sh
-pnpm run lint
-```


### PR DESCRIPTION
## Summary

- Adds a `## Features` section after the introduction, listing all nine major features with brief descriptions (live dashboard, trip history, energy statistics, remote commands, push notifications, Homepage widget, PWA, i18n, self-hosting)
- Updates the opening paragraph and adds a callout block making clear the project targets modern MG cars (SAIC Motor), not classic British MG vehicles (MGB, Midget, MGF, etc.)
- Removes leftover Vue CLI scaffold boilerplate (`## Type Support for .vue Imports in TS`, `## Customize configuration`, `## Project Setup`) that was never cleaned up from initial project scaffolding

## Test plan

- [ ] Verify the README renders correctly on GitHub
- [ ] Confirm the features section reads accurately against actual app functionality
- [ ] Confirm the MG/SAIC callout is visible and clearly worded

🤖 Generated with [Claude Code](https://claude.com/claude-code)