### PR TITLE
fix: rename climate usage stat to remote preconditioning

### DIFF
--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -45,7 +45,7 @@
       "distanceInRange": "Distance in period",
       "monthlyMileage": "Monthly mileage",
       "avgTripLength": "Avg trip length",
-      "climateUsage": "Climate usage",
+      "climateUsage": "Remote preconditioning",
       "commutePattern": "Peak drive time",
       "batteryVoltageTrend": "12V trend",
       "parkingLocations": "Parking locations",
@@ -54,7 +54,7 @@
     "cardDesc": {
       "distanceInRange": "Total distance across all trips in the selected time window.",
       "avgTripLength": "Average distance per trip in the selected period.",
-      "climateUsage": "Percentage of recorded snapshots during which climate control was active.",
+      "climateUsage": "Percentage of recorded snapshots during which remote climate preconditioning was active. Does not reflect in-car A/C usage while driving.",
       "commutePattern": "The hour of day with the most trip starts in the selected period - your most common time to drive.",
       "batteryVoltageTrend": "Change in average 12V battery voltage from the start to the end of the selected period. Shows current voltage when less than two days of data are available.",
       "parkingLocations": "Number of distinct parking spots used across all trips in the selected period, based on rounded GPS coordinates.",

--- a/frontend/src/locales/nl.json
+++ b/frontend/src/locales/nl.json
@@ -45,7 +45,7 @@
       "distanceInRange": "Afstand in periode",
       "monthlyMileage": "Maandkilometrage",
       "avgTripLength": "Gem. ritlengte",
-      "climateUsage": "Klimaatgebruik",
+      "climateUsage": "Voorconditionering",
       "commutePattern": "Piek rijtijd",
       "batteryVoltageTrend": "12V-trend",
       "parkingLocations": "Parkeerlocaties",
@@ -54,7 +54,7 @@
     "cardDesc": {
       "distanceInRange": "Totale afstand over alle ritten in de geselecteerde periode.",
       "avgTripLength": "Gemiddelde afstand per rit in de geselecteerde periode.",
-      "climateUsage": "Percentage van geregistreerde momenten waarop de klimaatbeheersing actief was.",
+      "climateUsage": "Percentage van geregistreerde momenten waarop de klimaatvoorconditionering actief was. Geeft geen weergave van airco-gebruik tijdens het rijden.",
       "commutePattern": "Het uur van de dag met de meeste ritstarts in de geselecteerde periode - jouw meest voorkomende rijtijd.",
       "batteryVoltageTrend": "Verandering in gemiddelde 12V-accuspanning van het begin tot het einde van de geselecteerde periode. Toont de huidige spanning als er minder dan twee dagen aan data beschikbaar is.",
       "parkingLocations": "Aantal unieke parkeerplaatsen gebruikt over alle ritten in de geselecteerde periode, gebaseerd op afgeronde GPS-coordinaten.",


### PR DESCRIPTION
## Summary

- Renames the statistics insight card from \"Climate usage\" to \"Remote preconditioning\" (EN) and \"Klimaatgebruik\" to \"Voorconditionering\" (NL)
- Updates the card description in both locales to clarify it measures `remoteClimateState` from the SAIC gateway, which only fires when remote pre-conditioning is active -- not when the in-car A/C is running while driving

## Why

Investigation against `example_data.txt` confirmed the gateway only exposes `climate/remoteClimateState` (labelled "Remote climate state" in its own Home Assistant discovery config). There is no topic for in-car HVAC state during driving, so the old label \"Climate usage\" was misleading and caused confusion when the stat showed 0% despite regular A/C use.

## Test plan

- [ ] Statistics page shows \"Remote preconditioning\" card label in EN locale
- [ ] Statistics page shows \"Voorconditionering\" card label in NL locale
- [ ] Tooltip/description accurately describes the data source

🤖 Generated with [Claude Code](https://claude.com/claude-code)