### PR TITLE
Fix GitHub Actions token permission errors (CodeQL + dependency graph)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,13 +17,13 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
 
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@v4
         with:
           version: 11
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v4
         with:
           node-version: 22
           cache: pnpm
@@ -49,13 +49,13 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
 
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@v4
         with:
           version: 11
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v4
         with:
           node-version: 22
           cache: pnpm
@@ -75,13 +75,13 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
 
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@v4
         with:
           version: 11
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v4
         with:
           node-version: 22
           cache: pnpm
@@ -101,7 +101,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
 
       - uses: actions/setup-dotnet@v5
         with:
@@ -119,7 +119,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
 
       - uses: actions/setup-dotnet@v5
         with:
@@ -153,7 +153,7 @@ jobs:
             context: .
             dockerfile: src/GarageStack.Worker/Dockerfile
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
 
       - name: Log in to Docker Hub (avoids pull rate limits)
         continue-on-error: true

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,38 @@
+name: CodeQL
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+  schedule:
+    - cron: '0 7 * * 1'
+
+permissions:
+  contents: read
+  security-events: write
+  actions: read
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [actions, csharp, javascript-typescript]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: ${{ matrix.language }}
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v4
+
+      - name: Analyze
+        uses: github/codeql-action/analyze@v4
+        with:
+          category: codeql-${{ matrix.language }}

--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -1,0 +1,50 @@
+name: Dependency submission
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+  dependency-graph: write
+
+jobs:
+  dotnet:
+    name: .NET dependency snapshot
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 10.0.x
+
+      - name: Submit .NET dependencies
+        uses: actions/nuget-dependency-submission-action@v1
+        with:
+          solution-directory: .
+
+  frontend:
+    name: Frontend dependency snapshot
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 11
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+          cache-dependency-path: frontend/pnpm-lock.yaml
+
+      - name: Install dependencies
+        working-directory: frontend
+        run: pnpm install --frozen-lockfile
+
+      - name: Submit frontend dependencies
+        uses: actions/dependency-submission-action@v1
+        with:
+          working-directory: frontend

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -17,7 +17,7 @@ jobs:
     name: Trivy filesystem scan
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
 
       - name: Run Trivy (SARIF output)
         uses: aquasecurity/trivy-action@v0.36.0


### PR DESCRIPTION
## Summary

- Add explicit `codeql.yml` workflow with `security-events: write` permission, replacing GitHub's default CodeQL setup which ran without proper token scopes
- Add `dependency-submission.yml` with `dependency-graph: write` to replace the automatically triggered `component-detection-dependency-submission-action` that was failing authentication
- Fix invalid action versions in `ci.yml` and `security.yml` — `actions/checkout`, `pnpm/action-setup`, and `actions/setup-node` were all pinned to `@v6` which does not exist (latest is `@v4`)

## Test plan

- [ ] Verify CodeQL analysis workflow runs successfully on this PR
- [ ] Verify no "Requires authentication" errors in the Actions run
- [ ] After merge, disable **Automatic dependency submission** under Settings -> Code security -> Dependency graph
- [ ] After merge, disable **Default setup** under Settings -> Code security -> Code scanning (CodeQL)

🤖 Generated with [Claude Code](https://claude.com/claude-code)