### PR TITLE
feat: optimize Scalar API docs and hide from production

### DIFF
--- a/src/GarageStack.Api/Program.cs
+++ b/src/GarageStack.Api/Program.cs
@@ -65,7 +65,19 @@ try
         builder.Services.AddHostedService(sp => sp.GetRequiredService<MqttPublisher>());
         builder.Services.AddHostedService<TelemetryNotificationService>();
     }
-    builder.Services.AddOpenApi();
+    builder.Services.AddOpenApi(opts =>
+    {
+        opts.AddDocumentTransformer((doc, _, _) =>
+        {
+            doc.Info = new()
+            {
+                Title = "GarageStack API",
+                Version = "v1",
+                Description = "REST API for GarageStack -- vehicle telemetry, statistics, and notifications.",
+            };
+            return Task.CompletedTask;
+        });
+    });
     builder.Services.ConfigureHttpJsonOptions(opts =>
     {
         opts.SerializerOptions.ReferenceHandler = ReferenceHandler.IgnoreCycles;
@@ -235,10 +247,18 @@ try
     app.UseAuthentication();
     app.UseAuthorization();
 
-    if (app.Environment.IsDevelopment())
+    if (app.Environment.IsDevelopment() || app.Environment.IsEnvironment("Demo"))
     {
         app.MapOpenApi();
-        app.MapScalarApiReference(opts => opts.WithTitle("GarageStack API"));
+        app.MapScalarApiReference(opts => opts
+            .WithTitle("GarageStack API")
+            .WithTheme(ScalarTheme.DeepSpace)
+            .EnableDarkMode()
+            .WithDynamicBaseServerUrl(true)
+            .SortTagsAlphabetically()
+            .SortOperationsByMethod()
+            .AddPreferredSecuritySchemes(["Bearer"])
+            .AddHttpAuthentication("Bearer", _ => { }));
     }
 
     app.MapHub<TelemetryHub>("/hubs/telemetry").RequireAuthorization();

--- a/src/GarageStack.Api/Properties/launchSettings.json
+++ b/src/GarageStack.Api/Properties/launchSettings.json
@@ -7,7 +7,7 @@
       "launchBrowser": false,
       "applicationUrl": "http://localhost:5000",
       "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development",
+        "ASPNETCORE_ENVIRONMENT": "Demo",
         "DEMO_MODE": "true",
         "Auth__Username": "demo",
         "Auth__Password": "demo",


### PR DESCRIPTION
## Summary

- Scalar API reference is now only exposed in `Development` and `Demo` environments -- production gets no docs endpoint
- Demo launch profile corrected to use `ASPNETCORE_ENVIRONMENT=Demo` (was `Development`), cleanly separating the two environments
- OpenAPI document metadata added (title, version, description)
- Scalar upgraded to the current non-deprecated API with improved defaults:
  - **DeepSpace** dark theme
  - Dynamic base server URL (works on any port)
  - Tags sorted alphabetically, operations sorted by HTTP method
  - Bearer auth slot pre-wired so a JWT token can be pasted once and applied to all requests

## Test plan

- [ ] Start with `dotnet run` (Development) -- Scalar accessible at `/scalar`
- [ ] Start with `start-demo.ps1` (Demo) -- Scalar accessible at `http://localhost:5000/scalar`
- [ ] Build/publish with `ASPNETCORE_ENVIRONMENT=Production` -- `/scalar` and `/openapi/v1.json` return 404
- [ ] In Scalar, confirm DeepSpace dark theme, alphabetical sidebar, and Bearer auth field visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)