### PR TITLE
Hide redundant EV Battery card for HEV

### DIFF
--- a/frontend/src/stores/settings.ts
+++ b/frontend/src/stores/settings.ts
@@ -165,7 +165,7 @@ export function defaultCards(type: VehicleType | 'unknown' = 'unknown'): CardCon
   const all: CardConfig[] = [
     { id: 'fuelLevel', visible: type !== 'bev' },
     { id: 'fuelRange', visible: type !== 'bev' },
-    { id: 'evBattery', visible: true },
+    { id: 'evBattery', visible: type !== 'hev' },
     { id: 'charging', visible: type === 'phev' || type === 'bev' },
     { id: 'odometer', visible: true },
     { id: 'battery12v', visible: true },


### PR DESCRIPTION
## Summary

- For HEV, the **HV Battery** card already displays SoC as a percentage (derived from kWh / total capacity), plus voltage, current, and power in a detail modal
- The **EV Battery** card shows the same SoC value as a plain card with no additional detail, making it a duplicate for HEV owners
- `evBattery` is now hidden by default when the vehicle type is `hev` — one-line change in `defaultCards()`

> Existing users can reset their layout via dashboard edit mode > **Reset Layout** to pick up the new default.

## Test plan

- [ ] Confirm EV Battery card is hidden by default for HEV vehicle type
- [ ] Confirm EV Battery card is still visible by default for BEV, PHEV, and unknown types
- [ ] Confirm all 125 unit tests pass (`pnpm run test:unit`)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)