### PR TITLE
Fix invalid dependency-graph permission in dependency submission workflow

### DIFF
--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -5,8 +5,7 @@ on:
     branches: [main]
 
 permissions:
-  contents: read
-  dependency-graph: write
+  contents: write
 
 jobs:
   dotnet:


### PR DESCRIPTION
## Summary
- Replace the non-existent `dependency-graph: write` permission with `contents: write`
- `dependency-graph` is not a valid GitHub Actions permission key, causing the workflow to fail validation
- `contents: write` is the correct permission required by the dependency submission actions to post snapshots

## Test plan
- [ ] Confirm the workflow file passes GitHub Actions validation on push to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)