### PR TITLE
Hide vehicle-type-restricted cards from edit mode

### DIFF
--- a/frontend/src/views/DashboardView.vue
+++ b/frontend/src/views/DashboardView.vue
@@ -37,6 +37,20 @@ const vehicleType = computed((): VehicleType | 'unknown' => {
 
 const isHev = computed(() => vehicleType.value === 'hev')
 
+const hiddenByTypeIds = computed((): Set<CardId> => {
+  if (vehicleType.value === 'unknown') return new Set()
+  const typeDefaults = defaultCards(vehicleType.value)
+  return new Set(typeDefaults.filter((c) => !c.visible).map((c) => c.id))
+})
+
+const editableCards = computed({
+  get: () => settings.cards.filter((c) => !hiddenByTypeIds.value.has(c.id)),
+  set: (newVal) => {
+    const restricted = settings.cards.filter((c) => hiddenByTypeIds.value.has(c.id))
+    settings.cards = [...newVal, ...restricted]
+  },
+})
+
 // Card IDs whose visibility differs between vehicle types (derived from defaultCards).
 // When the override changes these are reset to the new type's defaults.
 const TYPE_SPECIFIC_CARD_IDS = (() => {
@@ -280,7 +294,7 @@ onUnmounted(() => {
       </div>
 
       <VueDraggable
-        v-model="settings.cards"
+        v-model="editableCards"
         class="status-grid status-grid--edit"
         :animation="200"
         ghost-class="card-slot--ghost"
@@ -288,7 +302,7 @@ onUnmounted(() => {
         handle=".card-slot__handle"
       >
         <div
-          v-for="card in settings.cards"
+          v-for="card in editableCards"
           :key="card.id"
           class="card-slot"
           :class="{ 'card-slot--hidden': !card.visible }"


### PR DESCRIPTION
## Summary

- Cards not applicable to the current vehicle type (e.g. EV-only cards on a HEV/ICE) were visible in dashboard edit mode, allowing the user to toggle them on even though they never render in normal mode
- Added `hiddenByTypeIds` computed -- derives the set of card IDs that `defaultCards()` marks as not visible for the detected vehicle type
- Added `editableCards` writable computed that filters those IDs from the draggable list; its setter re-appends the restricted cards to `settings.cards` so they remain tracked in the store without appearing in the UI
- `VueDraggable` now binds to `editableCards` instead of `settings.cards` directly

## Test plan

- [ ] Open dashboard edit mode with a known vehicle type (e.g. HEV) and confirm EV-only cards (e.g. `evBattery`, `charging`) no longer appear
- [ ] Confirm reordering and hide/show of remaining cards still works correctly
- [ ] Confirm `resetLayout` still restores the correct defaults
- [ ] Confirm type override change in settings still updates card visibility correctly

🤖 Generated with [Claude Code](https://claude.ai/claude-code)