### PR TITLE
Fix sunroof alert gap, Docker Hub login resilience, and topics endpoint accuracy

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -101,6 +101,7 @@ jobs:
 
       - name: Log in to Docker Hub (avoids pull rate limits for moby/buildkit)
         if: github.event_name != 'pull_request'
+        continue-on-error: true
         uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}

--- a/frontend/src/composables/__tests__/useVehicleAlerts.spec.ts
+++ b/frontend/src/composables/__tests__/useVehicleAlerts.spec.ts
@@ -120,21 +120,24 @@ describe('getOpenItems', () => {
     expect(items).toContain('bonnet')
   })
 
-  it('detects open windows and sunroof', () => {
+  it('detects open windows', () => {
     const items = getOpenItems(
       makeSnapshot({
         driverWindowOpen: true,
         passengerWindowOpen: true,
         rearLeftWindowOpen: true,
         rearRightWindowOpen: true,
-        sunRoofOpen: true,
       }),
     )
     expect(items).toContain('driver window')
     expect(items).toContain('passenger window')
     expect(items).toContain('rear left window')
     expect(items).toContain('rear right window')
-    expect(items).not.toContain('sunroof')
+  })
+
+  it('detects open sunroof', () => {
+    const items = getOpenItems(makeSnapshot({ sunRoofOpen: true }))
+    expect(items).toContain('sunroof')
   })
 
   it('returns only open items when mixed', () => {

--- a/frontend/src/composables/useVehicleAlerts.ts
+++ b/frontend/src/composables/useVehicleAlerts.ts
@@ -17,6 +17,7 @@ export function getOpenItems(s: TelemetrySnapshot): string[] {
   if (s.passengerWindowOpen) open.push('passenger window')
   if (s.rearLeftWindowOpen) open.push('rear left window')
   if (s.rearRightWindowOpen) open.push('rear right window')
+  if (s.sunRoofOpen) open.push('sunroof')
   return open
 }
 

--- a/src/GarageStack.Api/Endpoints/VehicleEndpoints.cs
+++ b/src/GarageStack.Api/Endpoints/VehicleEndpoints.cs
@@ -186,7 +186,7 @@ public static class VehicleEndpoints
 
             return Results.Ok(topics);
         })
-        .WithSummary("Distinct raw MQTT topics seen for a vehicle");
+        .WithSummary("Distinct raw MQTT topics seen for a vehicle (one entry per 15-second merge window; topics arriving mid-window are not recorded)");
 
         var push = app.MapGroup("/api/push")
             .WithTags("Push Notifications")

--- a/src/GarageStack.Tests/PushNotificationCheckServiceTests.cs
+++ b/src/GarageStack.Tests/PushNotificationCheckServiceTests.cs
@@ -219,6 +219,18 @@ public class PushNotificationCheckServiceTests
         Assert.Equal("windows-open-parked", alerts[0].Item1);
     }
 
+    [Fact]
+    public void CheckWindowsOpenWhileParked_SunroofOpen_FiresAlert()
+    {
+        var alerts = new List<(string, string, string)>();
+
+        PushNotificationCheckService.CheckWindowsOpenWhileParked(
+            Parked(s => s.SunRoofOpen = true), alerts, withinParkingGrace: false);
+
+        Assert.Single(alerts);
+        Assert.Contains("sunroof", alerts[0].Item3);
+    }
+
     // ---------------------------------------------------------------------------
     // CheckChargingComplete — BEV/PHEV only, transition detection
     // ---------------------------------------------------------------------------

--- a/src/GarageStack.Worker/Services/PushNotificationCheckService.cs
+++ b/src/GarageStack.Worker/Services/PushNotificationCheckService.cs
@@ -209,6 +209,7 @@ public class PushNotificationCheckService(
         if (s.PassengerWindowOpen == true) open.Add("passenger");
         if (s.RearLeftWindowOpen == true) open.Add("rear left");
         if (s.RearRightWindowOpen == true) open.Add("rear right");
+        if (s.SunRoofOpen == true) open.Add("sunroof");
 
         if (open.Count > 0)
             alerts.Add(("windows-open-parked", "Window Left Open", $"Window(s) open while parked: {string.Join(", ", open)}"));


### PR DESCRIPTION
## Summary

- **Sunroof in parked-open alerts (Medium)**: `PushNotificationCheckService.CheckWindowsOpenWhileParked` and the frontend `getOpenItems` helper now both include `sunRoofOpen` alongside the four side windows. The README documents "any window or sunroof open while engine is off" as a covered condition, but both code paths silently omitted it. The existing `useVehicleAlerts` test that asserted `sunroof` was *not* present has been corrected and split into separate window/sunroof cases. A backend test for the sunroof case is also added.
- **Docker Hub login resilience (Medium)**: Added `continue-on-error: true` to the Docker Hub pull-rate-limit login step in `docker-publish.yml`. Without it, a missing `DOCKERHUB_USERNAME` or `DOCKERHUB_TOKEN` secret aborts the job before GHCR publishing is reached. The same step in `ci.yml` already uses `continue-on-error`.
- **Topics endpoint description (Low)**: Updated the `/api/vehicles/{vin}/topics` summary to document that only the first MQTT topic per 15-second merge window is stored; topics arriving mid-window are merged into the existing row without recording their raw topic path.

## Test plan

- [ ] `dotnet test` — 183 tests pass (includes new sunroof backend test)
- [ ] `pnpm vitest run` — 126 tests pass (sunroof test now asserts presence, not absence)
- [ ] Parked with sunroof open: push notification fires with "sunroof" in body
- [ ] Fork repo with no Docker Hub secrets: publish job completes (GHCR push succeeds despite Docker Hub login warning)

🤖 Generated with [Claude Code](https://claude.com/claude-code)