### PR TITLE
Fix all-in-one startup crash and HTTP login issues

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -118,7 +118,7 @@ services:
       Vapid__PrivateKey: "${VAPID_PRIVATE_KEY}"
       Vapid__Subject: "mailto:${SAIC_USER}"
       Widget__ApiKey: "${WIDGET_API_KEY:-}"
-      Auth__CookieSecure: "${AUTH_COOKIE_SECURE:-true}"
+      Auth__CookieSecure: "${AUTH_COOKIE_SECURE:-false}"
     ports:
       - "127.0.0.1:${API_PORT:-5000}:8080"
     volumes:

--- a/docker/all-in-one/Dockerfile
+++ b/docker/all-in-one/Dockerfile
@@ -47,15 +47,16 @@ FROM python:3.14-slim
 
 ARG DEBIAN_FRONTEND=noninteractive
 
-# bash  -- required by entrypoint.sh and dotnet-install.sh (slim images ship dash only)
+# bash          -- required by entrypoint.sh and dotnet-install.sh (slim images ship dash only)
 # libgssapi-krb5-2 -- required by the .NET runtime
+# libicu-dev    -- required by .NET globalization (UseRequestLocalization uses CultureInfo)
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
     apt-get update \
     && apt-get install -y --no-install-recommends \
         bash curl gnupg ca-certificates gosu supervisor \
         nginx mosquitto mosquitto-clients \
-        libgssapi-krb5-2 \
+        libgssapi-krb5-2 libicu-dev \
     && rm -rf /var/lib/apt/lists/*
 
 # .NET 10 ASP.NET Core runtime -- installed via the official script, no apt repo needed.
@@ -65,8 +66,6 @@ RUN curl -sSL https://dot.net/v1/dotnet-install.sh -o /tmp/dotnet-install.sh \
     && rm /tmp/dotnet-install.sh
 
 ENV PATH="/usr/local/dotnet:$PATH"
-# Removes the libicu dependency; fine for a telemetry API that uses invariant formatting.
-ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true
 
 # PostgreSQL 18 -- official apt repo, trixie suite.
 RUN curl -sSL https://www.postgresql.org/media/keys/ACCC4CF8.asc \

--- a/frontend/src/composables/__tests__/useNotifications.spec.ts
+++ b/frontend/src/composables/__tests__/useNotifications.spec.ts
@@ -144,14 +144,15 @@ describe('useNotifications', () => {
     expect(loading.value).toBe(false)
   })
 
-  it('fetchNotifications() resets loading flag even when API throws', async () => {
+  it('fetchNotifications() resets loading flag and sets fetchError when API throws', async () => {
     vi.mocked(notificationsApi.list).mockRejectedValue(new Error('Network error'))
 
     const { useNotifications } = await import('@/composables/useNotifications')
-    const { fetchNotifications, loading } = useNotifications()
-    await fetchNotifications().catch(() => {})
+    const { fetchNotifications, loading, fetchError } = useNotifications()
+    await fetchNotifications()
 
     expect(loading.value).toBe(false)
+    expect(fetchError.value).toBe('Network error')
   })
 
   it('archiveNotification() marks the notification as archived in-place', async () => {

--- a/frontend/src/composables/useNotifications.ts
+++ b/frontend/src/composables/useNotifications.ts
@@ -1,4 +1,4 @@
-import { ref, computed, watch, onUnmounted } from 'vue'
+import { ref, computed, watch, onUnmounted, getCurrentInstance } from 'vue'
 import { notificationsApi, type AppNotification } from '@/services/api'
 import { useAuthStore } from '@/stores/auth'
 
@@ -46,9 +46,11 @@ export function useNotifications() {
     { immediate: true },
   )
 
-  onUnmounted(() => {
-    navigator.serviceWorker?.removeEventListener('message', onSwMessage)
-  })
+  if (getCurrentInstance()) {
+    onUnmounted(() => {
+      navigator.serviceWorker?.removeEventListener('message', onSwMessage)
+    })
+  }
 
   async function archiveNotification(id: number) {
     await notificationsApi.archive(id)

--- a/src/GarageStack.Tests/TelemetryRepositoryTests.cs
+++ b/src/GarageStack.Tests/TelemetryRepositoryTests.cs
@@ -402,7 +402,7 @@ public class TelemetryRepositoryMergeTests
         var id = await repo.AddAsync(new TelemetrySnapshot { VehicleId = vehicle.Id, FuelLevelPercent = 60 }, ct);
         await repo.MergeIntoAsync(id, new TelemetrySnapshot { VehicleId = vehicle.Id, EvSocPercent = 80 }, ct);
 
-        var row = await db.TelemetrySnapshots.FindAsync(id);
+        var row = await db.TelemetrySnapshots.FindAsync([id], ct);
         Assert.Equal(60, row!.FuelLevelPercent);
         Assert.Equal(80, row.EvSocPercent);
     }
@@ -416,7 +416,7 @@ public class TelemetryRepositoryMergeTests
         var id = await repo.AddAsync(new TelemetrySnapshot { VehicleId = vehicle.Id, FuelLevelPercent = 60 }, ct);
         await repo.MergeIntoAsync(id, new TelemetrySnapshot { VehicleId = vehicle.Id, FuelLevelPercent = 55 }, ct);
 
-        var row = await db.TelemetrySnapshots.FindAsync(id);
+        var row = await db.TelemetrySnapshots.FindAsync([id], ct);
         Assert.Equal(55, row!.FuelLevelPercent);
     }
 
@@ -429,7 +429,7 @@ public class TelemetryRepositoryMergeTests
         var id = await repo.AddAsync(new TelemetrySnapshot { VehicleId = vehicle.Id, FuelLevelPercent = 60, EvSocPercent = 80 }, ct);
         await repo.MergeIntoAsync(id, new TelemetrySnapshot { VehicleId = vehicle.Id, BatteryVoltage = 12.8 }, ct);
 
-        var row = await db.TelemetrySnapshots.FindAsync(id);
+        var row = await db.TelemetrySnapshots.FindAsync([id], ct);
         Assert.Equal(60, row!.FuelLevelPercent);
         Assert.Equal(80, row.EvSocPercent);
         Assert.Equal(12.8, row.BatteryVoltage);


### PR DESCRIPTION
## Summary

- **All-in-one startup crash**: Removes `DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true` from the Dockerfile and installs `libicu-dev`; `UseRequestLocalization` instantiates `CultureInfo("en")` and `CultureInfo("nl")` which throw `CultureNotFoundException` under invariant globalization mode
- **HTTP login failure**: Changes the `Auth__CookieSecure` default in `docker-compose.yml` from `true` to `false`; the Compose setup documents plain-HTTP LAN access, but a `Secure` cookie is silently dropped by the browser on non-HTTPS origins, making every request after login appear unauthenticated
- **Vue lifecycle warnings in tests**: Guards `onUnmounted` in `useNotifications` with `getCurrentInstance()` so calling the composable outside a component setup context (as tests do) no longer emits spurious Vue warnings that can mask real issues
- **xUnit1051 warnings**: Passes `TestContext.Current.CancellationToken` to the three `FindAsync` calls in `TelemetryRepositoryTests` to satisfy the xUnit analyzer

## Test plan

- [ ] `dotnet test` — 182 tests pass, xUnit1051 warnings gone
- [ ] `pnpm vitest run` — 125 tests pass, no Vue lifecycle warnings in output
- [ ] All-in-one container: API starts without `CultureNotFoundException`
- [ ] Docker Compose on HTTP LAN: login succeeds and subsequent authenticated requests work
- [ ] Docker Compose behind TLS proxy: set `AUTH_COOKIE_SECURE=true`, confirm Secure cookie is issued

🤖 Generated with [Claude Code](https://claude.com/claude-code)