### PR TITLE
feat: skeleton loaders and sticky paginator header for trip sidebar

### DIFF
--- a/frontend/src/assets/main.css
+++ b/frontend/src/assets/main.css
@@ -1115,11 +1115,25 @@ body,
   background: var(--color-surface);
   border: 1px solid var(--color-border);
   border-radius: var(--radius);
-  padding: 1rem;
+  padding: 0 1rem 1rem;
   overflow-y: auto;
   display: flex;
   flex-direction: column;
   gap: 0.75rem;
+}
+
+.trip-sidebar__header {
+  position: sticky;
+  top: 0;
+  z-index: 1;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  margin: 0 -1rem;
+  padding: 1rem 1rem 0.75rem;
+  background: var(--color-surface);
+  border-bottom: 1px solid var(--color-border);
 }
 
 .trip-sidebar__title {
@@ -1240,6 +1254,12 @@ body,
   border-bottom: 1px solid var(--color-border);
   padding-top: 0;
   padding-bottom: 0.25rem;
+}
+
+.paginator--inline {
+  border-top: none;
+  border-bottom: none;
+  padding: 0;
 }
 
 .paginator__btn {
@@ -1997,6 +2017,12 @@ body,
 
 .skeleton--text-lg {
   max-width: 78%;
+}
+
+.skeleton--trip-time {
+  width: 3rem;
+  height: 1.2em;
+  flex-shrink: 0;
 }
 
 /* ── App footer ───────────────────────────────────────────── */

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -194,7 +194,8 @@
     "last30days": "Last 30 days",
     "last90days": "Last 90 days",
     "heatmap": "Heatmap",
-    "findCar": "Find car"
+    "findCar": "Find car",
+    "points": "pts"
   },
   "pwa": {
     "install": {

--- a/frontend/src/locales/nl.json
+++ b/frontend/src/locales/nl.json
@@ -194,7 +194,8 @@
     "last30days": "Afgelopen 30 dagen",
     "last90days": "Afgelopen 90 dagen",
     "heatmap": "Heatmap",
-    "findCar": "Vind auto"
+    "findCar": "Vind auto",
+    "points": "ptn"
   },
   "pwa": {
     "install": {

--- a/frontend/src/views/MapView.vue
+++ b/frontend/src/views/MapView.vue
@@ -459,8 +459,8 @@ onUnmounted(() => {
               </div>
               <span class="trip-list__meta">
                 {{ trip.distanceKm }} {{ t('common.km') }} &middot;
-                {{ formatDuration(trip.startedAt, trip.endedAt) }} &middot;
-                {{ trip.pointCount }}
+                {{ formatDuration(trip.startedAt, trip.endedAt) }} &middot; {{ trip.pointCount }}
+                {{ t('trips.points') }}
               </span>
             </div>
           </li>

--- a/frontend/src/views/MapView.vue
+++ b/frontend/src/views/MapView.vue
@@ -404,61 +404,67 @@ onUnmounted(() => {
     <div class="map-layout">
       <!-- Trip sidebar -->
       <aside ref="tripSidebarRef" class="trip-sidebar">
-        <h3 class="trip-sidebar__title">{{ t('trips.title') }}</h3>
+        <div class="trip-sidebar__header">
+          <h3 class="trip-sidebar__title">{{ t('trips.title') }}</h3>
+          <AppPaginator
+            v-if="!store.loading && totalPages > 1"
+            v-model="tripsPage"
+            :total-pages="totalPages"
+            class="paginator--inline"
+          />
+        </div>
 
-        <div v-if="store.loading" class="loading-state">
-          <font-awesome-icon icon="spinner" spin />
+        <div v-if="store.loading" class="trip-list">
+          <div v-for="i in PAGE_SIZE" :key="i" class="trip-list__item">
+            <span class="trip-list__dot skeleton" />
+            <div class="trip-list__info">
+              <div class="trip-list__header">
+                <span class="skeleton skeleton--text skeleton--text-lg" />
+                <span class="skeleton skeleton--trip-time" />
+              </div>
+              <span class="skeleton skeleton--text skeleton--text-md" />
+            </div>
+          </div>
         </div>
 
         <div v-else-if="!store.trips.length" class="empty-state text-sm">
           {{ t('trips.noTrips') }}
         </div>
 
-        <template v-else>
-          <AppPaginator
-            v-if="totalPages > 1"
-            v-model="tripsPage"
-            :total-pages="totalPages"
-            class="paginator--top"
-          />
-
-          <ul class="trip-list">
-            <li
-              v-for="(trip, displayIdx) in displayTrips"
-              :key="pageOffset + displayIdx"
-              class="trip-list__item"
-              :class="{
-                'trip-list__item--active': selectedTripIndex === realIndex(pageOffset + displayIdx),
-              }"
-              @click="selectTrip(realIndex(pageOffset + displayIdx))"
-            >
-              <span
-                class="trip-list__dot"
-                :class="tripColorClass(realIndex(pageOffset + displayIdx))"
-              />
-              <div class="trip-list__info">
-                <div class="trip-list__header">
-                  <span class="trip-list__name">{{
-                    new Date(trip.startedAt).toLocaleDateString(displayLocale)
-                  }}</span>
-                  <span class="trip-list__time">{{
-                    new Date(trip.startedAt).toLocaleTimeString(displayLocale, {
-                      hour: '2-digit',
-                      minute: '2-digit',
-                    })
-                  }}</span>
-                </div>
-                <span class="trip-list__meta">
-                  {{ trip.distanceKm }} {{ t('common.km') }} &middot;
-                  {{ formatDuration(trip.startedAt, trip.endedAt) }} &middot;
-                  {{ trip.pointCount }}
-                </span>
+        <ul v-else class="trip-list">
+          <li
+            v-for="(trip, displayIdx) in displayTrips"
+            :key="pageOffset + displayIdx"
+            class="trip-list__item"
+            :class="{
+              'trip-list__item--active': selectedTripIndex === realIndex(pageOffset + displayIdx),
+            }"
+            @click="selectTrip(realIndex(pageOffset + displayIdx))"
+          >
+            <span
+              class="trip-list__dot"
+              :class="tripColorClass(realIndex(pageOffset + displayIdx))"
+            />
+            <div class="trip-list__info">
+              <div class="trip-list__header">
+                <span class="trip-list__name">{{
+                  new Date(trip.startedAt).toLocaleDateString(displayLocale)
+                }}</span>
+                <span class="trip-list__time">{{
+                  new Date(trip.startedAt).toLocaleTimeString(displayLocale, {
+                    hour: '2-digit',
+                    minute: '2-digit',
+                  })
+                }}</span>
               </div>
-            </li>
-          </ul>
-
-          <AppPaginator v-if="totalPages > 1" v-model="tripsPage" :total-pages="totalPages" />
-        </template>
+              <span class="trip-list__meta">
+                {{ trip.distanceKm }} {{ t('common.km') }} &middot;
+                {{ formatDuration(trip.startedAt, trip.endedAt) }} &middot;
+                {{ trip.pointCount }}
+              </span>
+            </div>
+          </li>
+        </ul>
       </aside>
 
       <!-- Map -->


### PR DESCRIPTION
## Summary

- Replaces the loading spinner in the map trip sidebar with 10 shimmer skeleton rows that mirror the real trip item layout (dot, date/time header, meta line)
- Moves the paginator into a sticky sidebar header — title on the left, paginator on the right — so navigation is always visible while scrolling the list
- Removes the duplicate top and bottom `AppPaginator` instances from the list body
- Adds `.trip-sidebar__header` (sticky, full-width bleed, solid background to cover scroll-behind content), `.paginator--inline` (strips border/padding for header use), and `.skeleton--trip-time` (fixed-width time placeholder) CSS helpers

## Test plan

- [ ] Load the Map view — sidebar shows 10 skeleton rows while trips fetch
- [ ] After load, confirm paginator appears in the header (right side) only when `totalPages > 1`
- [ ] Scroll the trip list — header with title and paginator stays pinned at the top of the sidebar
- [ ] Paginate — list updates, selected trip deselects, skeleton is not re-shown
- [ ] Mobile: sidebar stacks vertically, sticky header still works within `max-height: 240px` scroll area

🤖 Generated with [Claude Code](https://claude.com/claude-code)