### PR TITLE
refactor: remove manual fetchStatus calls from footer refresh button

### DIFF
--- a/frontend/src/components/AppFooter.vue
+++ b/frontend/src/components/AppFooter.vue
@@ -50,11 +50,9 @@ const isNL = computed({
   },
 })
 
-async function refresh() {
+function refresh() {
   if (!vin.value) return
   send(vin.value, 'refresh', 'force')
-  await vehicleStore.fetchStatus(vin.value)
-  setTimeout(() => vehicleStore.fetchStatus(vin.value!), 4000)
 }
 </script>
 


### PR DESCRIPTION
## Summary

- The footer's refresh button previously called `fetchStatus` immediately after sending the force-refresh MQTT command, then again 4 seconds later via `setTimeout`, to manually poll for the car's response
- With SignalR in place (PR #113), the car's MQTT response automatically flows through `pg_notify` → `TelemetryNotificationService` → SignalR broadcast → Pinia store, making both calls redundant
- The button itself is kept — it still sends the `refresh/force` MQTT command to the car, which is the only way to trigger an immediate poll rather than waiting for the car's natural cycle

## Test plan

- [ ] Click the refresh button and confirm the dashboard/sidebar data still updates after the car responds (via SignalR broadcast)
- [ ] Confirm the button shows the spinner while the MQTT command is in flight (`sending === 'refresh'`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)