### PR TITLE
feat: improve frontend accessibility and title tooltips for truncated text

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -214,11 +214,16 @@ watch(
               <span class="skeleton skeleton--text skeleton--text-md" />
             </template>
             <template v-else>
-              <font-awesome-icon icon="wifi" />
-              <span class="sidebar-footer__text">{{ onlineStatusText }}</span>
-              <span v-if="onlineStatusTime" class="sidebar-online-status__time">{{
-                onlineStatusTime
+              <font-awesome-icon icon="wifi" aria-hidden="true" />
+              <span class="sidebar-footer__text" :title="onlineStatusText">{{
+                onlineStatusText
               }}</span>
+              <span
+                v-if="onlineStatusTime"
+                class="sidebar-online-status__time"
+                :title="onlineStatusTime"
+                >{{ onlineStatusTime }}</span
+              >
             </template>
           </div>
           <div v-if="isInitialLoading || lastFetched" class="sidebar-timestamp">
@@ -227,8 +232,10 @@ watch(
               <span class="skeleton skeleton--text skeleton--text-sm" />
             </template>
             <template v-else>
-              <font-awesome-icon icon="rotate" :spin="vehicleStore.loading" />
-              <span class="sidebar-footer__text">{{ t('common.fetched') }} {{ lastFetched }}</span>
+              <font-awesome-icon icon="rotate" :spin="vehicleStore.loading" aria-hidden="true" />
+              <span class="sidebar-footer__text" :title="`${t('common.fetched')} ${lastFetched}`"
+                >{{ t('common.fetched') }} {{ lastFetched }}</span
+              >
             </template>
           </div>
           <div v-if="isInitialLoading || lastRecorded" class="sidebar-timestamp">
@@ -237,15 +244,15 @@ watch(
               <span class="skeleton skeleton--text skeleton--text-lg" />
             </template>
             <template v-else>
-              <font-awesome-icon icon="clock" />
-              <span class="sidebar-footer__text"
+              <font-awesome-icon icon="clock" aria-hidden="true" />
+              <span class="sidebar-footer__text" :title="`${t('common.recorded')} ${lastRecorded}`"
                 >{{ t('common.recorded') }} {{ lastRecorded }}</span
               >
             </template>
           </div>
           <div class="sidebar-user">
-            <font-awesome-icon icon="user" />
-            <span class="sidebar-user__email">{{ auth.username }}</span>
+            <font-awesome-icon icon="user" aria-hidden="true" />
+            <span class="sidebar-user__email" :title="auth.username">{{ auth.username }}</span>
           </div>
           <button
             v-if="isDemoMode"

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -215,7 +215,7 @@ watch(
             </template>
             <template v-else>
               <font-awesome-icon icon="wifi" aria-hidden="true" />
-              <span class="sidebar-footer__text" :title="onlineStatusText">{{
+              <span class="sidebar-footer__text" :title="onlineStatusText ?? undefined">{{
                 onlineStatusText
               }}</span>
               <span

--- a/frontend/src/components/AppPaginator.vue
+++ b/frontend/src/components/AppPaginator.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
 
 const props = defineProps<{
   modelValue: number
@@ -9,6 +10,8 @@ const props = defineProps<{
 const emit = defineEmits<{
   (e: 'update:modelValue', page: number): void
 }>()
+
+const { t } = useI18n()
 
 const pageInput = ref(props.modelValue)
 
@@ -45,9 +48,10 @@ function next() {
     <button
       class="btn btn-sm btn-outline-secondary paginator__btn"
       :disabled="modelValue === 1"
+      :aria-label="t('common.prevPage')"
       @click="prev"
     >
-      <font-awesome-icon icon="chevron-left" />
+      <font-awesome-icon icon="chevron-left" aria-hidden="true" />
     </button>
     <input
       v-model.number="pageInput"
@@ -55,17 +59,19 @@ function next() {
       min="1"
       :max="totalPages"
       class="paginator__input"
+      :aria-label="t('common.pageOf', { n: modelValue, total: totalPages })"
       @blur="commit"
       @keydown.enter.prevent="commit"
       @focus="onFocus"
     />
-    <span class="paginator__sep">/ {{ totalPages }}</span>
+    <span class="paginator__sep" aria-hidden="true">/ {{ totalPages }}</span>
     <button
       class="btn btn-sm btn-outline-secondary paginator__btn"
       :disabled="modelValue === totalPages"
+      :aria-label="t('common.nextPage')"
       @click="next"
     >
-      <font-awesome-icon icon="chevron-right" />
+      <font-awesome-icon icon="chevron-right" aria-hidden="true" />
     </button>
   </div>
 </template>

--- a/frontend/src/components/DemoControlPanel.vue
+++ b/frontend/src/components/DemoControlPanel.vue
@@ -232,7 +232,14 @@ async function setLights(mode: 'off' | 'side' | 'dipped' | 'main') {
       <div class="demo-panel-section">
         <div class="demo-panel-section-label">{{ t('demo.soc') }}</div>
         <div class="demo-panel-range">
-          <input v-model.number="socValue" type="range" min="10" max="100" step="1" />
+          <input
+            v-model.number="socValue"
+            type="range"
+            min="10"
+            max="100"
+            step="1"
+            :aria-label="t('demo.soc')"
+          />
           <span>{{ socValue }}%</span>
           <button class="demo-toggle-btn" @click="applySoc">OK</button>
         </div>
@@ -241,7 +248,14 @@ async function setLights(mode: 'off' | 'side' | 'dipped' | 'main') {
       <div class="demo-panel-section">
         <div class="demo-panel-section-label">{{ t('demo.speed') }}</div>
         <div class="demo-panel-range">
-          <input v-model.number="speedValue" type="range" min="0" max="200" step="1" />
+          <input
+            v-model.number="speedValue"
+            type="range"
+            min="0"
+            max="200"
+            step="1"
+            :aria-label="t('demo.speed')"
+          />
           <span>{{ speedValue }} km/h</span>
           <button class="demo-toggle-btn" @click="applySpeed">OK</button>
         </div>

--- a/frontend/src/components/NotificationPanel.vue
+++ b/frontend/src/components/NotificationPanel.vue
@@ -115,10 +115,10 @@ onUnmounted(() => document.removeEventListener('keydown', onKey))
             </h3>
             <button
               class="notif-panel__close"
-              :aria-label="t('common.cancel')"
+              :aria-label="t('common.close')"
               @click="emit('close')"
             >
-              <font-awesome-icon icon="xmark" />
+              <font-awesome-icon icon="xmark" aria-hidden="true" />
             </button>
           </div>
 
@@ -176,16 +176,18 @@ onUnmounted(() => document.removeEventListener('keydown', onKey))
                     v-if="!n.isArchived"
                     class="notif-item__btn"
                     :title="t('notifications.archive')"
+                    :aria-label="t('notifications.archive')"
                     @click="emit('archive', n.id)"
                   >
-                    <font-awesome-icon icon="box-archive" />
+                    <font-awesome-icon icon="box-archive" aria-hidden="true" />
                   </button>
                   <button
                     class="notif-item__btn notif-item__btn--danger"
                     :title="t('notifications.delete')"
+                    :aria-label="t('notifications.delete')"
                     @click="emit('delete', n.id)"
                   >
-                    <font-awesome-icon icon="trash" />
+                    <font-awesome-icon icon="trash" aria-hidden="true" />
                   </button>
                 </div>
               </li>

--- a/frontend/src/components/PwaInstallModal.vue
+++ b/frontend/src/components/PwaInstallModal.vue
@@ -57,8 +57,8 @@ function onDismiss() {
             </button>
           </div>
 
-          <label class="pwa-install-modal__never">
-            <input v-model="neverShow" type="checkbox" />
+          <label class="pwa-install-modal__never" for="pwa-never-show">
+            <input id="pwa-never-show" v-model="neverShow" type="checkbox" />
             <span>{{ t('pwa.install.neverShow') }}</span>
           </label>
         </div>

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -321,6 +321,7 @@
     "open": "Open",
     "closed": "Closed",
     "cancel": "Cancel",
+    "close": "Close",
     "apply": "Apply",
     "confirm": "Confirm",
     "filters": "Filters",
@@ -328,7 +329,10 @@
     "offline": "Offline",
     "min": "min",
     "fetched": "Fetched",
-    "recorded": "Recorded"
+    "recorded": "Recorded",
+    "prevPage": "Previous page",
+    "nextPage": "Next page",
+    "pageOf": "Page {n} of {total}"
   },
   "demo": {
     "banner": "Demo mode - displaying sample data only",

--- a/frontend/src/locales/nl.json
+++ b/frontend/src/locales/nl.json
@@ -321,6 +321,7 @@
     "open": "Open",
     "closed": "Gesloten",
     "cancel": "Annuleren",
+    "close": "Sluiten",
     "apply": "Toepassen",
     "confirm": "Bevestigen",
     "filters": "Filters",
@@ -328,7 +329,10 @@
     "offline": "Offline",
     "min": "min",
     "fetched": "Opgehaald",
-    "recorded": "Geregistreerd"
+    "recorded": "Geregistreerd",
+    "prevPage": "Vorige pagina",
+    "nextPage": "Volgende pagina",
+    "pageOf": "Pagina {n} van {total}"
   },
   "demo": {
     "banner": "Demo modus - alleen voorbeelddata wordt getoond",

--- a/frontend/src/views/MapView.vue
+++ b/frontend/src/views/MapView.vue
@@ -398,7 +398,12 @@ onUnmounted(() => {
               <span class="settings-toggle__label">{{ t('trips.heatmap') }}</span>
             </div>
             <div class="settings-toggle__control form-check form-switch">
-              <input v-model="heatmapEnabled" type="checkbox" class="form-check-input" />
+              <input
+                v-model="heatmapEnabled"
+                type="checkbox"
+                class="form-check-input"
+                :aria-label="t('trips.heatmap')"
+              />
             </div>
           </div>
         </FiltersPanel>
@@ -459,9 +464,11 @@ onUnmounted(() => {
             />
             <div class="trip-list__info">
               <div class="trip-list__header">
-                <span class="trip-list__name">{{
-                  new Date(trip.startedAt).toLocaleDateString(displayLocale)
-                }}</span>
+                <span
+                  class="trip-list__name"
+                  :title="new Date(trip.startedAt).toLocaleDateString(displayLocale)"
+                  >{{ new Date(trip.startedAt).toLocaleDateString(displayLocale) }}</span
+                >
                 <span class="trip-list__time">{{
                   new Date(trip.startedAt).toLocaleTimeString(displayLocale, {
                     hour: '2-digit',
@@ -469,7 +476,10 @@ onUnmounted(() => {
                   })
                 }}</span>
               </div>
-              <span class="trip-list__meta">
+              <span
+                class="trip-list__meta"
+                :title="`${trip.distanceKm} ${t('common.km')} · ${formatDuration(trip.startedAt, trip.endedAt)} · ${trip.pointCount} ${t('trips.points')}`"
+              >
                 {{ trip.distanceKm }} {{ t('common.km') }} &middot;
                 {{ formatDuration(trip.startedAt, trip.endedAt) }} &middot; {{ trip.pointCount }}
                 {{ t('trips.points') }}


### PR DESCRIPTION
## Summary

- **AppPaginator**: `aria-label` on prev/next buttons and page number input; `aria-hidden` on decorative chevron icons; new i18n keys `common.prevPage`, `common.nextPage`, `common.pageOf` (EN + NL)
- **NotificationPanel**: `aria-label` on archive/delete icon-only buttons; corrected close button label from `common.cancel` to new `common.close` key; `aria-hidden` on all decorative icons
- **PwaInstallModal**: explicit `id`/`for` pairing between the "never show" checkbox and its label
- **DemoControlPanel**: `aria-label` on the SOC and speed `<input type="range">` sliders
- **App.vue**: `:title` tooltips on sidebar email, fetched/recorded timestamps and online status text so hover reveals full string when overflowed; `aria-hidden` on decorative sidebar icons
- **MapView**: `:aria-label` on heatmap toggle checkbox; `:title` on `.trip-list__name` and `.trip-list__meta` spans to expose full content on overflow ellipsis

## Test plan

- [ ] Tab through the paginator — buttons announce "Previous page" / "Next page", input announces current page position
- [ ] Tab to notification archive/delete buttons — screen reader reads the action label
- [ ] Hover over a truncated sidebar email or timestamp — full text tooltip appears
- [ ] Hover over a truncated trip name or meta row in the map sidebar — full text tooltip appears
- [ ] Inspect heatmap toggle with a screen reader — announces "Heatmap"
- [ ] Check SOC and speed sliders in demo panel — announced by label

🤖 Generated with [Claude Code](https://claude.com/claude-code)