### PR TITLE
Fix mobile layout gap caused by DemoBanner in normal flow

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -112,7 +112,7 @@ watch(
 <template>
   <RouterView v-if="isLoginRoute" />
 
-  <div v-else class="app-layout">
+  <div v-else class="app-layout" :class="{ 'has-demo-banner': isDemoMode }">
     <DemoBanner v-if="isDemoMode" />
 
     <!-- Mobile topbar -->

--- a/frontend/src/assets/main.css
+++ b/frontend/src/assets/main.css
@@ -16,6 +16,7 @@
   --topbar-height: 56px;
   --footer-height: 48px;
   --radius: 10px;
+  --demo-banner-height: 2.2rem;
 }
 
 [data-theme='light'] {
@@ -2085,6 +2086,19 @@ body,
   /* Push body below fixed topbar on mobile */
   .app-body {
     margin-top: var(--topbar-height);
+  }
+
+  /* When demo banner is present, fix it below the topbar and extend the body offset */
+  .demo-banner {
+    position: fixed;
+    top: var(--topbar-height);
+    left: 0;
+    right: 0;
+    z-index: 199;
+  }
+
+  .has-demo-banner .app-body {
+    margin-top: calc(var(--topbar-height) + var(--demo-banner-height));
   }
 
   .sidebar-backdrop {


### PR DESCRIPTION
## Summary
- On mobile, `DemoBanner` was left in normal flex flow while `mobile-topbar` is `position: fixed` (removed from flow), creating a ~35px gap between the topbar and page content
- Added `--demo-banner-height: 2.2rem` CSS variable and made `.demo-banner` `position: fixed` below the topbar on mobile
- Added `.has-demo-banner` class to `app-layout` (via `isDemoMode`) so `app-body` margin-top correctly accounts for both the topbar and banner heights

## Test plan
- [ ] Open app in demo mode on a mobile viewport (e.g. iPhone SE in Chrome DevTools)
- [ ] Confirm no extra gap between topbar and page content
- [ ] Confirm demo banner is visible just below the topbar
- [ ] Check non-demo mode on mobile is unaffected
- [ ] Check desktop layout in both demo and non-demo mode is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)