### PR TITLE
fix: increase card-info-btn touch target to 24x24px on mobile

### DIFF
--- a/frontend/src/assets/main.css
+++ b/frontend/src/assets/main.css
@@ -2170,10 +2170,10 @@ body,
   }
 
   .card-info-btn {
-    top: -5px;
-    right: -5px;
-    width: 22px;
-    height: 22px;
+    top: -6px;
+    right: -6px;
+    width: 24px;
+    height: 24px;
     font-size: 0.6rem;
   }
 


### PR DESCRIPTION
## Summary

- Increases `.card-info-btn` width/height from `22px` to `24px` in the mobile media query override
- Adjusts `top`/`right` offset by 1px to maintain visual positioning
- Resolves 7 failing touch target size elements flagged in a Lighthouse accessibility audit (WCAG 2.2 minimum is 24x24px)

## Test plan

- [x] All 133 unit tests pass
- [ ] Visually verify info buttons on mobile viewport still sit flush at card corner
- [ ] Re-run Lighthouse mobile audit and confirm accessibility score improves

🤖 Generated with [Claude Code](https://claude.com/claude-code)