### PR TITLE
Fix security review findings (cookie, CORS, push dedup, SQL injection, SW URL)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -35,20 +35,26 @@ MQTT_EXTERNAL_PORT=1883
 # Host port for the frontend (nginx). Use 8080 by default to avoid clashing
 # with existing reverse proxies/web servers that already bind port 80.
 FRONTEND_PORT=8080
-# Host port for the API (only needed if you access the API directly;
-# the frontend proxies /api requests internally and does not need this open).
+# Host port for the API. The API is bound to 127.0.0.1 by default, so it is
+# reachable only from the local machine. The frontend proxies /api internally
+# and does not require direct host access. Remove the 127.0.0.1: prefix in
+# docker-compose.yml only if you intentionally want the API reachable from LAN.
 API_PORT=5000
 
 # ── CORS ────────────────────────────────────────────────────────────────────
-# The URL your browser uses to reach the frontend - must match exactly.
-# Add more origins by setting Cors__Origins__1 etc. directly in docker-compose.
-CORS_ORIGIN=http://localhost
+# The URL your browser uses to reach the frontend - must match exactly including
+# the port. Add more origins by setting Cors__Origins__1 etc. in docker-compose.
+CORS_ORIGIN=http://localhost:8080
 
 # ── API Authentication ───────────────────────────────────────────────────────
 # Required for issuing login JWT tokens. Use at least 32 random bytes.
 # Generate with OpenSSL: openssl rand -base64 32
 # PowerShell alternative: [Convert]::ToBase64String((1..32 | ForEach-Object { Get-Random -Minimum 0 -Maximum 256 }))
 JWT_SECRET=
+
+# Set to false only for trusted LAN HTTP installs (e.g. http://192.168.x.x:8080).
+# Leave unset or true when the app is served over HTTPS or behind a TLS proxy.
+# AUTH_COOKIE_SECURE=false
 
 # ── Logging ──────────────────────────────────────────────────────────────────
 # Set to true to enable Debug-level logs (api + worker). Useful when diagnosing

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -104,7 +104,7 @@ services:
     environment:
       ASPNETCORE_ENVIRONMENT: "Production"
       ConnectionStrings__DefaultConnection: "Host=${POSTGRES_HOST:-postgres};Port=${POSTGRES_PORT:-5432};Database=${POSTGRES_DB:-garagestack};Username=${POSTGRES_USER:-garagestack};Password=${POSTGRES_PASSWORD}"
-      Cors__Origins__0: "${CORS_ORIGIN:-http://localhost}"
+      Cors__Origins__0: "${CORS_ORIGIN:-http://localhost:8080}"
       Jwt__Secret: "${JWT_SECRET}"
       SAIC_USER: "${SAIC_USER}"
       SAIC_PASSWORD: "${SAIC_PASSWORD}"
@@ -118,8 +118,9 @@ services:
       Vapid__PrivateKey: "${VAPID_PRIVATE_KEY}"
       Vapid__Subject: "mailto:${SAIC_USER}"
       Widget__ApiKey: "${WIDGET_API_KEY:-}"
+      Auth__CookieSecure: "${AUTH_COOKIE_SECURE:-true}"
     ports:
-      - "${API_PORT:-5000}:8080"
+      - "127.0.0.1:${API_PORT:-5000}:8080"
     volumes:
       - api_logs:/app/logs
       - api_dataprotection:/root/.aspnet/DataProtection-Keys

--- a/docker/all-in-one/entrypoint.sh
+++ b/docker/all-in-one/entrypoint.sh
@@ -62,10 +62,13 @@ if [ ! -f "$PGDATA/PG_VERSION" ]; then
     gosu postgres /usr/lib/postgresql/18/bin/pg_ctl -D "$PGDATA" \
         -l /data/logs/postgres-init.log start -w
 
-    gosu postgres psql -v ON_ERROR_STOP=1 <<-EOSQL
-        CREATE USER "${POSTGRES_USER}" WITH PASSWORD '${POSTGRES_PASSWORD}';
-        CREATE DATABASE "${POSTGRES_DB}" OWNER "${POSTGRES_USER}";
-        GRANT ALL PRIVILEGES ON DATABASE "${POSTGRES_DB}" TO "${POSTGRES_USER}";
+    gosu postgres psql -v ON_ERROR_STOP=1 \
+        -v pguser="${POSTGRES_USER}" \
+        -v pgpassword="${POSTGRES_PASSWORD}" \
+        -v pgdb="${POSTGRES_DB}" <<-'EOSQL'
+        CREATE USER :"pguser" WITH PASSWORD :'pgpassword';
+        CREATE DATABASE :"pgdb" OWNER :"pguser";
+        GRANT ALL PRIVILEGES ON DATABASE :"pgdb" TO :"pguser";
 EOSQL
 
     gosu postgres /usr/lib/postgresql/18/bin/pg_ctl -D "$PGDATA" stop -w

--- a/frontend/src/sw.ts
+++ b/frontend/src/sw.ts
@@ -45,7 +45,15 @@ self.addEventListener('push', (event) => {
 self.addEventListener('notificationclick', (event) => {
   event.notification.close()
 
-  const targetUrl = (event.notification.data as { url?: string })?.url ?? '/'
+  const rawUrl = (event.notification.data as { url?: string })?.url ?? '/'
+  const targetUrl = (() => {
+    try {
+      const parsed = new URL(rawUrl, self.location.origin)
+      return parsed.origin === self.location.origin ? parsed.href : '/'
+    } catch {
+      return rawUrl.startsWith('/') ? rawUrl : '/'
+    }
+  })()
 
   event.waitUntil(
     self.clients.matchAll({ type: 'window', includeUncontrolled: true }).then((clientList) => {

--- a/src/GarageStack.Api/Endpoints/AuthEndpoints.cs
+++ b/src/GarageStack.Api/Endpoints/AuthEndpoints.cs
@@ -103,10 +103,13 @@ public static class AuthEndpoints
 
             var tokenString = new JwtSecurityTokenHandler().WriteToken(token);
 
+            var cookieSecure = config.GetValue<bool?>("Auth:CookieSecure")
+                ?? (!env.IsDevelopment() || httpContext.Request.IsHttps);
+
             httpContext.Response.Cookies.Append("garagestack-auth", tokenString, new CookieOptions
             {
                 HttpOnly = true,
-                Secure = !env.IsDevelopment() || httpContext.Request.IsHttps,
+                Secure = cookieSecure,
                 SameSite = SameSiteMode.Strict,
                 Expires = expires,
                 Path = "/",

--- a/src/GarageStack.Core/Interfaces/IPushSender.cs
+++ b/src/GarageStack.Core/Interfaces/IPushSender.cs
@@ -2,5 +2,5 @@ namespace GarageStack.Core.Interfaces;
 
 public interface IPushSender
 {
-    Task SendToAllAsync(string title, string body, CancellationToken ct = default, string? category = null);
+    Task SendToAllAsync(string title, string body, CancellationToken ct = default, string? category = null, int? vehicleId = null);
 }

--- a/src/GarageStack.Core/Models/AppNotification.cs
+++ b/src/GarageStack.Core/Models/AppNotification.cs
@@ -9,4 +9,5 @@ public class AppNotification
     public bool IsArchived { get; set; }
     public bool IsDeleted { get; set; }
     public string? Category { get; set; }
+    public int? VehicleId { get; set; }
 }

--- a/src/GarageStack.Data/Demo/DemoPushSender.cs
+++ b/src/GarageStack.Data/Demo/DemoPushSender.cs
@@ -9,7 +9,7 @@ public sealed class DemoPushSender : IPushSender
 
     public DemoPushSender(ILogger<DemoPushSender> logger) => _logger = logger;
 
-    public Task SendToAllAsync(string title, string body, CancellationToken ct = default, string? category = null)
+    public Task SendToAllAsync(string title, string body, CancellationToken ct = default, string? category = null, int? vehicleId = null)
     {
         _logger.LogDebug("Demo mode: suppressed push notification '{Title}' (category={Category})", title, category);
         return Task.CompletedTask;

--- a/src/GarageStack.Data/Migrations/20260608202624_AddVehicleIdToAppNotification.Designer.cs
+++ b/src/GarageStack.Data/Migrations/20260608202624_AddVehicleIdToAppNotification.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using GarageStack.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace GarageStack.Data.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260608202624_AddVehicleIdToAppNotification")]
+    partial class AddVehicleIdToAppNotification
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/GarageStack.Data/Migrations/20260608202624_AddVehicleIdToAppNotification.cs
+++ b/src/GarageStack.Data/Migrations/20260608202624_AddVehicleIdToAppNotification.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace GarageStack.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddVehicleIdToAppNotification : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "VehicleId",
+                table: "AppNotifications",
+                type: "integer",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "VehicleId",
+                table: "AppNotifications");
+        }
+    }
+}

--- a/src/GarageStack.Tests/MqttConsumerServiceTests.cs
+++ b/src/GarageStack.Tests/MqttConsumerServiceTests.cs
@@ -18,7 +18,7 @@ file sealed class FakePushSender : IPushSender
 {
     public List<(string Title, string Body)> Sent { get; } = [];
 
-    public Task SendToAllAsync(string title, string body, CancellationToken ct = default, string? category = null)
+    public Task SendToAllAsync(string title, string body, CancellationToken ct = default, string? category = null, int? vehicleId = null)
     {
         Sent.Add((title, body));
         return Task.CompletedTask;

--- a/src/GarageStack.Tests/PushNotificationCheckServiceTests.cs
+++ b/src/GarageStack.Tests/PushNotificationCheckServiceTests.cs
@@ -8,7 +8,7 @@ namespace GarageStack.Tests;
 
 file sealed class FakeNotificationPushSender : IPushSender
 {
-    public Task SendToAllAsync(string title, string body, CancellationToken ct = default, string? category = null)
+    public Task SendToAllAsync(string title, string body, CancellationToken ct = default, string? category = null, int? vehicleId = null)
         => Task.CompletedTask;
 }
 

--- a/src/GarageStack.Worker/Services/PushNotificationCheckService.cs
+++ b/src/GarageStack.Worker/Services/PushNotificationCheckService.cs
@@ -82,15 +82,16 @@ public class PushNotificationCheckService(
                     continue;
 
                 // Cross-service dedup: check DB so MQTT-emitted notifications suppress repeated checker alerts.
+                // VehicleId is included so one vehicle's alert cannot suppress another vehicle's same-category alert.
                 var cutoff = DateTime.UtcNow - _cooldown;
-                if (await db.AppNotifications.AnyAsync(n => n.Category == key && n.CreatedAt > cutoff, ct))
+                if (await db.AppNotifications.AnyAsync(n => n.Category == key && n.VehicleId == vehicle.Id && n.CreatedAt > cutoff, ct))
                 {
                     _lastNotified[notifKey] = DateTime.UtcNow;
                     continue;
                 }
 
                 _lastNotified[notifKey] = DateTime.UtcNow;
-                await pushSender.SendToAllAsync(title, body, ct, key);
+                await pushSender.SendToAllAsync(title, body, ct, key, vehicle.Id);
                 logger.LogInformation("Push sent: {Key} - {Title}", notifKey, title);
             }
         }

--- a/src/GarageStack.Worker/Services/PushSenderService.cs
+++ b/src/GarageStack.Worker/Services/PushSenderService.cs
@@ -45,7 +45,7 @@ public sealed class PushSenderService : IPushSender, IDisposable
 
     public bool IsConfigured => _pushClient is not null;
 
-    public async Task SendToAllAsync(string title, string body, CancellationToken ct = default, string? category = null)
+    public async Task SendToAllAsync(string title, string body, CancellationToken ct = default, string? category = null, int? vehicleId = null)
     {
         // Always persist so the in-app bell works regardless of push configuration
         try
@@ -58,6 +58,7 @@ public sealed class PushSenderService : IPushSender, IDisposable
                 Body = body,
                 CreatedAt = DateTime.UtcNow,
                 Category = category,
+                VehicleId = vehicleId,
             });
             await recordDb.SaveChangesAsync(ct);
         }


### PR DESCRIPTION
## Summary

Addresses all findings from the ChatGPT security review:

- **High: Cookie Secure flag blocks HTTP deployments** — `Auth:CookieSecure` is now a configurable setting (env var `AUTH_COOKIE_SECURE`). Defaults to the existing auto-detect behaviour; set to `false` for trusted LAN HTTP installs. Documented in `.env.example`.

- **High: CORS_ORIGIN default mismatch** — Changed default from `http://localhost` to `http://localhost:8080` to match `FRONTEND_PORT=8080`, preventing an out-of-the-box 403 on login.

- **Medium: Push notification dedup misses vehicle identity** — Added nullable `VehicleId` column to `AppNotification` (EF migration included). `IPushSender.SendToAllAsync` gains an optional `vehicleId` parameter. The DB cross-service dedup query now filters on both `Category` and `VehicleId`, preventing one vehicle's alert from suppressing another vehicle's same-category alert.

- **Medium: API port exposed on host network** — API port in `docker-compose.yml` bound to `127.0.0.1`; nginx already proxies `/api` internally so no user-facing change.

- **Medium: PostgreSQL password SQL injection in entrypoint.sh** — Bootstrap SQL now uses psql variable binding (`:'pgpassword'`) instead of shell interpolation, correctly handling passwords containing single quotes.

- **Low: Notification click URL not validated to same-origin** — Service worker `notificationclick` handler normalises the payload URL to same-origin before navigating, falling back to `/`.

## Test plan

- [x] All 180 backend unit tests pass (`dotnet test`)
- [x] Frontend lint and type-check clean (`pnpm run lint && pnpm run type-check`)
- [ ] Set `AUTH_COOKIE_SECURE=false` + plain HTTP stack — login cookie arrives without `Secure` attribute
- [ ] Default `.env` — frontend at `http://localhost:8080` can POST `/api/auth/login` without 403
- [ ] Two-vehicle setup — low-battery alert on vehicle A does not suppress same alert on vehicle B
- [ ] All-in-one with `POSTGRES_PASSWORD` containing a single quote — first boot succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)