### PR TITLE
Add PWA install modal with never-show-again option

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -9,6 +9,7 @@ import AppFooter from '@/components/AppFooter.vue'
 import NotificationPanel from '@/components/NotificationPanel.vue'
 import DemoBanner from '@/components/DemoBanner.vue'
 import DemoControlPanel from '@/components/DemoControlPanel.vue'
+import PwaInstallModal from '@/components/PwaInstallModal.vue'
 import { useNotifications } from '@/composables/useNotifications'
 
 const isDemoMode = import.meta.env.VITE_DEMO_MODE === 'true'
@@ -254,5 +255,6 @@ watch(
     />
 
     <DemoControlPanel v-if="isDemoMode" :open="demoControlsOpen" />
+    <PwaInstallModal />
   </div>
 </template>

--- a/frontend/src/components/PwaInstallModal.vue
+++ b/frontend/src/components/PwaInstallModal.vue
@@ -1,0 +1,173 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { usePwaInstall } from '@/composables/usePwaInstall'
+
+const { t } = useI18n()
+const { modalVisible, install, dismiss } = usePwaInstall()
+
+const neverShow = ref(false)
+
+function onDismiss() {
+  dismiss(neverShow.value)
+}
+</script>
+
+<template>
+  <Teleport to="body">
+    <Transition name="modal">
+      <div v-if="modalVisible" class="detail-modal-backdrop" @click.self="onDismiss">
+        <div
+          class="detail-modal pwa-install-modal"
+          role="dialog"
+          :aria-modal="true"
+          :aria-label="t('pwa.install.title')"
+        >
+          <div class="pwa-install-modal__icon" aria-hidden="true">
+            <img src="/pwa-192x192.png" :alt="t('pwa.install.iconAlt')" />
+          </div>
+
+          <div class="pwa-install-modal__content">
+            <h2 class="pwa-install-modal__title">{{ t('pwa.install.title') }}</h2>
+            <p class="pwa-install-modal__desc">{{ t('pwa.install.description') }}</p>
+
+            <ul class="pwa-install-modal__features">
+              <li>
+                <font-awesome-icon icon="bolt" class="pwa-install-modal__feature-icon" />
+                {{ t('pwa.install.featureOffline') }}
+              </li>
+              <li>
+                <font-awesome-icon icon="bell" class="pwa-install-modal__feature-icon" />
+                {{ t('pwa.install.featureNotifications') }}
+              </li>
+              <li>
+                <font-awesome-icon icon="mobile-screen" class="pwa-install-modal__feature-icon" />
+                {{ t('pwa.install.featureNative') }}
+              </li>
+            </ul>
+          </div>
+
+          <div class="pwa-install-modal__actions">
+            <button class="btn btn-primary pwa-install-modal__cta" @click="install">
+              <font-awesome-icon icon="download" />
+              {{ t('pwa.install.install') }}
+            </button>
+            <button class="btn btn-outline-secondary" @click="onDismiss">
+              {{ t('pwa.install.notNow') }}
+            </button>
+          </div>
+
+          <label class="pwa-install-modal__never">
+            <input v-model="neverShow" type="checkbox" />
+            <span>{{ t('pwa.install.neverShow') }}</span>
+          </label>
+        </div>
+      </div>
+    </Transition>
+  </Teleport>
+</template>
+
+<style scoped>
+.pwa-install-modal {
+  text-align: center;
+  padding: 2rem 1.5rem 1.5rem;
+}
+
+.pwa-install-modal__icon {
+  margin-bottom: 1rem;
+}
+
+.pwa-install-modal__icon img {
+  width: 72px;
+  height: 72px;
+  border-radius: 18px;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.3);
+}
+
+.pwa-install-modal__content {
+  margin-bottom: 1.5rem;
+}
+
+.pwa-install-modal__title {
+  font-size: 1.2rem;
+  font-weight: 700;
+  margin: 0 0 0.5rem;
+  color: var(--color-text);
+}
+
+.pwa-install-modal__desc {
+  font-size: 0.9rem;
+  color: var(--color-text-muted);
+  margin: 0 0 1rem;
+  line-height: 1.5;
+}
+
+.pwa-install-modal__features {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  text-align: left;
+}
+
+.pwa-install-modal__features li {
+  font-size: 0.85rem;
+  color: var(--color-text-muted);
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.pwa-install-modal__feature-icon {
+  color: var(--color-primary);
+  width: 14px;
+  flex-shrink: 0;
+}
+
+.pwa-install-modal__actions {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.pwa-install-modal__cta {
+  font-size: 0.95rem;
+  padding: 0.65rem 1.5rem;
+  justify-content: center;
+  gap: 0.5rem;
+}
+
+.pwa-install-modal__never {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.4rem;
+  margin-top: 1rem;
+  font-size: 0.8rem;
+  color: var(--color-text-muted);
+  cursor: pointer;
+  user-select: none;
+}
+
+.pwa-install-modal__never input[type='checkbox'] {
+  accent-color: var(--color-primary);
+  cursor: pointer;
+}
+
+@media (min-width: 768px) {
+  .pwa-install-modal {
+    max-width: 380px;
+  }
+
+  .pwa-install-modal__actions {
+    flex-direction: row;
+    justify-content: center;
+  }
+
+  .pwa-install-modal__cta {
+    flex: 1;
+  }
+}
+</style>

--- a/frontend/src/composables/usePwaInstall.ts
+++ b/frontend/src/composables/usePwaInstall.ts
@@ -1,0 +1,78 @@
+import { ref, onMounted, onUnmounted } from 'vue'
+
+const STORAGE_KEY = 'garagestack-pwa-install-dismissed'
+
+interface BeforeInstallPromptEvent extends Event {
+  prompt(): Promise<void>
+  readonly userChoice: Promise<{ outcome: 'accepted' | 'dismissed' }>
+}
+
+const promptEvent = ref<BeforeInstallPromptEvent | null>(null)
+const modalVisible = ref(false)
+
+function isInstalled(): boolean {
+  return (
+    window.matchMedia('(display-mode: standalone)').matches ||
+    ('standalone' in window.navigator &&
+      (window.navigator as Navigator & { standalone: boolean }).standalone === true)
+  )
+}
+
+function isDismissedForever(): boolean {
+  try {
+    return localStorage.getItem(STORAGE_KEY) === 'never'
+  } catch {
+    return false
+  }
+}
+
+function onBeforeInstallPrompt(e: Event) {
+  e.preventDefault()
+  if (isInstalled() || isDismissedForever()) return
+  promptEvent.value = e as BeforeInstallPromptEvent
+  modalVisible.value = true
+}
+
+export function usePwaInstall() {
+  onMounted(() => {
+    window.addEventListener('beforeinstallprompt', onBeforeInstallPrompt)
+  })
+
+  onUnmounted(() => {
+    window.removeEventListener('beforeinstallprompt', onBeforeInstallPrompt)
+  })
+
+  async function install() {
+    if (!promptEvent.value) return
+    await promptEvent.value.prompt()
+    const { outcome } = await promptEvent.value.userChoice
+    promptEvent.value = null
+    modalVisible.value = false
+    if (outcome === 'accepted') {
+      try {
+        localStorage.setItem(STORAGE_KEY, 'never')
+      } catch {
+        // ignore
+      }
+    }
+  }
+
+  function dismiss(neverShow: boolean) {
+    modalVisible.value = false
+    promptEvent.value = null
+    if (neverShow) {
+      try {
+        localStorage.setItem(STORAGE_KEY, 'never')
+      } catch {
+        // ignore
+      }
+    }
+  }
+
+  return {
+    modalVisible,
+    canInstall: promptEvent,
+    install,
+    dismiss,
+  }
+}

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -195,6 +195,19 @@
     "heatmap": "Heatmap",
     "findCar": "Find car"
   },
+  "pwa": {
+    "install": {
+      "title": "Install GarageStack",
+      "description": "Add GarageStack to your home screen for the best experience.",
+      "iconAlt": "GarageStack app icon",
+      "featureOffline": "Fast access, even offline",
+      "featureNotifications": "Push notifications for vehicle events",
+      "featureNative": "Full-screen native app feel",
+      "install": "Install app",
+      "notNow": "Not now",
+      "neverShow": "Don't show this again"
+    }
+  },
   "push": {
     "enable": "Enable notifications",
     "enabled": "Notifications on",

--- a/frontend/src/locales/nl.json
+++ b/frontend/src/locales/nl.json
@@ -195,6 +195,19 @@
     "heatmap": "Heatmap",
     "findCar": "Vind auto"
   },
+  "pwa": {
+    "install": {
+      "title": "GarageStack installeren",
+      "description": "Voeg GarageStack toe aan je startscherm voor de beste ervaring.",
+      "iconAlt": "GarageStack app-icoon",
+      "featureOffline": "Snelle toegang, ook offline",
+      "featureNotifications": "Pushmeldingen voor voertuigevents",
+      "featureNative": "Volledig scherm, native app-gevoel",
+      "install": "App installeren",
+      "notNow": "Niet nu",
+      "neverShow": "Niet meer tonen"
+    }
+  },
   "push": {
     "enable": "Meldingen inschakelen",
     "enabled": "Meldingen aan",


### PR DESCRIPTION
## Summary

- Adds `usePwaInstall.ts` composable that captures the browser `beforeinstallprompt` event and suppresses it until the user acts
- Adds `PwaInstallModal.vue` — a themed bottom-sheet/dialog with the app icon, three feature highlights, an Install CTA, and a Not Now button
- A "Don't show this again" checkbox persists the dismiss choice to `localStorage`; the prompt is also suppressed when the app is already running in standalone mode (installed PWA) or on iOS Safari via `navigator.standalone`
- i18n keys added for English and Dutch under `pwa.install.*`
- `PwaInstallModal` mounted in `App.vue`

## Test plan

- [ ] Load the app in a Chromium browser that supports `beforeinstallprompt` — modal should appear
- [ ] Click "Not now" — modal closes, reappears on next page load
- [ ] Tick "Don't show this again" and dismiss — modal never appears again
- [ ] Click "Install app" — native browser install prompt fires, modal closes
- [ ] Open the installed PWA in standalone mode — modal does not appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)