### PR TITLE
feat: extend SignalR with real-time notifications, trip and availability events

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, ref, watch } from 'vue'
+import { computed, ref, watch, onBeforeUnmount } from 'vue'
 import { RouterLink, RouterView, useRoute, useRouter } from 'vue-router'
 import { useI18n } from 'vue-i18n'
 import { useSettingsStore } from '@/stores/settings'
@@ -10,7 +10,7 @@ import NotificationPanel from '@/components/NotificationPanel.vue'
 import DemoBanner from '@/components/DemoBanner.vue'
 import DemoControlPanel from '@/components/DemoControlPanel.vue'
 import PwaInstallModal from '@/components/PwaInstallModal.vue'
-import { useNotifications } from '@/composables/useNotifications'
+import { useNotifications, prependNotification } from '@/composables/useNotifications'
 import { useSignalR } from '@/composables/useSignalR'
 
 const isDemoMode = import.meta.env.VITE_DEMO_MODE === 'true'
@@ -62,8 +62,30 @@ const {
 const carModel = computed(() => vehicleStore.vehicles[0]?.model ?? null)
 const vehicleId = computed(() => vehicleStore.vehicles[0]?.id ?? null)
 
-const { start: startSignalR, stop: stopSignalR } = useSignalR((snapshot) => {
-  vehicleStore.applyLiveStatus(snapshot)
+const availabilityToast = ref<'online' | 'offline' | null>(null)
+let toastTimer: ReturnType<typeof setTimeout> | null = null
+
+watch(
+  () => vehicleStore.currentStatus?.isAvailable,
+  (now, prev) => {
+    if (prev === undefined || prev === null || now === null || now === undefined) return
+    if (now === prev) return
+    if (toastTimer) clearTimeout(toastTimer)
+    availabilityToast.value = now ? 'online' : 'offline'
+    toastTimer = setTimeout(() => {
+      availabilityToast.value = null
+    }, 5000)
+  },
+)
+
+onBeforeUnmount(() => {
+  if (toastTimer) clearTimeout(toastTimer)
+})
+
+const { start: startSignalR, stop: stopSignalR } = useSignalR({
+  onTelemetryUpdated: (snapshot) => vehicleStore.applyLiveStatus(snapshot),
+  onNotificationReceived: (notification) => prependNotification(notification),
+  onTripCompleted: () => vehicleStore.notifyTripCompleted(),
 })
 
 watch(vehicleId, (id) => {
@@ -251,6 +273,19 @@ watch(
         <RouterView />
       </main>
     </div>
+
+    <Transition name="availability-toast">
+      <div
+        v-if="availabilityToast"
+        class="availability-toast"
+        :class="`availability-toast--${availabilityToast}`"
+      >
+        <font-awesome-icon
+          :icon="availabilityToast === 'online' ? 'wifi' : 'triangle-exclamation'"
+        />
+        {{ availabilityToast === 'online' ? t('vehicle.wentOnline') : t('vehicle.wentOffline') }}
+      </div>
+    </Transition>
 
     <AppFooter />
 

--- a/frontend/src/assets/main.css
+++ b/frontend/src/assets/main.css
@@ -3092,3 +3092,43 @@ body,
     width: auto;
   }
 }
+
+.availability-toast {
+  position: fixed;
+  bottom: 5rem;
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.6rem 1.1rem;
+  border-radius: 6px;
+  font-size: 0.875rem;
+  font-weight: 500;
+  z-index: 2000;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.25);
+  pointer-events: none;
+}
+
+.availability-toast--online {
+  background: var(--color-success);
+  color: #fff;
+}
+
+.availability-toast--offline {
+  background: var(--color-danger);
+  color: #fff;
+}
+
+.availability-toast-enter-active,
+.availability-toast-leave-active {
+  transition:
+    opacity 0.2s ease,
+    transform 0.2s ease;
+}
+
+.availability-toast-enter-from,
+.availability-toast-leave-to {
+  opacity: 0;
+  transform: translateX(-50%) translateY(8px);
+}

--- a/frontend/src/composables/useNotifications.ts
+++ b/frontend/src/composables/useNotifications.ts
@@ -3,6 +3,10 @@ import { notificationsApi, type AppNotification } from '@/services/api'
 import { useAuthStore } from '@/stores/auth'
 
 const notifications = ref<AppNotification[]>([])
+
+export function prependNotification(notification: AppNotification) {
+  notifications.value = [notification, ...notifications.value]
+}
 const panelOpen = ref(false)
 const loading = ref(false)
 const fetchError = ref<string | null>(null)

--- a/frontend/src/composables/useSignalR.ts
+++ b/frontend/src/composables/useSignalR.ts
@@ -1,10 +1,16 @@
 import { ref, onUnmounted } from 'vue'
 import * as signalR from '@microsoft/signalr'
-import type { TelemetrySnapshot } from '@/services/api'
+import type { TelemetrySnapshot, AppNotification } from '@/services/api'
 
 const BASE_URL = import.meta.env.VITE_API_URL ?? ''
 
-export function useSignalR(onTelemetryUpdated: (snapshot: TelemetrySnapshot) => void) {
+export interface SignalRCallbacks {
+  onTelemetryUpdated: (snapshot: TelemetrySnapshot) => void
+  onNotificationReceived: (notification: AppNotification) => void
+  onTripCompleted: (vehicleId: number) => void
+}
+
+export function useSignalR(callbacks: SignalRCallbacks) {
   const connected = ref(false)
   let connection: signalR.HubConnection | null = null
 
@@ -18,7 +24,15 @@ export function useSignalR(onTelemetryUpdated: (snapshot: TelemetrySnapshot) => 
       .build()
 
     connection.on('telemetryUpdated', (snapshot: TelemetrySnapshot) => {
-      onTelemetryUpdated(snapshot)
+      callbacks.onTelemetryUpdated(snapshot)
+    })
+
+    connection.on('notificationReceived', (notification: AppNotification) => {
+      callbacks.onNotificationReceived(notification)
+    })
+
+    connection.on('tripCompleted', (vid: number) => {
+      callbacks.onTripCompleted(vid)
     })
 
     connection.onreconnecting(() => {

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -64,6 +64,8 @@
     "dailyKwhChart": "Daily Electric Usage (kWh)"
   },
   "vehicle": {
+    "wentOnline": "Vehicle is online",
+    "wentOffline": "Vehicle went offline",
     "fuel": "Fuel",
     "range": "Range",
     "odometer": "Odometer",

--- a/frontend/src/locales/nl.json
+++ b/frontend/src/locales/nl.json
@@ -64,6 +64,8 @@
     "dailyKwhChart": "Dagelijks elektrisch verbruik (kWh)"
   },
   "vehicle": {
+    "wentOnline": "Voertuig is online",
+    "wentOffline": "Voertuig is offline gegaan",
     "fuel": "Brandstof",
     "range": "Bereik",
     "odometer": "Kilometerteller",

--- a/frontend/src/stores/vehicle.ts
+++ b/frontend/src/stores/vehicle.ts
@@ -1,5 +1,5 @@
 import { defineStore } from 'pinia'
-import { ref, computed } from 'vue'
+import { ref, computed, nextTick } from 'vue'
 import {
   vehicleApi,
   type Vehicle,
@@ -21,6 +21,10 @@ export const useVehicleStore = defineStore('vehicle', () => {
   const loading = computed(() => loadingCount.value > 0)
   const error = ref<string | null>(null)
   const lastUpdated = ref<Date | null>(null)
+
+  // Reactive one-shot flags set for a single tick when specific state transitions occur.
+  const tripJustCompleted = ref(false)
+  const chargingJustCompleted = ref(false)
 
   async function fetchVehicles() {
     loadingCount.value++
@@ -70,8 +74,29 @@ export const useVehicleStore = defineStore('vehicle', () => {
   }
 
   function applyLiveStatus(snapshot: TelemetrySnapshot) {
+    const prev = currentStatus.value
+
+    // Charging complete: was charging, cable still connected, now stopped
+    if (
+      prev?.isCharging === true &&
+      snapshot.isCharging === false &&
+      snapshot.chargerConnected === true
+    ) {
+      chargingJustCompleted.value = true
+      nextTick(() => {
+        chargingJustCompleted.value = false
+      })
+    }
+
     currentStatus.value = snapshot
     lastUpdated.value = new Date()
+  }
+
+  function notifyTripCompleted() {
+    tripJustCompleted.value = true
+    nextTick(() => {
+      tripJustCompleted.value = false
+    })
   }
 
   async function fetchLastTrip(vin: string) {
@@ -115,6 +140,8 @@ export const useVehicleStore = defineStore('vehicle', () => {
     loading,
     error,
     lastUpdated,
+    tripJustCompleted,
+    chargingJustCompleted,
     fetchVehicles,
     fetchStatus,
     fetchConfig,
@@ -122,5 +149,6 @@ export const useVehicleStore = defineStore('vehicle', () => {
     fetchTrips,
     fetchLastTrip,
     applyLiveStatus,
+    notifyTripCompleted,
   }
 })

--- a/frontend/src/views/MapView.vue
+++ b/frontend/src/views/MapView.vue
@@ -318,6 +318,18 @@ watch(dateRangeDays, async (days) => {
   }
 })
 
+// Trip just finished: silently prepend without resetting selection or page
+watch(
+  () => store.tripJustCompleted,
+  async (completed) => {
+    if (!completed || !vin.value) return
+    await store.fetchTrips(
+      vin.value,
+      new Date(Date.now() - dateRangeDays.value * 86_400_000).toISOString(),
+    )
+  },
+)
+
 // Deselect when paginating
 watch(tripsPage, () => {
   selectedTripIndex.value = null

--- a/frontend/src/views/StatisticsView.vue
+++ b/frontend/src/views/StatisticsView.vue
@@ -94,6 +94,14 @@ async function load() {
 onMounted(load)
 watch(() => settings.filterDays, load)
 
+// Trip just finished: refresh stats and trip list silently
+watch(
+  () => store.tripJustCompleted,
+  (completed) => {
+    if (completed) load()
+  },
+)
+
 const effectiveVehicleType = computed(() => {
   if (settings.vehicleTypeOverride !== 'auto') return settings.vehicleTypeOverride
   return store.detectedVehicleType

--- a/src/GarageStack.Api/Services/TelemetryNotificationService.cs
+++ b/src/GarageStack.Api/Services/TelemetryNotificationService.cs
@@ -1,4 +1,6 @@
 using System.Collections.Concurrent;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 using System.Threading.Channels;
 using GarageStack.Api.Hubs;
 using GarageStack.Core.Interfaces;
@@ -17,6 +19,8 @@ public class TelemetryNotificationService(
     // topics per poll cycle) into a single SignalR broadcast after a quiet period.
     private readonly ConcurrentDictionary<int, CancellationTokenSource> _pending = new();
 
+    private record PgEvent(string Channel, string Payload);
+
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
         var connectionString = config.GetConnectionString("DefaultConnection");
@@ -26,15 +30,30 @@ public class TelemetryNotificationService(
             return;
         }
 
-        var channel = Channel.CreateUnbounded<int>(new UnboundedChannelOptions { SingleReader = true });
+        var channel = Channel.CreateUnbounded<PgEvent>(new UnboundedChannelOptions { SingleReader = true });
 
         _ = ListenAsync(connectionString, channel.Writer, stoppingToken);
 
-        await foreach (var vehicleId in channel.Reader.ReadAllAsync(stoppingToken))
-            ScheduleBroadcast(vehicleId, stoppingToken);
+        await foreach (var evt in channel.Reader.ReadAllAsync(stoppingToken))
+        {
+            switch (evt.Channel)
+            {
+                case "telemetry_updated":
+                    if (int.TryParse(evt.Payload, out var vehicleId))
+                        ScheduleBroadcast(vehicleId, stoppingToken);
+                    break;
+                case "notification_created":
+                    _ = BroadcastNotificationAsync(evt.Payload, stoppingToken);
+                    break;
+                case "trip_completed":
+                    if (int.TryParse(evt.Payload, out var tripVehicleId))
+                        _ = BroadcastTripCompletedAsync(tripVehicleId, stoppingToken);
+                    break;
+            }
+        }
     }
 
-    private async Task ListenAsync(string connectionString, ChannelWriter<int> writer, CancellationToken ct)
+    private async Task ListenAsync(string connectionString, ChannelWriter<PgEvent> writer, CancellationToken ct)
     {
         while (!ct.IsCancellationRequested)
         {
@@ -45,17 +64,13 @@ public class TelemetryNotificationService(
 
                 await using (var cmd = conn.CreateCommand())
                 {
-                    cmd.CommandText = "LISTEN telemetry_updated";
+                    cmd.CommandText = "LISTEN telemetry_updated; LISTEN notification_created; LISTEN trip_completed";
                     await cmd.ExecuteNonQueryAsync(ct);
                 }
 
-                logger.LogInformation("Listening for PostgreSQL telemetry_updated notifications");
+                logger.LogInformation("Listening for PostgreSQL notifications on telemetry_updated, notification_created, trip_completed");
 
-                conn.Notification += (_, e) =>
-                {
-                    if (int.TryParse(e.Payload, out var vehicleId))
-                        writer.TryWrite(vehicleId);
-                };
+                conn.Notification += (_, e) => writer.TryWrite(new PgEvent(e.Channel, e.Payload));
 
                 while (!ct.IsCancellationRequested)
                     await conn.WaitAsync(ct);
@@ -89,7 +104,7 @@ public class TelemetryNotificationService(
             try
             {
                 await Task.Delay(2_000, cts.Token);
-                await BroadcastAsync(vehicleId, stoppingToken);
+                await BroadcastTelemetryAsync(vehicleId, stoppingToken);
             }
             catch (OperationCanceledException) { }
             finally
@@ -100,7 +115,7 @@ public class TelemetryNotificationService(
         }, cts.Token);
     }
 
-    private async Task BroadcastAsync(int vehicleId, CancellationToken ct)
+    private async Task BroadcastTelemetryAsync(int vehicleId, CancellationToken ct)
     {
         try
         {
@@ -112,11 +127,57 @@ public class TelemetryNotificationService(
             await hubContext.Clients.Group($"vehicle-{vehicleId}")
                 .SendAsync("telemetryUpdated", snapshot, ct);
 
-            logger.LogDebug("SignalR broadcast for vehicleId={VehicleId}", vehicleId);
+            logger.LogDebug("SignalR broadcast telemetryUpdated for vehicleId={VehicleId}", vehicleId);
         }
         catch (Exception ex)
         {
             logger.LogError(ex, "Failed to broadcast telemetry for vehicleId={VehicleId}", vehicleId);
         }
     }
+
+    private async Task BroadcastNotificationAsync(string json, CancellationToken ct)
+    {
+        try
+        {
+            var notification = JsonSerializer.Deserialize<NotificationPayload>(json, JsonOptions);
+            if (notification is null) return;
+
+            await hubContext.Clients.All.SendAsync("notificationReceived", notification, ct);
+            logger.LogDebug("SignalR broadcast notificationReceived id={Id}", notification.Id);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Failed to broadcast notification");
+        }
+    }
+
+    private async Task BroadcastTripCompletedAsync(int vehicleId, CancellationToken ct)
+    {
+        try
+        {
+            await hubContext.Clients.Group($"vehicle-{vehicleId}")
+                .SendAsync("tripCompleted", vehicleId, ct);
+
+            logger.LogDebug("SignalR broadcast tripCompleted for vehicleId={VehicleId}", vehicleId);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Failed to broadcast tripCompleted for vehicleId={VehicleId}", vehicleId);
+        }
+    }
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+    };
+
+    // Mirrors the payload shape written by PushSenderService
+    private sealed record NotificationPayload(
+        int Id,
+        string Title,
+        string Body,
+        string CreatedAt,
+        [property: JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)] string? Category,
+        [property: JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)] int? VehicleId);
 }

--- a/src/GarageStack.Worker/Mqtt/MqttConsumerService.cs
+++ b/src/GarageStack.Worker/Mqtt/MqttConsumerService.cs
@@ -1,8 +1,10 @@
 using System.Text.Json;
 using GarageStack.Core.Interfaces;
 using GarageStack.Core.Models;
+using GarageStack.Data;
 using GarageStack.Worker.Services;
 using MQTTnet;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
@@ -159,6 +161,7 @@ public class MqttConsumerService(
         using var scope = scopeFactory.CreateScope();
         var vehicleRepoMain = scope.ServiceProvider.GetRequiredService<IVehicleRepository>();
         var telemetryRepo = scope.ServiceProvider.GetRequiredService<ITelemetryRepository>();
+        var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
 
         try
         {
@@ -184,7 +187,14 @@ public class MqttConsumerService(
                 _mergeState[vehicle.Id] = (newId, patch.RecordedAt);
             }
 
-            await CheckEngineStartAsync(vin, patch, ct);
+            var tripCompleted = await CheckEngineStartAsync(vin, patch, ct);
+            if (tripCompleted && patch.VehicleId > 0)
+            {
+                var vid = patch.VehicleId.ToString();
+                await db.Database.ExecuteSqlInterpolatedAsync(
+                    $"SELECT pg_notify('trip_completed', {vid})", ct);
+                logger.LogInformation("Trip completed for vehicleId={VehicleId} - notifying SignalR clients", patch.VehicleId);
+            }
         }
         catch (Exception ex)
         {
@@ -192,16 +202,16 @@ public class MqttConsumerService(
         }
     }
 
-    internal async Task CheckEngineStartAsync(string vin, TelemetrySnapshot snapshot, CancellationToken ct)
+    internal async Task<bool> CheckEngineStartAsync(string vin, TelemetrySnapshot snapshot, CancellationToken ct)
     {
-        if (snapshot.EngineRunning is null) return;
+        if (snapshot.EngineRunning is null) return false;
 
         if (_engineStateSeeded.Add(vin))
         {
             // First observation after startup: seed state without firing to avoid
             // false "engine started" alerts when the worker restarts while driving.
             _lastEngineRunning[vin] = snapshot.EngineRunning.Value;
-            return;
+            return false;
         }
 
         var wasRunning = _lastEngineRunning.TryGetValue(vin, out var prev) && prev;
@@ -211,7 +221,14 @@ public class MqttConsumerService(
         {
             logger.LogInformation("Engine started for VIN={Vin} - sending push notification", vin);
             await pushSender.SendToAllAsync("Engine started", "Your car has been started.", ct, "engine-start", snapshot.VehicleId);
+            return false;
         }
+
+        // Engine stopped: a trip just completed
+        if (!snapshot.EngineRunning.Value && wasRunning)
+            return true;
+
+        return false;
     }
 
     private async Task HandleHaDiscoveryAsync(string payload, CancellationToken ct)

--- a/src/GarageStack.Worker/Services/PushSenderService.cs
+++ b/src/GarageStack.Worker/Services/PushSenderService.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using GarageStack.Core.Interfaces;
 using GarageStack.Data;
 using Lib.Net.Http.WebPush;
@@ -52,15 +53,30 @@ public sealed class PushSenderService : IPushSender, IDisposable
         {
             using var recordScope = _scopeFactory.CreateScope();
             var recordDb = recordScope.ServiceProvider.GetRequiredService<AppDbContext>();
-            recordDb.AppNotifications.Add(new GarageStack.Core.Models.AppNotification
+            var record = new GarageStack.Core.Models.AppNotification
             {
                 Title = title,
                 Body = body,
                 CreatedAt = DateTime.UtcNow,
                 Category = category,
                 VehicleId = vehicleId,
-            });
+            };
+            recordDb.AppNotifications.Add(record);
             await recordDb.SaveChangesAsync(ct);
+
+            // Signal the API process via PostgreSQL so connected browser clients get
+            // an immediate notificationReceived push without polling.
+            var notifyJson = JsonSerializer.Serialize(new
+            {
+                id = record.Id,
+                title = record.Title,
+                body = record.Body,
+                createdAt = record.CreatedAt.ToString("O"),
+                category = record.Category,
+                vehicleId = record.VehicleId,
+            });
+            await recordDb.Database.ExecuteSqlInterpolatedAsync(
+                $"SELECT pg_notify('notification_created', {notifyJson})", ct);
         }
         catch (Exception ex)
         {


### PR DESCRIPTION
## Summary

- **Live notification badge**: `PushSenderService` fires `pg_notify('notification_created', json)` after saving to DB; `TelemetryNotificationService` LISTENs and broadcasts `notificationReceived` over SignalR so the bell badge and panel update instantly without polling
- **Vehicle online/offline toast**: `App.vue` watches `isAvailable` transitions in the telemetry snapshot and shows a 5-second slide-up toast (already carried by the existing `telemetryUpdated` event)
- **Trip-end refresh**: `MqttConsumerService` fires `pg_notify('trip_completed', vehicleId)` when engine stops; `TelemetryNotificationService` broadcasts `tripCompleted` to the vehicle group; `MapView` and `StatisticsView` silently re-fetch trip data on receipt
- **Charging-complete detection**: `applyLiveStatus` in the vehicle store detects `isCharging: true → false` with cable connected and sets a one-tick `chargingJustCompleted` flag for components to react to

## Architecture notes

All cross-process signalling (Worker → API) uses the existing PostgreSQL LISTEN/NOTIFY pattern — no new infrastructure needed. The single hub connection per browser session now handles four event types: `telemetryUpdated`, `notificationReceived`, `tripCompleted`, and the availability transition is derived client-side from the snapshot.

## Test plan

- [ ] Start engine: confirm no trip-completed event fires
- [ ] Stop engine: confirm MapView and StatisticsView refresh their trip lists
- [ ] Trigger a push notification (e.g. low tyre pressure check): confirm bell badge increments and panel prepends the new item without opening/closing
- [ ] Toggle vehicle availability (disconnect/reconnect MQTT): confirm online/offline toast appears and auto-dismisses after 5 seconds
- [ ] Charge to completion with cable connected: confirm `chargingJustCompleted` flag is set (visible in Vue devtools)

🤖 Generated with [Claude Code](https://claude.com/claude-code)