### PR TITLE
Harden deployment defaults and pin pnpm version

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,6 +30,11 @@ MQTT_HOST=mosquitto
 MQTT_PORT=1883
 # Host port Mosquitto is published on (only relevant for the bundled broker).
 MQTT_EXTERNAL_PORT=1883
+# Dedicated broker credentials — decoupled from your SAIC/MG account so a
+# LAN-exposed broker does not leak your cloud account password.
+# Generate a strong password: openssl rand -hex 32
+MQTT_BROKER_USERNAME=garagestack
+MQTT_BROKER_PASSWORD=changeme_use_something_strong
 
 # ── Ports ───────────────────────────────────────────────────────────────────
 # Host port for the frontend (nginx). Use 8080 by default to avoid clashing

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
 
       - uses: pnpm/action-setup@v6
         with:
-          version: 10
+          version: 11
 
       - uses: actions/setup-node@v6
         with:
@@ -53,7 +53,7 @@ jobs:
 
       - uses: pnpm/action-setup@v6
         with:
-          version: 10
+          version: 11
 
       - uses: actions/setup-node@v6
         with:
@@ -79,7 +79,7 @@ jobs:
 
       - uses: pnpm/action-setup@v6
         with:
-          version: 10
+          version: 11
 
       - uses: actions/setup-node@v6
         with:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,8 +8,8 @@ services:
       -c "
       set -eu;
       rm -f /mosquitto/data/passwd /mosquitto/data/acl;
-      mosquitto_passwd -b -c /mosquitto/data/passwd \"${SAIC_USER}\" \"${SAIC_PASSWORD}\";
-      printf 'user %s\\ntopic readwrite #\\n' \"${SAIC_USER}\" > /mosquitto/data/acl;
+      mosquitto_passwd -b -c /mosquitto/data/passwd \"${MQTT_BROKER_USERNAME:-garagestack}\" \"${MQTT_BROKER_PASSWORD}\";
+      printf 'user %s\\ntopic readwrite #\\n' \"${MQTT_BROKER_USERNAME:-garagestack}\" > /mosquitto/data/acl;
       chown mosquitto:mosquitto /mosquitto/data/passwd /mosquitto/data/acl;
       chmod 600 /mosquitto/data/passwd /mosquitto/data/acl;
       exec /docker-entrypoint.sh /usr/sbin/mosquitto -c /mosquitto/config/mosquitto.conf
@@ -30,8 +30,8 @@ services:
       SAIC_USER: "${SAIC_USER}"
       SAIC_PASSWORD: "${SAIC_PASSWORD}"
       MQTT_URI: "tcp://mosquitto:1883"
-      MQTT_USER: "${SAIC_USER}"
-      MQTT_PASSWORD: "${SAIC_PASSWORD}"
+      MQTT_USER: "${MQTT_BROKER_USERNAME:-garagestack}"
+      MQTT_PASSWORD: "${MQTT_BROKER_PASSWORD}"
       SAIC_REGION: "${SAIC_REGION:-eu}"
 
   # Bundled Postgres - only starts when you pass --profile bundled-postgres.
@@ -77,8 +77,8 @@ services:
       ConnectionStrings__DefaultConnection: "Host=${POSTGRES_HOST:-postgres};Port=${POSTGRES_PORT:-5432};Database=${POSTGRES_DB:-garagestack};Username=${POSTGRES_USER:-garagestack};Password=${POSTGRES_PASSWORD}"
       Mqtt__Host: "${MQTT_HOST:-mosquitto}"
       Mqtt__Port: "${MQTT_PORT:-1883}"
-      Mqtt__Username: "${SAIC_USER}"
-      Mqtt__Password: "${SAIC_PASSWORD}"
+      Mqtt__Username: "${MQTT_BROKER_USERNAME:-garagestack}"
+      Mqtt__Password: "${MQTT_BROKER_PASSWORD}"
       Vapid__PublicKey: "${VAPID_PUBLIC_KEY}"
       Vapid__PrivateKey: "${VAPID_PRIVATE_KEY}"
       Vapid__Subject: "mailto:${SAIC_USER}"
@@ -112,13 +112,13 @@ services:
       Auth__Password: "${SAIC_PASSWORD}"
       Mqtt__Host: "${MQTT_HOST:-mosquitto}"
       Mqtt__Port: "${MQTT_PORT:-1883}"
-      Mqtt__Username: "${SAIC_USER}"
-      Mqtt__Password: "${SAIC_PASSWORD}"
+      Mqtt__Username: "${MQTT_BROKER_USERNAME:-garagestack}"
+      Mqtt__Password: "${MQTT_BROKER_PASSWORD}"
       Vapid__PublicKey: "${VAPID_PUBLIC_KEY}"
       Vapid__PrivateKey: "${VAPID_PRIVATE_KEY}"
       Vapid__Subject: "mailto:${SAIC_USER}"
       Widget__ApiKey: "${WIDGET_API_KEY:-}"
-      Auth__CookieSecure: "${AUTH_COOKIE_SECURE:-false}"
+      Auth__CookieSecure: "${AUTH_COOKIE_SECURE:-true}"
     ports:
       - "127.0.0.1:${API_PORT:-5000}:8080"
     volumes:

--- a/docker/all-in-one/entrypoint.sh
+++ b/docker/all-in-one/entrypoint.sh
@@ -39,9 +39,9 @@ export Vapid__Subject="${Vapid__Subject:-mailto:${SAIC_USER}}"
 export Jwt__Secret="${JWT_SECRET:?JWT_SECRET environment variable is required}"
 export Auth__Username="${SAIC_USER}"
 export Auth__Password="${SAIC_PASSWORD}"
-# Default false: this container is usually served over plain HTTP on a LAN.
-# Set AUTH_COOKIE_SECURE=true when sitting behind a TLS-terminating proxy.
-export Auth__CookieSecure="${AUTH_COOKIE_SECURE:-false}"
+# Default true: matches API production behavior and is correct behind any TLS proxy.
+# Set AUTH_COOKIE_SECURE=false only for trusted plain-HTTP LAN installs.
+export Auth__CookieSecure="${AUTH_COOKIE_SECURE:-true}"
 
 # CORS: the URL users open in their browser
 export Cors__Origins__0="${CORS_ORIGIN:-http://localhost:8080}"

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -2,7 +2,7 @@ FROM node:24-alpine AS build
 WORKDIR /app
 ARG VITE_DEMO_MODE=false
 ENV VITE_DEMO_MODE=$VITE_DEMO_MODE
-RUN apk upgrade --no-cache && corepack enable && corepack prepare pnpm@latest --activate
+RUN apk upgrade --no-cache && corepack enable && corepack prepare pnpm@11.1.3 --activate
 COPY package.json pnpm-lock.yaml ./
 RUN pnpm config set minimum-release-age 0 && pnpm install --frozen-lockfile --ignore-scripts
 COPY . .

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -63,5 +63,6 @@
   },
   "engines": {
     "node": "^20.19.0 || >=22.12.0"
-  }
+  },
+  "packageManager": "pnpm@11.1.3"
 }


### PR DESCRIPTION
## Summary

- **Cookie secure default (High)**: `Auth__CookieSecure` now defaults to `true` in both `docker-compose.yml` and the all-in-one `entrypoint.sh`. The previous `false` default issued non-Secure JWT cookies for any install that did not explicitly set the variable — including HTTPS and reverse-proxy setups where a Secure cookie is required. Plain-HTTP LAN installs must now set `AUTH_COOKIE_SECURE=false`.
- **Compose MQTT credentials (Medium)**: The bundled Mosquitto broker and all three consumer services (gateway, worker, API) now use `MQTT_BROKER_USERNAME` / `MQTT_BROKER_PASSWORD` instead of `SAIC_USER` / `SAIC_PASSWORD`. Decoupled credentials mean a LAN-exposed broker no longer leaks the MG cloud account password. Both variables are documented in `.env.example`. Default username is `garagestack`; password must be set explicitly.
- **pnpm version pinning (Low)**: `frontend/Dockerfile` pins `pnpm@11.1.3` (was `pnpm@latest`). A `packageManager` field is added to `frontend/package.json` as the canonical version declaration. CI updated from `version: 10` to `version: 11` to match the all-in-one Dockerfile.

## Test plan

- [ ] `dotnet test` — 182 tests pass
- [ ] Compose on HTTP LAN with `AUTH_COOKIE_SECURE=false`: login works, cookie is non-Secure
- [ ] Compose behind HTTPS proxy without `AUTH_COOKIE_SECURE` set: login works, cookie is Secure
- [ ] Compose with new `MQTT_BROKER_USERNAME` / `MQTT_BROKER_PASSWORD` values: all services connect to Mosquitto successfully
- [ ] `docker build -f frontend/Dockerfile frontend/` completes without version warnings
- [ ] CI passes on PR (pnpm 11 installs and tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)