### PR TITLE
Fix status card label truncation (flex:1 missing on card body)

### DIFF
--- a/frontend/src/assets/main.css
+++ b/frontend/src/assets/main.css
@@ -354,6 +354,7 @@ body,
   display: flex;
   flex-direction: column;
   gap: 0.2rem;
+  flex: 1;
   min-width: 0;
   overflow: hidden;
 }


### PR DESCRIPTION
## Summary
- `.status-card__body` was missing `flex: 1`, causing it to grow to match its content width (long labels like "Climate control") instead of being bounded by the card
- `white-space: nowrap; overflow: hidden; text-overflow: ellipsis` were already set on `.status-card__label` and `.status-card__value`, but had no effect because the parent had no width constraint
- Adding `flex: 1` forces the body to fill available space within the card, making ellipsis truncation work as intended

## Test plan
- [ ] Confirm long labels like "Climate control", "Today's distance" etc. now truncate with ellipsis instead of stretching the card
- [ ] Check on mobile (2-column grid) and desktop grids
- [ ] Confirm the card layout (icon + body + optional chevron) still aligns correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)