### PR TITLE
Add speed slider to Demo Controls

### DIFF
--- a/frontend/src/components/DemoControlPanel.vue
+++ b/frontend/src/components/DemoControlPanel.vue
@@ -13,6 +13,7 @@ const vin = computed(() => vehicleStore.vehicles[0]?.vin ?? null)
 const status = computed(() => vehicleStore.currentStatus)
 
 const socValue = ref<number>(78)
+const speedValue = ref<number>(0)
 
 async function sendOverride(override: Record<string, boolean | number | null>) {
   if (!vin.value) return
@@ -26,6 +27,10 @@ async function toggle(field: string, current: boolean | null | undefined) {
 
 async function applySoc() {
   await sendOverride({ evSocPercent: socValue.value })
+}
+
+async function applySpeed() {
+  await sendOverride({ speed: speedValue.value })
 }
 
 async function applyTemperature(field: string, value: string) {
@@ -230,6 +235,15 @@ async function setLights(mode: 'off' | 'side' | 'dipped' | 'main') {
           <input v-model.number="socValue" type="range" min="10" max="100" step="1" />
           <span>{{ socValue }}%</span>
           <button class="demo-toggle-btn" @click="applySoc">OK</button>
+        </div>
+      </div>
+
+      <div class="demo-panel-section">
+        <div class="demo-panel-section-label">{{ t('demo.speed') }}</div>
+        <div class="demo-panel-range">
+          <input v-model.number="speedValue" type="range" min="0" max="200" step="1" />
+          <span>{{ speedValue }} km/h</span>
+          <button class="demo-toggle-btn" @click="applySpeed">OK</button>
         </div>
       </div>
 

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -338,6 +338,7 @@
     "chargerConnected": "Connected",
     "isCharging": "Charging",
     "interior": "Interior",
-    "exterior": "Exterior"
+    "exterior": "Exterior",
+    "speed": "Speed"
   }
 }

--- a/frontend/src/locales/nl.json
+++ b/frontend/src/locales/nl.json
@@ -338,6 +338,7 @@
     "chargerConnected": "Verbonden",
     "isCharging": "Laden",
     "interior": "Interieur",
-    "exterior": "Exterieur"
+    "exterior": "Exterieur",
+    "speed": "Snelheid"
   }
 }

--- a/src/GarageStack.Core/Models/DemoStatusOverrideDto.cs
+++ b/src/GarageStack.Core/Models/DemoStatusOverrideDto.cs
@@ -21,5 +21,6 @@ public record DemoStatusOverrideDto(
     bool? LightsSide,
     double? EvSocPercent,
     double? InteriorTemperature,
-    double? ExteriorTemperature
+    double? ExteriorTemperature,
+    double? Speed
 );

--- a/src/GarageStack.Data/Demo/DemoTelemetryRepository.cs
+++ b/src/GarageStack.Data/Demo/DemoTelemetryRepository.cs
@@ -71,6 +71,7 @@ public sealed class DemoTelemetryRepository : ITelemetryRepository
             }
             if (dto.InteriorTemperature.HasValue) _current.InteriorTemperature = dto.InteriorTemperature;
             if (dto.ExteriorTemperature.HasValue) _current.ExteriorTemperature = dto.ExteriorTemperature;
+            if (dto.Speed.HasValue) _current.Speed = dto.Speed;
         }
     }
 


### PR DESCRIPTION
## Summary

- Adds a 0-200 km/h range slider to the Demo Controls panel, matching the existing SOC slider pattern
- Wires `Speed` through `DemoStatusOverrideDto` and `DemoTelemetryRepository.ApplyOverride` so it updates the live demo snapshot on OK
- Adds `demo.speed` i18n key for EN ("Speed") and NL ("Snelheid")

## Test plan

- [ ] Open demo mode, expand Demo Controls panel
- [ ] Drag the Speed slider and press OK -- confirm the speed card on the dashboard updates
- [ ] Verify slider resets to 0 on page reload (default snapshot value)
- [ ] Check both EN and NL locales render the section label correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)