### PR TITLE
Fix PWA cache busting: prevent stale sw.js from causing bad-precaching-response

### DIFF
--- a/docker/all-in-one/nginx.conf
+++ b/docker/all-in-one/nginx.conf
@@ -39,6 +39,22 @@ server {
         try_files $uri $uri/ /index.html;
     }
 
+    # SW and manifest must never be HTTP-cached: the browser needs to fetch
+    # them fresh on every load to detect app updates. Long-caching these causes
+    # the SW to keep precaching stale asset hashes after a new deployment.
+    location = /sw.js {
+        add_header Cache-Control "no-store, no-cache, must-revalidate" always;
+        try_files $uri =404;
+    }
+    location = /registerSW.js {
+        add_header Cache-Control "no-store, no-cache, must-revalidate" always;
+        try_files $uri =404;
+    }
+    location = /manifest.webmanifest {
+        add_header Cache-Control "no-store, no-cache, must-revalidate" always;
+        try_files $uri =404;
+    }
+
     location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff2?)$ {
         expires 1y;
         add_header Cache-Control "public, immutable";

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -30,6 +30,22 @@ server {
         try_files $uri $uri/ /index.html;
     }
 
+    # SW and manifest must never be HTTP-cached: the browser needs to fetch
+    # them fresh on every load to detect app updates. Long-caching these causes
+    # the SW to keep precaching stale asset hashes after a new deployment.
+    location = /sw.js {
+        add_header Cache-Control "no-store, no-cache, must-revalidate" always;
+        try_files $uri =404;
+    }
+    location = /registerSW.js {
+        add_header Cache-Control "no-store, no-cache, must-revalidate" always;
+        try_files $uri =404;
+    }
+    location = /manifest.webmanifest {
+        add_header Cache-Control "no-store, no-cache, must-revalidate" always;
+        try_files $uri =404;
+    }
+
     location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff2?)$ {
         expires 1y;
         add_header Cache-Control "public, immutable";

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -2,6 +2,33 @@ import './assets/main.css'
 import 'leaflet/dist/leaflet.css'
 
 import { createApp } from 'vue'
+
+if ('serviceWorker' in navigator) {
+  let refreshing = false
+  navigator.serviceWorker.addEventListener('controllerchange', () => {
+    if (refreshing) return
+    refreshing = true
+    window.location.reload()
+  })
+
+  // If a SW install fails (e.g. stale precache manifest after deploy while
+  // sw.js was HTTP-cached as immutable), unregister and reload so the next
+  // load fetches a fresh sw.js and installs cleanly.
+  const watchInstalling = (sw: ServiceWorker, reg: ServiceWorkerRegistration) =>
+    sw.addEventListener('statechange', () => {
+      if (sw.state === 'redundant') reg.unregister().then(() => window.location.reload())
+    })
+
+  window.addEventListener('load', () => {
+    navigator.serviceWorker.getRegistration('/').then((reg) => {
+      if (!reg) return
+      if (reg.installing) watchInstalling(reg.installing, reg)
+      reg.addEventListener('updatefound', () => {
+        if (reg.installing) watchInstalling(reg.installing, reg)
+      })
+    })
+  })
+}
 import { createPinia } from 'pinia'
 import { createI18n } from 'vue-i18n'
 import { library } from '@fortawesome/fontawesome-svg-core'


### PR DESCRIPTION
## Summary

- nginx was serving `sw.js` and `registerSW.js` with `Cache-Control: public, immutable` (caught by the general `*.js` regex rule), causing browsers to cache them indefinitely
- After a new build deployed, the stale cached `sw.js` still referenced old content-hashed asset filenames that no longer existed, causing Workbox to throw `bad-precaching-response` and the SW install to fail
- Add exact-match nginx locations (highest nginx priority) for `sw.js`, `registerSW.js`, and `manifest.webmanifest` with `no-store, no-cache, must-revalidate` so they are always fetched fresh
- Add a `controllerchange` listener in `main.ts` so the page auto-reloads when a new SW takes control, ensuring updated assets are immediately served
- Add a `redundant`-state listener that unregisters a failed SW and reloads, allowing browsers already stuck with a stale `sw.js` to self-heal automatically on the next page load

## Test plan

- [ ] Deploy and verify `sw.js` response headers show `Cache-Control: no-store, no-cache, must-revalidate`
- [ ] Deploy a new build and confirm the PWA on other machines picks up the update and reloads automatically
- [ ] Verify hashed assets (`/assets/*.js`, `/assets/*.css`) still get `Cache-Control: public, immutable`

🤖 Generated with [Claude Code](https://claude.com/claude-code)