### PR TITLE
fix: show PWA install/not-now buttons side by side on mobile

### DIFF
--- a/frontend/src/components/PwaInstallModal.vue
+++ b/frontend/src/components/PwaInstallModal.vue
@@ -128,7 +128,8 @@ function onDismiss() {
 
 .pwa-install-modal__actions {
   display: flex;
-  flex-direction: column;
+  flex-direction: row;
+  justify-content: center;
   gap: 0.6rem;
 }
 
@@ -159,11 +160,6 @@ function onDismiss() {
 @media (min-width: 768px) {
   .pwa-install-modal {
     max-width: 380px;
-  }
-
-  .pwa-install-modal__actions {
-    flex-direction: row;
-    justify-content: center;
   }
 
   .pwa-install-modal__cta {


### PR DESCRIPTION
## Summary
- Changed `.pwa-install-modal__actions` from `flex-direction: column` to `row` so both buttons sit on the same line on all screen sizes
- Removed the redundant `flex-direction: row` override from the `@media (min-width: 768px)` block

## Test plan
- [ ] Open the PWA install modal on a mobile viewport and confirm both buttons appear side by side
- [ ] Confirm layout still looks correct on desktop

🤖 Generated with [Claude Code](https://claude.com/claude-code)