### PR TITLE
Fix: exclude sunroof from open-window notifications

### DIFF
--- a/frontend/src/composables/__tests__/useVehicleAlerts.spec.ts
+++ b/frontend/src/composables/__tests__/useVehicleAlerts.spec.ts
@@ -135,11 +135,6 @@ describe('getOpenItems', () => {
     expect(items).toContain('rear right window')
   })
 
-  it('detects open sunroof', () => {
-    const items = getOpenItems(makeSnapshot({ sunRoofOpen: true }))
-    expect(items).toContain('sunroof')
-  })
-
   it('returns only open items when mixed', () => {
     const items = getOpenItems(makeSnapshot({ driverDoorOpen: true, passengerDoorOpen: false }))
     expect(items).toHaveLength(1)

--- a/frontend/src/composables/useVehicleAlerts.ts
+++ b/frontend/src/composables/useVehicleAlerts.ts
@@ -17,7 +17,6 @@ export function getOpenItems(s: TelemetrySnapshot): string[] {
   if (s.passengerWindowOpen) open.push('passenger window')
   if (s.rearLeftWindowOpen) open.push('rear left window')
   if (s.rearRightWindowOpen) open.push('rear right window')
-  if (s.sunRoofOpen) open.push('sunroof')
   return open
 }
 

--- a/src/GarageStack.Tests/PushNotificationCheckServiceTests.cs
+++ b/src/GarageStack.Tests/PushNotificationCheckServiceTests.cs
@@ -219,18 +219,6 @@ public class PushNotificationCheckServiceTests
         Assert.Equal("windows-open-parked", alerts[0].Item1);
     }
 
-    [Fact]
-    public void CheckWindowsOpenWhileParked_SunroofOpen_FiresAlert()
-    {
-        var alerts = new List<(string, string, string)>();
-
-        PushNotificationCheckService.CheckWindowsOpenWhileParked(
-            Parked(s => s.SunRoofOpen = true), alerts, withinParkingGrace: false);
-
-        Assert.Single(alerts);
-        Assert.Contains("sunroof", alerts[0].Item3);
-    }
-
     // ---------------------------------------------------------------------------
     // CheckChargingComplete — BEV/PHEV only, transition detection
     // ---------------------------------------------------------------------------

--- a/src/GarageStack.Worker/Services/PushNotificationCheckService.cs
+++ b/src/GarageStack.Worker/Services/PushNotificationCheckService.cs
@@ -209,7 +209,6 @@ public class PushNotificationCheckService(
         if (s.PassengerWindowOpen == true) open.Add("passenger");
         if (s.RearLeftWindowOpen == true) open.Add("rear left");
         if (s.RearRightWindowOpen == true) open.Add("rear right");
-        if (s.SunRoofOpen == true) open.Add("sunroof");
 
         if (open.Count > 0)
             alerts.Add(("windows-open-parked", "Window Left Open", $"Window(s) open while parked: {string.Join(", ", open)}"));


### PR DESCRIPTION
## Summary

- Removes sunroof from the backend `CheckWindowsOpenWhileParked` alert check
- Removes sunroof from the frontend `getOpenItems` alert composable
- Drops the corresponding tests for sunroof detection

The MG API always reports `sunRoofOpen=true` regardless of actual state, causing constant false-positive "window left open" notifications for vehicles without a sunroof.

## Test plan

- [x] All 225 backend tests pass
- [x] All 23 frontend vehicle alert tests pass
- [ ] Confirm no sunroof notification fires after parking

🤖 Generated with [Claude Code](https://claude.com/claude-code)