### PR TITLE
Fix road animation hidden when OS reduces motion

### DIFF
--- a/frontend/src/assets/main.css
+++ b/frontend/src/assets/main.css
@@ -657,6 +657,13 @@ body,
   }
 }
 
+@media (prefers-reduced-motion: reduce) {
+  .road-center-dash {
+    animation: none;
+    stroke-dashoffset: 0;
+  }
+}
+
 .tyre-diagram {
   background: var(--color-surface);
   border: 1px solid var(--color-border);


### PR DESCRIPTION
## Summary

- Adds a `@media (prefers-reduced-motion: reduce)` guard to `.road-center-dash` in `main.css`
- Without this, Android devices with \"Remove animations\" or the Developer Options animation scale set to off would suppress the CSS animation entirely, making the road overlay invisible while driving
- The fix keeps the dashes visible as a static element instead of disappearing

## Test plan

- [ ] Drive with the app open and confirm the road overlay appears on devices with reduced motion enabled
- [ ] Confirm the scrolling animation still works on devices with motion enabled
- [ ] Clear PWA cache on Android if the road animation was previously missing (cache may also be a factor for some users)

🤖 Generated with [Claude Code](https://claude.com/claude-code)