### PR TITLE
Fix security review findings

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -100,6 +100,7 @@ jobs:
           echo "Resolved MinVer version: $VERSION"
 
       - name: Log in to Docker Hub (avoids pull rate limits for moby/buildkit)
+        if: github.event_name != 'pull_request'
         uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}

--- a/docker/all-in-one/entrypoint.sh
+++ b/docker/all-in-one/entrypoint.sh
@@ -11,17 +11,24 @@ POSTGRES_PASSWORD="${POSTGRES_PASSWORD:?POSTGRES_PASSWORD environment variable i
 SAIC_USER="${SAIC_USER:?SAIC_USER environment variable is required}"
 SAIC_PASSWORD="${SAIC_PASSWORD:?SAIC_PASSWORD environment variable is required}"
 
+# Dedicated internal MQTT broker credentials — decoupled from SAIC account credentials
+# so a LAN-exposed broker does not leak the user's cloud account password.
+MQTT_BROKER_USERNAME="${MQTT_BROKER_USERNAME:-garagestack}"
+if [ -z "${MQTT_BROKER_PASSWORD:-}" ]; then
+    MQTT_BROKER_PASSWORD="$(openssl rand -hex 32)"
+fi
+
 # Derived connection string for .NET services
 export ConnectionStrings__DefaultConnection="Host=127.0.0.1;Port=5432;Database=${POSTGRES_DB};Username=${POSTGRES_USER};Password=${POSTGRES_PASSWORD}"
 
 # Internal MQTT (Mosquitto runs in this container)
 export Mqtt__Host="127.0.0.1"
 export Mqtt__Port="1883"
-export Mqtt__Username="${SAIC_USER}"
-export Mqtt__Password="${SAIC_PASSWORD}"
+export Mqtt__Username="${MQTT_BROKER_USERNAME}"
+export Mqtt__Password="${MQTT_BROKER_PASSWORD}"
 export MQTT_URI="tcp://127.0.0.1:1883"
-export MQTT_USER="${SAIC_USER}"
-export MQTT_PASSWORD="${SAIC_PASSWORD}"
+export MQTT_USER="${MQTT_BROKER_USERNAME}"
+export MQTT_PASSWORD="${MQTT_BROKER_PASSWORD}"
 
 # VAPID subject defaults to the SAIC account email
 export Vapid__PublicKey="${VAPID_PUBLIC_KEY:-}"
@@ -50,8 +57,8 @@ mkdir -p /data/dataprotection /root/.aspnet
 ln -sfn /data/dataprotection /root/.aspnet/DataProtection-Keys
 
 # Generate Mosquitto password and ACL files from SAIC credentials.
-mosquitto_passwd -b -c /etc/mosquitto/conf.d/passwd "${SAIC_USER}" "${SAIC_PASSWORD}"
-printf 'user %s\ntopic readwrite #\n' "${SAIC_USER}" > /etc/mosquitto/conf.d/acl
+mosquitto_passwd -b -c /etc/mosquitto/conf.d/passwd "${MQTT_BROKER_USERNAME}" "${MQTT_BROKER_PASSWORD}"
+printf 'user %s\ntopic readwrite #\n' "${MQTT_BROKER_USERNAME}" > /etc/mosquitto/conf.d/acl
 chmod 600 /etc/mosquitto/conf.d/passwd /etc/mosquitto/conf.d/acl
 
 # ── PostgreSQL initialisation ──────────────────────────────────────────────────

--- a/frontend/src/composables/useNotifications.ts
+++ b/frontend/src/composables/useNotifications.ts
@@ -5,6 +5,7 @@ import { useAuthStore } from '@/stores/auth'
 const notifications = ref<AppNotification[]>([])
 const panelOpen = ref(false)
 const loading = ref(false)
+const fetchError = ref<string | null>(null)
 
 export function useNotifications() {
   const auth = useAuthStore()
@@ -12,8 +13,11 @@ export function useNotifications() {
 
   async function fetchNotifications() {
     loading.value = true
+    fetchError.value = null
     try {
       notifications.value = await notificationsApi.list()
+    } catch (err) {
+      fetchError.value = err instanceof Error ? err.message : 'Failed to load notifications'
     } finally {
       loading.value = false
     }
@@ -81,6 +85,7 @@ export function useNotifications() {
     unreadCount,
     panelOpen,
     loading,
+    fetchError,
     fetchNotifications,
     archiveNotification,
     archiveAllNotifications,

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -218,8 +218,7 @@ export const pushApi = {
   getVapidPublicKey: () => request<{ publicKey: string }>('/api/push/vapid-public-key'),
   subscribe: (endpoint: string, p256DhKey: string, authKey: string) =>
     send('/api/push/subscribe', 'POST', { endpoint, p256DhKey, authKey }),
-  unsubscribe: (endpoint: string) =>
-    send(`/api/push/unsubscribe?endpoint=${encodeURIComponent(endpoint)}`, 'DELETE'),
+  unsubscribe: (endpoint: string) => send('/api/push/unsubscribe', 'POST', { endpoint }),
 }
 
 export interface AppNotification {

--- a/src/GarageStack.Api/Endpoints/VehicleEndpoints.cs
+++ b/src/GarageStack.Api/Endpoints/VehicleEndpoints.cs
@@ -232,9 +232,9 @@ public static class VehicleEndpoints
         })
         .WithSummary("Register a browser push subscription");
 
-        push.MapDelete("/unsubscribe", async (string endpoint, AppDbContext db, CancellationToken ct) =>
+        push.MapPost("/unsubscribe", async (PushUnsubscribeRequest req, AppDbContext db, CancellationToken ct) =>
         {
-            var sub = await db.PushSubscriptions.FirstOrDefaultAsync(s => s.Endpoint == endpoint, ct);
+            var sub = await db.PushSubscriptions.FirstOrDefaultAsync(s => s.Endpoint == req.Endpoint, ct);
             if (sub is not null)
             {
                 db.PushSubscriptions.Remove(sub);
@@ -249,4 +249,5 @@ public static class VehicleEndpoints
 }
 
 public record PushSubscribeRequest(string Endpoint, string P256DhKey, string AuthKey);
+public record PushUnsubscribeRequest(string Endpoint);
 public record VehicleListItemDto(int Id, string Vin, string? Model, string? Series, DateTime CreatedAt);

--- a/src/GarageStack.Data/Migrations/20260607100354_AddVehicleLastParkedAt.cs
+++ b/src/GarageStack.Data/Migrations/20260607100354_AddVehicleLastParkedAt.cs
@@ -21,23 +21,19 @@ namespace GarageStack.Data.Migrations
                 type: "timestamp with time zone",
                 nullable: true);
 
-            migrationBuilder.CreateIndex(
-                name: "IX_TelemetrySnapshots_VehicleId_RecordedAt",
-                table: "TelemetrySnapshots",
-                columns: new[] { "VehicleId", "RecordedAt" });
+            // IX_TelemetrySnapshots_VehicleId_RecordedAt already exists from InitialCreate;
+            // do not recreate it here or upgrade will fail with a duplicate relation error.
         }
 
         /// <inheritdoc />
         protected override void Down(MigrationBuilder migrationBuilder)
         {
-            migrationBuilder.DropIndex(
-                name: "IX_TelemetrySnapshots_VehicleId_RecordedAt",
-                table: "TelemetrySnapshots");
-
             migrationBuilder.DropColumn(
                 name: "LastParkedAt",
                 table: "Vehicles");
 
+            // IX_TelemetrySnapshots_VehicleId_RecordedAt was not created in Up,
+            // so it must not be dropped here; it belongs to InitialCreate.
             migrationBuilder.CreateIndex(
                 name: "IX_TelemetrySnapshots_VehicleId_RecordedAt_Chart",
                 table: "TelemetrySnapshots",

--- a/src/GarageStack.Tests/MqttTopicParserTests.cs
+++ b/src/GarageStack.Tests/MqttTopicParserTests.cs
@@ -5,8 +5,8 @@ namespace GarageStack.Tests;
 public class MqttTopicParserTests
 {
     [Theory]
-    [InlineData("saic/user@example.com/vehicles/LSJW94398TG031833/drivetrain/fuelLevel", "LSJW94398TG031833")]
-    [InlineData("saic/user/vehicles/VIN123/location/latitude", "VIN123")]
+    [InlineData("saic/user@example.com/vehicles/FAKEVN00000000001/drivetrain/fuelLevel", "FAKEVN00000000001")]
+    [InlineData("saic/user/vehicles/FAKEVN00000000002/location/latitude", "FAKEVN00000000002")]
     public void TryExtractVin_ValidTopic_ReturnsVin(string topic, string expectedVin)
     {
         var result = MqttTopicParser.TryExtractVin(topic, out var vin);
@@ -17,6 +17,8 @@ public class MqttTopicParserTests
     [Theory]
     [InlineData("saic/user/notVehicles/VIN/something")]
     [InlineData("homeassistant/sensor/something")]
+    [InlineData("saic/user/vehicles/VIN123/location/latitude")]  // too short / invalid VIN
+    [InlineData("saic/user/vehicles/FAKEVN00000000001X/location/latitude")]  // too long (18 chars)
     [InlineData("")]
     public void TryExtractVin_InvalidTopic_ReturnsFalse(string topic)
     {

--- a/src/GarageStack.Worker/Mqtt/MqttConsumerService.cs
+++ b/src/GarageStack.Worker/Mqtt/MqttConsumerService.cs
@@ -210,7 +210,7 @@ public class MqttConsumerService(
         if (snapshot.EngineRunning.Value && !wasRunning)
         {
             logger.LogInformation("Engine started for VIN={Vin} - sending push notification", vin);
-            await pushSender.SendToAllAsync("Engine started", "Your car has been started.", ct, "engine-start");
+            await pushSender.SendToAllAsync("Engine started", "Your car has been started.", ct, "engine-start", snapshot.VehicleId);
         }
     }
 

--- a/src/GarageStack.Worker/Mqtt/MqttTopicParser.cs
+++ b/src/GarageStack.Worker/Mqtt/MqttTopicParser.cs
@@ -2,14 +2,22 @@ namespace GarageStack.Worker.Mqtt;
 
 public static class MqttTopicParser
 {
+    // VIN is exactly 17 alphanumeric characters (I, O, Q excluded per ISO 3779).
+    private static readonly System.Text.RegularExpressions.Regex VinPattern =
+        new(@"^[A-HJ-NPR-Z0-9]{17}$", System.Text.RegularExpressions.RegexOptions.None);
+
     public static bool TryExtractVin(string topic, out string vin)
     {
         // Topic pattern: saic/<user>/vehicles/<VIN>/...
         var parts = topic.Split('/');
-        if (parts.Length >= 4 && parts[2] == "vehicles")
+        if (parts.Length >= 4 && parts[0] == "saic" && parts[2] == "vehicles")
         {
-            vin = parts[3];
-            return !string.IsNullOrWhiteSpace(vin);
+            var candidate = parts[3];
+            if (VinPattern.IsMatch(candidate))
+            {
+                vin = candidate;
+                return true;
+            }
         }
         vin = string.Empty;
         return false;

--- a/unraid/garagestack.xml
+++ b/unraid/garagestack.xml
@@ -44,13 +44,13 @@
   <Config
     Name="MQTT Port"
     Target="1883"
-    Default="1883"
+    Default=""
     Mode="tcp"
-    Description="Host port for the internal Mosquitto MQTT broker. Only expose if you need direct MQTT access from other devices."
+    Description="Host port for the internal Mosquitto MQTT broker. Leave blank (default) to keep the broker LAN-private. Only set if you need direct MQTT access from other devices."
     Type="Port"
     Display="advanced"
     Required="false"
-    Mask="false">1883</Config>
+    Mask="false"></Config>
 
   <!-- ── Volumes ────────────────────────────────────────────────────────────── -->
 


### PR DESCRIPTION
## Summary

- **Migration**: Removes a duplicate `CreateIndex` in `AddVehicleLastParkedAt` that would cause upgrade failures on existing databases (index already exists from `InitialCreate`)
- **MQTT credentials**: Decouples the internal Mosquitto broker from SAIC account credentials — new `MQTT_BROKER_USERNAME`/`MQTT_BROKER_PASSWORD` env vars with a random default; Unraid template no longer publishes port 1883 by default
- **Push dedup**: Passes `vehicleId` in the MQTT engine-start notification so the DB dedup check in `PushNotificationCheckService` can correctly suppress duplicate alerts
- **Push unsubscribe**: Moves the push endpoint from the query string to a POST body so it does not appear in proxy/server logs
- **VIN validation**: `MqttTopicParser` now validates VIN against ISO 3779 (17 chars, valid charset) before any DB write, preventing log noise from malformed topics
- **Notification errors**: `fetchNotifications` in `useNotifications` now catches errors internally and exposes a `fetchError` ref instead of propagating unhandled rejections
- **CI**: Docker Hub login step is now skipped on `pull_request` events so fork PR builds do not fail on missing secrets

## Test plan

- [ ] Run `dotnet test` — all 182 tests pass
- [ ] Fresh install: apply migrations, verify no duplicate-index error
- [ ] Upgrade from prior schema: run `dotnet ef database update`, verify clean run
- [ ] All-in-one container: confirm MQTT broker uses generated credentials, not SAIC password
- [ ] Unraid template: confirm port 1883 is blank by default
- [ ] Subscribe + unsubscribe push in browser: verify unsubscribe hits `POST /api/push/unsubscribe` with JSON body
- [ ] Fork PR: confirm Docker Hub login step is skipped in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)