### PR TITLE
Add speed-reactive 3-lane road animation to CarDiagram

### DIFF
--- a/frontend/src/assets/main.css
+++ b/frontend/src/assets/main.css
@@ -616,6 +616,47 @@ body,
 
 /* ── Tyre diagram ─────────────────────────────────────────── */
 
+/* ── Road driving animation ───────────────────────────── */
+
+.road-surface {
+  fill: #2a2a2a;
+  opacity: 0.5;
+}
+
+[data-theme='light'] .road-surface {
+  fill: #a0a0a0;
+  opacity: 0.35;
+}
+
+.road-edge {
+  stroke: rgba(255, 255, 255, 0.35);
+  stroke-width: 1.5;
+}
+
+[data-theme='light'] .road-edge {
+  stroke: rgba(255, 255, 255, 0.7);
+}
+
+.road-center-dash {
+  stroke: rgba(255, 255, 255, 0.6);
+  stroke-width: 2.5;
+  stroke-dasharray: 30 15;
+  animation: road-scroll 1s linear infinite;
+}
+
+[data-theme='light'] .road-center-dash {
+  stroke: rgba(255, 255, 255, 0.85);
+}
+
+@keyframes road-scroll {
+  from {
+    stroke-dashoffset: 0;
+  }
+  to {
+    stroke-dashoffset: -45;
+  }
+}
+
 .tyre-diagram {
   background: var(--color-surface);
   border: 1px solid var(--color-border);
@@ -641,11 +682,11 @@ body,
   justify-content: center;
 }
 
-/* SVG viewBox is 340×480; keep it narrow enough to fit on iPhone SE (375px) */
+/* SVG viewBox is 420×480 (widened for 3-lane road); max-width keeps it on small screens */
 .tyre-car-wrap {
   position: relative;
   display: inline-block;
-  width: 220px;
+  width: 300px;
   max-width: 100%;
 }
 
@@ -704,8 +745,9 @@ body,
 /* ── Pressure label positioning ──────────────────────────── */
 /*
   Labels float at the outer endpoints of the indicator lines.
-  SVG viewBox 340×480; line ends at FL(72,68) FR(268,68) RL(72,404) RR(268,404).
-  As % of container: x=72/340=21.2% x=268/340=78.8% y=68/480=14.2% y=404/480=84.2%
+  SVG viewBox -40 0 420 480; line ends at FL(72,131) FR(268,131) RL(72,341) RR(268,341).
+  CSS % = (svg_x + 40) / 420: x=72→26.7%  x=268→73.3%
+  y unchanged: 131/480=27.3%  341/480=71%
 */
 
 .tyre-labels {
@@ -727,22 +769,22 @@ body,
 
 .tyre-label--fl {
   top: 27.3%;
-  left: 21.2%;
+  left: 26.7%;
   transform: translate(-100%, -50%);
 }
 .tyre-label--fr {
   top: 27.3%;
-  left: 78.8%;
+  left: 73.3%;
   transform: translate(0%, -50%);
 }
 .tyre-label--rl {
   top: 71%;
-  left: 21.2%;
+  left: 26.7%;
   transform: translate(-100%, -50%);
 }
 .tyre-label--rr {
   top: 71%;
-  left: 78.8%;
+  left: 73.3%;
   transform: translate(0%, -50%);
 }
 
@@ -947,10 +989,10 @@ body,
 /* ── Open panel icon badges ───────────────────────────────── */
 /*
   Circular warning badges floating at each panel location.
-  Positions derived from SVG viewBox 340×480 mapped to % of container.
-  Left doors  at x≈80/340 =23.5%, right at x≈260/340=76.5%
-  FL/FR doors top≈39%, RL/RR doors top≈50%
-  Bonnet top≈20%, Trunk top≈79%
+  Positions derived from SVG viewBox -40 0 420 480; CSS % = (svg_x + 40) / 420.
+  Left doors  x≈117 → 37.4%, right doors x≈223 → 62.6%
+  Bonnet/Trunk x=170 → 50%
+  Top values are y-based and unchanged.
 */
 
 .car-badge {
@@ -981,22 +1023,22 @@ body,
 }
 .car-badge--door-fl {
   top: 45%;
-  left: 34.5%;
+  left: 37.4%;
   transform: translate(-50%, -50%);
 }
 .car-badge--door-fr {
   top: 45%;
-  left: 65.5%;
+  left: 62.6%;
   transform: translate(-50%, -50%);
 }
 .car-badge--door-rl {
   top: 56%;
-  left: 34.5%;
+  left: 37.4%;
   transform: translate(-50%, -50%);
 }
 .car-badge--door-rr {
   top: 56%;
-  left: 65.5%;
+  left: 62.6%;
   transform: translate(-50%, -50%);
 }
 

--- a/frontend/src/components/CarDiagram.vue
+++ b/frontend/src/components/CarDiagram.vue
@@ -23,6 +23,7 @@ const props = defineProps<{
   fuelLevelPercent?: number | null
   chargerConnected?: boolean | null
   isCharging?: boolean | null
+  speed?: number | null
 }>()
 
 function pressureVariant(bar: number | null): string {
@@ -61,6 +62,14 @@ const fuelColor = computed(() => {
   if (pct >= 30) return 'var(--color-success)'
   if (pct >= 15) return 'var(--color-warning)'
   return 'var(--color-danger)'
+})
+
+const isMoving = computed(() => (props.speed ?? 0) > 0)
+
+const roadAnimDuration = computed(() => {
+  const s = props.speed ?? 0
+  if (s <= 0) return '2s'
+  return `${Math.max(0.2, Math.min(4, 60 / s)).toFixed(2)}s`
 })
 
 const activeLightKey = computed(() => {
@@ -121,17 +130,19 @@ const activeLightKey = computed(() => {
       <div class="tyre-diagram__wrap">
         <div class="tyre-car-wrap">
           <!--
-          ViewBox: 0 0 340 480
+          ViewBox: -40 0 420 480  (widened by 40 px each side; car stays at x=170 = 50%)
           Orange car: nested SVG, original bounds x≈137–245 y≈237–445
             placed at x=105 y=115 width=130 height=250 in parent coords.
+          Car body parent coords: x≈119–222; center x=170.
           Wheel corners (parent): FL(127,123) FR(213,123) RL(127,349) RR(213,349)
           Dots at outer side of each wheel: FL(110,145) FR(230,145) RL(110,327) RR(230,327)
           Labels at (~20° from horizontal):  FL→(72,131) FR→(268,131) RL→(72,341) RR→(268,341)
+          CSS % = (svg_x + 40) / 420: FL/RL=26.7%  FR/RR=73.3%
           Side light cones: left x=72–118 y=137–147 / right x=222–268 y=137–147
           Door icon badges: see .car-badge-* CSS classes
         -->
           <svg
-            viewBox="0 0 340 480"
+            viewBox="-40 0 420 480"
             xmlns="http://www.w3.org/2000/svg"
             class="tyre-diagram__svg"
             aria-label="Vehicle status diagram"
@@ -189,6 +200,32 @@ const activeLightKey = computed(() => {
                 <stop offset="100%" stop-color="#fb923c" stop-opacity="0" />
               </radialGradient>
             </defs>
+
+            <!-- Road animation: visible only while driving (speed > 0).
+                 ViewBox is -40 0 420 480. 3 equal lanes of 140 px each.
+                 Left lane: x=-40–100. Center lane: x=100–240 (car body x≈119–222, ~20 px margin).
+                 Right lane: x=240–380. Edges at x=-38 and x=378. -->
+            <g v-if="isMoving" class="road-anim-group">
+              <rect x="-40" y="0" width="420" height="480" class="road-surface" />
+              <line x1="-38" y1="0" x2="-38" y2="480" class="road-edge" />
+              <line x1="378" y1="0" x2="378" y2="480" class="road-edge" />
+              <line
+                x1="100"
+                y1="0"
+                x2="100"
+                y2="480"
+                class="road-center-dash"
+                :style="{ animationDuration: roadAnimDuration }"
+              />
+              <line
+                x1="240"
+                y1="0"
+                x2="240"
+                y2="480"
+                class="road-center-dash"
+                :style="{ animationDuration: roadAnimDuration }"
+              />
+            </g>
 
             <!--
               Light beams drawn behind car. Polygon bases extend into the car body area (y≈140-145)

--- a/frontend/src/views/DashboardView.vue
+++ b/frontend/src/views/DashboardView.vue
@@ -262,6 +262,7 @@ onUnmounted(() => {
             :fuel-level-percent="status.fuelLevelPercent"
             :charger-connected="status.chargerConnected"
             :is-charging="status.isCharging"
+            :speed="status.speed"
           />
           <div v-else class="card-slot__placeholder card-slot__placeholder--chart">
             <font-awesome-icon icon="car-side" />
@@ -360,6 +361,7 @@ onUnmounted(() => {
           :fuel-level-percent="status.fuelLevelPercent"
           :charger-connected="status.chargerConnected"
           :is-charging="status.isCharging"
+          :speed="status.speed"
           class="mb-4"
         />
 


### PR DESCRIPTION
## Summary

- Adds a road animation behind the car in the top-view diagram that appears whenever `speed > 0`
- Lane-separator dashes scroll at a speed proportional to real vehicle speed (`60 / speed` seconds per cycle, clamped to 0.2–4 s)
- Widened SVG viewBox from `0 0 340 480` to `-40 0 420 480` so the car sits centred in a middle lane with two equal outer lanes (140 px each) on either side
- Updated all dependent CSS percentage positions (tyre labels, door badges) to match the new viewBox geometry
- Light/dark theme variants for road surface and lane markings
- `speed` prop wired up in both `CarDiagram` usages in `DashboardView`

## Test plan

- [ ] Verify road animation appears/disappears correctly at speed > 0 / speed = 0
- [ ] Confirm dashes visibly speed up at higher speed values
- [ ] Check tyre pressure labels align with indicator lines
- [ ] Check door/bonnet/trunk badges sit over the correct car panels
- [ ] Test on narrow viewport (iPhone SE 375 px) — car-wrap has `max-width: 100%`
- [ ] Verify light and dark themes render the road correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)