### PR TITLE
fix: replace non-existent nuget-dependency-submission-action

### DIFF
--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -8,26 +8,11 @@ permissions:
   contents: write
 
 jobs:
-  dotnet:
-    name: .NET dependency snapshot
+  snapshot:
+    name: Dependency snapshot
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-dotnet@v4
-        with:
-          dotnet-version: 10.0.x
-
-      - name: Submit .NET dependencies
-        uses: github/nuget-dependency-submission-action@v1
-        with:
-          solution-directory: .
-
-  frontend:
-    name: Frontend dependency snapshot
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Submit frontend dependencies
+      - name: Submit dependencies
         uses: advanced-security/component-detection-dependency-submission-action@v0.1.1


### PR DESCRIPTION
## Summary

- `github/nuget-dependency-submission-action` does not exist as a published GitHub repository, causing the `.NET dependency snapshot` job to fail on every push to `main`
- `advanced-security/component-detection-dependency-submission-action` (already used in the frontend job) detects NuGet packages across the full repo automatically, making a separate dotnet job redundant
- Collapsed both jobs into a single `snapshot` job using the working action

## Test plan

- [ ] Verify the workflow passes on merge to `main`
- [ ] Confirm NuGet dependencies appear in the repository's dependency graph after the workflow runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)