### PR TITLE
refactor: use SignalR telemetry to auto-confirm vehicle commands

### DIFF
--- a/frontend/src/components/ClimateDetailCard.vue
+++ b/frontend/src/components/ClimateDetailCard.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, watch, ref } from 'vue'
+import { computed, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 import StatusCard from './StatusCard.vue'
 import DetailModal from './DetailModal.vue'
@@ -20,7 +20,7 @@ const props = defineProps<{
 }>()
 
 const { isOpen: modalOpen, open: openModal, close: closeModal } = useModal()
-const { sending, lastResult, isPending, clearPending, send } = useVehicleCommand()
+const { sending, lastResult, isPending, send } = useVehicleCommand()
 
 const TEMP_MIN = 16
 const TEMP_MAX = 28
@@ -36,15 +36,6 @@ const seatLabels = computed(() => [
 
 const seatLeftLocal = ref<number>(props.heatedSeatFrontLeft ?? 0)
 const seatRightLocal = ref<number>(props.heatedSeatFrontRight ?? 0)
-
-watch(
-  () => props.climateOn,
-  () => clearPending('climate'),
-)
-watch(
-  () => props.rearWindowDefroster,
-  () => clearPending('rear-defroster'),
-)
 
 function onSeatChange(side: 'seat-left' | 'seat-right', e: Event) {
   const val = Number((e.target as HTMLInputElement).value)
@@ -74,12 +65,19 @@ const hasAnyData = computed(
 
 function handleClimateToggle() {
   if (isPending('climate')) return
-  send(props.vin, 'climate', props.climateOn ? 'off' : 'on')
+  const newValue = !props.climateOn
+  send(props.vin, 'climate', newValue ? 'on' : 'off', (s) => s.climateOn === newValue)
 }
 
 function handleDefrostToggle() {
   if (isPending('rear-defroster')) return
-  send(props.vin, 'rear-defroster', props.rearWindowDefroster ? 'off' : 'on')
+  const newValue = !props.rearWindowDefroster
+  send(
+    props.vin,
+    'rear-defroster',
+    newValue ? 'on' : 'off',
+    (s) => s.rearWindowDefroster === newValue,
+  )
 }
 
 function applyTemperature() {

--- a/frontend/src/components/DoorsCard.vue
+++ b/frontend/src/components/DoorsCard.vue
@@ -20,7 +20,7 @@ const props = defineProps<{
 }>()
 
 const { isOpen: modalOpen, open: openModal, close: closeModal } = useModal()
-const { sending, lastResult, isPending, clearPending, send } = useVehicleCommand()
+const { sending, lastResult, isPending, send } = useVehicleCommand()
 
 const localLocked = ref<boolean | null>(null)
 const effectiveLocked = computed(() => localLocked.value ?? props.isLocked)
@@ -29,7 +29,6 @@ watch(
   () => props.isLocked,
   () => {
     localLocked.value = null
-    clearPending('lock')
   },
 )
 
@@ -102,7 +101,7 @@ const variant = computed(() => {
 async function handleLockToggle() {
   if (isPending('lock')) return
   const newLocked = !effectiveLocked.value
-  await send(props.vin, 'lock', newLocked ? 'True' : 'False')
+  await send(props.vin, 'lock', newLocked ? 'True' : 'False', (s) => s.isLocked === newLocked)
   if (lastResult.value?.ok) localLocked.value = newLocked
 }
 </script>

--- a/frontend/src/composables/__tests__/useVehicleCommand.spec.ts
+++ b/frontend/src/composables/__tests__/useVehicleCommand.spec.ts
@@ -84,6 +84,13 @@ function makeSnapshot(overrides: Partial<TelemetrySnapshot> = {}): TelemetrySnap
     batteryHeatingScheduleStartTime: null,
     elevation: null,
     bmsChargeStatus: null,
+    lastChargeEndingPower: null,
+    chargingLastEndAt: null,
+    chargingScheduleMode: null,
+    chargingScheduleStartTime: null,
+    chargingScheduleEndTime: null,
+    onboardChargerPlugStatus: null,
+    offboardChargerPlugStatus: null,
     ...overrides,
   }
 }
@@ -271,7 +278,7 @@ describe('useVehicleCommand', () => {
       sendCommandMock.mockResolvedValue(undefined)
       const store = useVehicleStore()
       const { send } = useVehicleCommand()
-      const onConfirmed = vi.fn()
+      const onConfirmed = vi.fn<() => void>()
 
       await send('VIN1', 'lock', 'True', (s) => s.isLocked === true, onConfirmed)
 
@@ -285,7 +292,7 @@ describe('useVehicleCommand', () => {
       sendCommandMock.mockResolvedValue(undefined)
       const store = useVehicleStore()
       const { send } = useVehicleCommand()
-      const onConfirmed = vi.fn()
+      const onConfirmed = vi.fn<() => void>()
 
       await send('VIN1', 'lock', 'True', (s) => s.isLocked === true, onConfirmed)
 

--- a/frontend/src/composables/__tests__/useVehicleCommand.spec.ts
+++ b/frontend/src/composables/__tests__/useVehicleCommand.spec.ts
@@ -1,6 +1,10 @@
 import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest'
+import { nextTick } from 'vue'
+import { setActivePinia, createPinia } from 'pinia'
 import { vehicleApi } from '@/services/api'
+import type { TelemetrySnapshot } from '@/services/api'
 import { useVehicleCommand } from '@/composables/useVehicleCommand'
+import { useVehicleStore } from '@/stores/vehicle'
 
 vi.mock('@/services/api', () => ({
   vehicleApi: {
@@ -11,8 +15,82 @@ vi.mock('@/services/api', () => ({
 // Typed reference to the mock after hoisting is resolved
 const sendCommandMock = vi.mocked(vehicleApi.sendCommand)
 
+function makeSnapshot(overrides: Partial<TelemetrySnapshot> = {}): TelemetrySnapshot {
+  return {
+    id: 1,
+    vehicleId: 1,
+    recordedAt: new Date().toISOString(),
+    fuelLevelPercent: null,
+    fuelRangeKm: null,
+    odometerKm: null,
+    isLocked: null,
+    engineRunning: null,
+    climateOn: null,
+    driverDoorOpen: null,
+    passengerDoorOpen: null,
+    rearLeftDoorOpen: null,
+    rearRightDoorOpen: null,
+    trunkOpen: null,
+    bonnetOpen: null,
+    driverWindowOpen: null,
+    passengerWindowOpen: null,
+    rearLeftWindowOpen: null,
+    rearRightWindowOpen: null,
+    latitude: null,
+    longitude: null,
+    speed: null,
+    heading: null,
+    batteryVoltage: null,
+    interiorTemperature: null,
+    exteriorTemperature: null,
+    evSocPercent: null,
+    isCharging: null,
+    sunRoofOpen: null,
+    tyrePressureFrontLeft: null,
+    tyrePressureFrontRight: null,
+    tyrePressureRearLeft: null,
+    tyrePressureRearRight: null,
+    mileageOfTheDay: null,
+    powerUsageOfDay: null,
+    mileageSinceLastCharge: null,
+    hvVoltage: null,
+    hvCurrent: null,
+    hvPower: null,
+    hvSocKwh: null,
+    hvTotalCapacityKwh: null,
+    powerUsageSinceLastCharge: null,
+    chargerConnected: null,
+    hvBatteryActive: null,
+    lightsMainBeam: null,
+    lightsDippedBeam: null,
+    lightsSide: null,
+    remoteTemperature: null,
+    heatedSeatFrontLeft: null,
+    heatedSeatFrontRight: null,
+    rearWindowDefroster: null,
+    isAvailable: null,
+    lastVehicleStateAt: null,
+    lastChargeStateAt: null,
+    currentJourneyDistance: null,
+    chargingType: null,
+    chargingCableLock: null,
+    remainingChargingTime: null,
+    obcCurrent: null,
+    obcVoltage: null,
+    obcPowerSinglePhase: null,
+    obcPowerThreePhase: null,
+    batteryHeating: null,
+    batteryHeatingScheduleMode: null,
+    batteryHeatingScheduleStartTime: null,
+    elevation: null,
+    bmsChargeStatus: null,
+    ...overrides,
+  }
+}
+
 describe('useVehicleCommand', () => {
   beforeEach(() => {
+    setActivePinia(createPinia())
     sendCommandMock.mockReset()
     vi.useFakeTimers()
   })
@@ -158,5 +236,74 @@ describe('useVehicleCommand', () => {
     clearPending('lock')
     await send('VIN1', 'lock', 'False')
     expect(sendCommandMock).toHaveBeenCalledTimes(2)
+  })
+
+  describe('isConfirmed', () => {
+    it('clears pending when isConfirmed returns true on telemetry update', async () => {
+      sendCommandMock.mockResolvedValue(undefined)
+      const store = useVehicleStore()
+      const { send, isPending } = useVehicleCommand()
+
+      await send('VIN1', 'lock', 'True', (s) => s.isLocked === true)
+      expect(isPending('lock')).toBe(true)
+
+      store.applyLiveStatus(makeSnapshot({ isLocked: true }))
+      await nextTick()
+
+      expect(isPending('lock')).toBe(false)
+    })
+
+    it('does not clear pending when isConfirmed returns false', async () => {
+      sendCommandMock.mockResolvedValue(undefined)
+      const store = useVehicleStore()
+      const { send, isPending } = useVehicleCommand()
+
+      await send('VIN1', 'lock', 'True', (s) => s.isLocked === true)
+      expect(isPending('lock')).toBe(true)
+
+      store.applyLiveStatus(makeSnapshot({ isLocked: false }))
+      await nextTick()
+
+      expect(isPending('lock')).toBe(true)
+    })
+
+    it('calls onConfirmed when isConfirmed returns true', async () => {
+      sendCommandMock.mockResolvedValue(undefined)
+      const store = useVehicleStore()
+      const { send } = useVehicleCommand()
+      const onConfirmed = vi.fn()
+
+      await send('VIN1', 'lock', 'True', (s) => s.isLocked === true, onConfirmed)
+
+      store.applyLiveStatus(makeSnapshot({ isLocked: true }))
+      await nextTick()
+
+      expect(onConfirmed).toHaveBeenCalledTimes(1)
+    })
+
+    it('does not call onConfirmed when isConfirmed returns false', async () => {
+      sendCommandMock.mockResolvedValue(undefined)
+      const store = useVehicleStore()
+      const { send } = useVehicleCommand()
+      const onConfirmed = vi.fn()
+
+      await send('VIN1', 'lock', 'True', (s) => s.isLocked === true, onConfirmed)
+
+      store.applyLiveStatus(makeSnapshot({ isLocked: false }))
+      await nextTick()
+
+      expect(onConfirmed).not.toHaveBeenCalled()
+    })
+
+    it('still clears pending via timeout when isConfirmed is provided', async () => {
+      sendCommandMock.mockResolvedValue(undefined)
+      const { send, isPending } = useVehicleCommand()
+
+      await send('VIN1', 'lock', 'True', (s) => s.isLocked === true)
+      expect(isPending('lock')).toBe(true)
+
+      vi.advanceTimersByTime(30_000)
+      expect(isPending('lock')).toBe(false)
+    })
   })
 })

--- a/frontend/src/composables/useVehicleCommand.ts
+++ b/frontend/src/composables/useVehicleCommand.ts
@@ -1,13 +1,16 @@
-import { ref } from 'vue'
-import { vehicleApi } from '@/services/api'
+import { ref, watch, getCurrentInstance, onUnmounted } from 'vue'
+import { vehicleApi, type TelemetrySnapshot } from '@/services/api'
+import { useVehicleStore } from '@/stores/vehicle'
 
 const PENDING_TIMEOUT_MS = 30_000
 
 export function useVehicleCommand() {
+  const store = useVehicleStore()
   const sending = ref<string | null>(null)
   const lastResult = ref<{ key: string; ok: boolean } | null>(null)
   const pendingSet = ref<Record<string, boolean>>({})
   const timers = new Map<string, ReturnType<typeof setTimeout>>()
+  const watchers = new Map<string, () => void>()
 
   function isPending(key: string): boolean {
     return !!pendingSet.value[key]
@@ -19,16 +22,32 @@ export function useVehicleCommand() {
       clearTimeout(t)
       timers.delete(key)
     }
+    const stopWatcher = watchers.get(key)
+    if (stopWatcher) {
+      stopWatcher()
+      watchers.delete(key)
+    }
     if (key in pendingSet.value) {
       const { [key]: _, ...rest } = pendingSet.value
       pendingSet.value = rest
     }
   }
 
+  if (getCurrentInstance()) {
+    onUnmounted(() => {
+      timers.forEach((t) => clearTimeout(t))
+      timers.clear()
+      watchers.forEach((stop) => stop())
+      watchers.clear()
+    })
+  }
+
   async function send(
     vin: string | null | undefined,
     command: string,
     value: string,
+    isConfirmed?: (snapshot: TelemetrySnapshot) => boolean,
+    onConfirmed?: () => void,
   ): Promise<boolean> {
     if (!vin || isPending(command)) return false
     sending.value = command
@@ -41,6 +60,18 @@ export function useVehicleCommand() {
         command,
         setTimeout(() => clearPending(command), PENDING_TIMEOUT_MS),
       )
+      if (isConfirmed) {
+        const stopWatch = watch(
+          () => store.currentStatus,
+          (snapshot) => {
+            if (snapshot && isConfirmed(snapshot)) {
+              clearPending(command)
+              onConfirmed?.()
+            }
+          },
+        )
+        watchers.set(command, stopWatch)
+      }
       return true
     } catch {
       lastResult.value = { key: command, ok: false }


### PR DESCRIPTION
## Summary

- `useVehicleCommand.send()` now accepts an optional `isConfirmed` predicate and `onConfirmed` callback. When provided, a watcher on `store.currentStatus` auto-clears the pending state as soon as a SignalR telemetry update satisfies the predicate — no polling, no manual `clearPending` calls in components.
- Removed the scattered prop-watcher `clearPending` calls from `DoorsCard` and `ClimateDetailCard`. `DoorsCard` keeps its prop watcher solely to reset the optimistic `localLocked` value when real telemetry arrives.
- Watchers are stopped when `clearPending` fires (manual or timeout) and on component unmount, so there are no leaks.
- Added 5 new unit tests covering the `isConfirmed` confirmation path, timeout fallback, and `onConfirmed` callback.

## Test plan

- [ ] All 133 unit tests pass (`pnpm exec vitest run`)
- [ ] Lock/unlock a door — pending spinner clears as soon as the vehicle confirms (not after 30 s timeout)
- [ ] Toggle climate / rear defroster — same behaviour
- [ ] Kill the MG API mid-command — pending state still clears after the 30 s timeout fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)