### PR TITLE
feat: batch climate controls with single Apply button

### DIFF
--- a/frontend/src/components/ClimateDetailCard.vue
+++ b/frontend/src/components/ClimateDetailCard.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, ref } from 'vue'
+import { computed, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import StatusCard from './StatusCard.vue'
 import DetailModal from './DetailModal.vue'
@@ -26,8 +26,6 @@ const { sending, lastResult, isPending, send } = useVehicleCommand()
 const TEMP_MIN = 16
 const TEMP_MAX = 28
 
-const sliderTemp = ref<number>(props.remoteTemperature ?? 22)
-
 const seatLabels = computed(() => [
   t('control.seat.off'),
   t('control.seat.low'),
@@ -35,15 +33,23 @@ const seatLabels = computed(() => [
   t('control.seat.high'),
 ])
 
+const localClimateOn = ref<boolean | null>(props.climateOn)
+const localRearDefroster = ref<boolean | null>(props.rearWindowDefroster)
+const localSteeringWheel = ref<boolean | null>(props.steeringWheelHeating)
+const sliderTemp = ref<number>(props.remoteTemperature ?? 22)
 const seatLeftLocal = ref<number>(props.heatedSeatFrontLeft ?? 0)
 const seatRightLocal = ref<number>(props.heatedSeatFrontRight ?? 0)
 
-function onSeatChange(side: 'seat-left' | 'seat-right', e: Event) {
-  const val = Number((e.target as HTMLInputElement).value)
-  if (side === 'seat-left') seatLeftLocal.value = val
-  else seatRightLocal.value = val
-  send(props.vin, side, String(val))
-}
+watch(modalOpen, (open) => {
+  if (open) {
+    localClimateOn.value = props.climateOn
+    localRearDefroster.value = props.rearWindowDefroster
+    localSteeringWheel.value = props.steeringWheelHeating
+    sliderTemp.value = props.remoteTemperature ?? 22
+    seatLeftLocal.value = props.heatedSeatFrontLeft ?? 0
+    seatRightLocal.value = props.heatedSeatFrontRight ?? 0
+  }
+})
 
 const summaryValue = computed((): string | null => {
   const parts: string[] = []
@@ -65,44 +71,88 @@ const hasAnyData = computed(
     props.steeringWheelHeating !== null,
 )
 
-function handleClimateToggle() {
-  if (isPending('climate')) return
-  const newValue = !props.climateOn
-  send(props.vin, 'climate', newValue ? 'on' : 'off', (s) => s.climateOn === newValue)
-}
+const commandKeys = [
+  'climate',
+  'rear-defroster',
+  'steering-wheel',
+  'climate-temperature',
+  'seat-left',
+  'seat-right',
+] as const
 
-function handleDefrostToggle() {
-  if (isPending('rear-defroster')) return
-  const newValue = !props.rearWindowDefroster
-  send(
-    props.vin,
-    'rear-defroster',
-    newValue ? 'on' : 'off',
-    (s) => s.rearWindowDefroster === newValue,
+const anyPending = computed(() => commandKeys.some((k) => isPending(k)))
+const isApplying = computed(() => anyPending.value || commandKeys.some((k) => sending.value === k))
+
+const hasPendingChanges = computed(() => {
+  if (props.climateOn !== null && localClimateOn.value !== props.climateOn) return true
+  if (props.rearWindowDefroster !== null && localRearDefroster.value !== props.rearWindowDefroster)
+    return true
+  if (
+    props.steeringWheelHeating !== null &&
+    localSteeringWheel.value !== props.steeringWheelHeating
   )
-}
-
-function handleSteeringWheelToggle() {
-  if (isPending('steering-wheel')) return
-  const newValue = !props.steeringWheelHeating
-  send(
-    props.vin,
-    'steering-wheel',
-    newValue ? 'on' : 'off',
-    (s) => s.steeringWheelHeating === newValue,
+    return true
+  if (
+    (props.climateOn !== null || props.remoteTemperature !== null) &&
+    sliderTemp.value !== (props.remoteTemperature ?? 22)
   )
-}
+    return true
+  if (props.heatedSeatFrontLeft !== null && seatLeftLocal.value !== props.heatedSeatFrontLeft)
+    return true
+  if (props.heatedSeatFrontRight !== null && seatRightLocal.value !== props.heatedSeatFrontRight)
+    return true
+  return false
+})
 
-function applyTemperature() {
-  send(props.vin, 'climate-temperature', String(sliderTemp.value))
+async function applyAll() {
+  if (props.climateOn !== null && localClimateOn.value !== props.climateOn) {
+    const target = localClimateOn.value
+    await send(props.vin, 'climate', target ? 'on' : 'off', (s) => s.climateOn === target)
+  }
+  if (
+    props.rearWindowDefroster !== null &&
+    localRearDefroster.value !== props.rearWindowDefroster
+  ) {
+    const target = localRearDefroster.value
+    await send(
+      props.vin,
+      'rear-defroster',
+      target ? 'on' : 'off',
+      (s) => s.rearWindowDefroster === target,
+    )
+  }
+  if (
+    props.steeringWheelHeating !== null &&
+    localSteeringWheel.value !== props.steeringWheelHeating
+  ) {
+    const target = localSteeringWheel.value
+    await send(
+      props.vin,
+      'steering-wheel',
+      target ? 'on' : 'off',
+      (s) => s.steeringWheelHeating === target,
+    )
+  }
+  if (
+    (props.climateOn !== null || props.remoteTemperature !== null) &&
+    sliderTemp.value !== (props.remoteTemperature ?? 22)
+  ) {
+    await send(props.vin, 'climate-temperature', String(sliderTemp.value))
+  }
+  if (props.heatedSeatFrontLeft !== null && seatLeftLocal.value !== props.heatedSeatFrontLeft) {
+    await send(props.vin, 'seat-left', String(seatLeftLocal.value))
+  }
+  if (props.heatedSeatFrontRight !== null && seatRightLocal.value !== props.heatedSeatFrontRight) {
+    await send(props.vin, 'seat-right', String(seatRightLocal.value))
+  }
 }
 
 function onSeatLeftChange(e: Event) {
-  onSeatChange('seat-left', e)
+  seatLeftLocal.value = Number((e.target as HTMLInputElement).value)
 }
 
 function onSeatRightChange(e: Event) {
-  onSeatChange('seat-right', e)
+  seatRightLocal.value = Number((e.target as HTMLInputElement).value)
 }
 </script>
 
@@ -138,23 +188,9 @@ function onSeatRightChange(e: Event) {
               :min="TEMP_MIN"
               :max="TEMP_MAX"
               step="1"
-              :disabled="
-                sending === 'climate-temperature' || isPending('climate-temperature') || !vin
-              "
+              :disabled="isApplying || !vin"
             />
             <span>{{ TEMP_MAX }}°</span>
-            <button
-              class="btn btn-primary btn-sm"
-              :class="isPending('climate-temperature') ? 'btn--pending' : ''"
-              :disabled="
-                sending === 'climate-temperature' || isPending('climate-temperature') || !vin
-              "
-              @click="applyTemperature"
-            >
-              <font-awesome-icon v-if="sending === 'climate-temperature'" icon="spinner" spin />
-              <font-awesome-icon v-else-if="isPending('climate-temperature')" icon="clock" />
-              <font-awesome-icon v-else icon="check" />
-            </button>
           </div>
         </div>
       </div>
@@ -168,21 +204,11 @@ function onSeatRightChange(e: Event) {
             class="form-check-input"
             type="checkbox"
             role="switch"
-            :checked="climateOn"
-            :disabled="sending === 'climate' || isPending('climate') || !vin"
-            @change="handleClimateToggle"
+            :checked="localClimateOn ?? false"
+            :disabled="isApplying || !vin"
+            @change="localClimateOn = !localClimateOn"
           />
         </div>
-      </div>
-      <div v-if="isPending('climate')" class="detail-list__feedback text-info">
-        <font-awesome-icon icon="clock" />
-        {{ t('control.pending') }}
-      </div>
-      <div
-        v-else-if="lastResult?.key === 'climate' && !lastResult.ok"
-        class="detail-list__feedback text-danger"
-      >
-        {{ t('control.error') }}
       </div>
 
       <!-- Rear defroster toggle -->
@@ -194,21 +220,11 @@ function onSeatRightChange(e: Event) {
             class="form-check-input"
             type="checkbox"
             role="switch"
-            :checked="rearWindowDefroster"
-            :disabled="sending === 'rear-defroster' || isPending('rear-defroster') || !vin"
-            @change="handleDefrostToggle"
+            :checked="localRearDefroster ?? false"
+            :disabled="isApplying || !vin"
+            @change="localRearDefroster = !localRearDefroster"
           />
         </div>
-      </div>
-      <div v-if="isPending('rear-defroster')" class="detail-list__feedback text-info">
-        <font-awesome-icon icon="clock" />
-        {{ t('control.pending') }}
-      </div>
-      <div
-        v-else-if="lastResult?.key === 'rear-defroster' && !lastResult.ok"
-        class="detail-list__feedback text-danger"
-      >
-        {{ t('control.error') }}
       </div>
 
       <!-- Steering wheel heating toggle -->
@@ -223,21 +239,11 @@ function onSeatRightChange(e: Event) {
             class="form-check-input"
             type="checkbox"
             role="switch"
-            :checked="steeringWheelHeating"
-            :disabled="sending === 'steering-wheel' || isPending('steering-wheel') || !vin"
-            @change="handleSteeringWheelToggle"
+            :checked="localSteeringWheel ?? false"
+            :disabled="isApplying || !vin"
+            @change="localSteeringWheel = !localSteeringWheel"
           />
         </div>
-      </div>
-      <div v-if="isPending('steering-wheel')" class="detail-list__feedback text-info">
-        <font-awesome-icon icon="clock" />
-        {{ t('control.pending') }}
-      </div>
-      <div
-        v-else-if="lastResult?.key === 'steering-wheel' && !lastResult.ok"
-        class="detail-list__feedback text-danger"
-      >
-        {{ t('control.error') }}
       </div>
 
       <!-- Interior temperature (read-only) -->
@@ -271,7 +277,7 @@ function onSeatRightChange(e: Event) {
               max="3"
               step="1"
               :value="seatLeftLocal"
-              :disabled="sending === 'seat-left' || isPending('seat-left') || !vin"
+              :disabled="isApplying || !vin"
               @change="onSeatLeftChange"
             />
           </div>
@@ -296,7 +302,7 @@ function onSeatRightChange(e: Event) {
               max="3"
               step="1"
               :value="seatRightLocal"
-              :disabled="sending === 'seat-right' || isPending('seat-right') || !vin"
+              :disabled="isApplying || !vin"
               @change="onSeatRightChange"
             />
           </div>
@@ -305,19 +311,31 @@ function onSeatRightChange(e: Event) {
           </div>
         </div>
       </div>
-
-      <!-- General error fallback -->
-      <div
-        v-if="
-          lastResult &&
-          !lastResult.ok &&
-          !['climate', 'rear-defroster', 'steering-wheel'].includes(lastResult.key)
-        "
-        class="detail-list__feedback text-danger"
-      >
-        {{ t('control.error') }}
-      </div>
     </div>
+
+    <template #footer>
+      <span v-if="anyPending" class="text-info me-auto">
+        <font-awesome-icon icon="clock" />
+        {{ t('control.pending') }}
+      </span>
+      <span v-else-if="lastResult && !lastResult.ok" class="text-danger me-auto">
+        {{ t('control.error') }}
+      </span>
+      <button class="btn btn-outline-secondary" @click="closeModal">
+        {{ t('common.cancel') }}
+      </button>
+      <button
+        class="btn btn-primary"
+        :class="anyPending ? 'btn--pending' : ''"
+        :disabled="isApplying || !vin || !hasPendingChanges"
+        @click="applyAll"
+      >
+        <font-awesome-icon v-if="isApplying" icon="spinner" spin />
+        <font-awesome-icon v-else-if="anyPending" icon="clock" />
+        <font-awesome-icon v-else icon="check" />
+        {{ anyPending ? t('control.pending') : t('common.apply') }}
+      </button>
+    </template>
   </DetailModal>
 </template>
 

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -318,6 +318,7 @@
     "open": "Open",
     "closed": "Closed",
     "cancel": "Cancel",
+    "apply": "Apply",
     "confirm": "Confirm",
     "filters": "Filters",
     "online": "Online",

--- a/frontend/src/locales/nl.json
+++ b/frontend/src/locales/nl.json
@@ -318,6 +318,7 @@
     "open": "Open",
     "closed": "Gesloten",
     "cancel": "Annuleren",
+    "apply": "Toepassen",
     "confirm": "Bevestigen",
     "filters": "Filters",
     "online": "Online",


### PR DESCRIPTION
## Summary

- All climate controls (AC toggle, rear defroster, steering wheel heating, temperature slider, seat heaters) now update local state only -- no commands fire on individual change
- A single **Apply** button in the modal footer sends only the controls whose values actually changed, sequentially
- Pending/error feedback ("Sent - waiting for car...") moved from per-control inline rows to the modal footer, matching the Find My Car pattern
- Apply button is disabled until there are unsaved changes and re-disabled while any command is in-flight or pending car confirmation
- Local state resets to current prop values each time the modal is opened
- Added `common.apply` i18n key (EN: "Apply", NL: "Toepassen")

## Test plan

- [ ] Open climate modal -- Apply button should be disabled (no changes yet)
- [ ] Toggle AC on/off -- Apply button enables, no command sent yet
- [ ] Click Apply -- spinner shows, then "Sent - waiting for car..." appears in footer
- [ ] Adjust multiple controls (temp + seat level) then Apply -- all changed values sent sequentially
- [ ] Close and reopen modal -- local state resets to current car values
- [ ] Error case (no VIN / network failure) -- error shown in footer

🤖 Generated with [Claude Code](https://claude.com/claude-code)