### PR TITLE
perf: enable SW navigation preload and GPU-composite skeleton shimmer

### DIFF
--- a/frontend/src/assets/main.css
+++ b/frontend/src/assets/main.css
@@ -1977,23 +1977,26 @@ body,
 
 @keyframes skeleton-shimmer {
   0% {
-    background-position: 100% 0;
+    transform: translateX(-100%);
   }
   100% {
-    background-position: 0% 0;
+    transform: translateX(100%);
   }
 }
 
 .skeleton {
   display: inline-block;
   border-radius: 4px;
-  background: linear-gradient(
-    90deg,
-    var(--color-surface-2) 25%,
-    var(--color-border) 50%,
-    var(--color-surface-2) 75%
-  );
-  background-size: 400% 100%;
+  background: var(--color-surface-2);
+  position: relative;
+  overflow: hidden;
+}
+
+.skeleton::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(90deg, transparent 0%, var(--color-border) 50%, transparent 100%);
   animation: skeleton-shimmer 1.5s linear infinite;
 }
 

--- a/frontend/src/sw.ts
+++ b/frontend/src/sw.ts
@@ -8,7 +8,17 @@ precacheAndRoute(self.__WB_MANIFEST)
 
 // Activate the new SW immediately instead of waiting for all tabs to close
 self.addEventListener('install', () => self.skipWaiting())
-self.addEventListener('activate', (event) => event.waitUntil(self.clients.claim()))
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    Promise.all([
+      // Enable navigation preload so the browser starts the network fetch in
+      // parallel with SW activation -- prevents the ~1.8s self-redirect that
+      // occurs when clients.claim() retriggers a navigation through the SW.
+      self.registration.navigationPreload?.enable() ?? Promise.resolve(),
+      self.clients.claim(),
+    ]),
+  )
+})
 
 self.addEventListener('push', (event) => {
   if (!event.data) return


### PR DESCRIPTION
## Summary

- **Service worker navigation preload**: `clients.claim()` in the SW `activate` event was causing Chrome to re-issue the navigation request through the newly-activated SW on every load. Because `navigationPreload` was never enabled, Workbox had no preloaded response and started a fresh network fetch -- Lighthouse flagged this as a ~1.8s self-redirect on the root URL. Enabling `self.registration.navigationPreload.enable()` allows Chrome to start the network fetch in parallel with SW activation; Workbox 7.4.0's `StrategyHandler.fetch()` already checks `event.preloadResponse` and uses it when present.

- **Skeleton shimmer GPU composite**: The `@keyframes skeleton-shimmer` animation was moving `background-position`, which is not GPU-compositable and triggered repaint on all 41 skeleton elements every frame. Replaced with a `::after` pseudo-element animated via `transform: translateX(-100% -> 100%)` so the animation runs entirely on the compositor thread.

## Test plan

- [ ] Deploy and run a fresh Lighthouse mobile audit -- redirect chain for `/` should disappear and LCP should improve
- [ ] Check dashboard skeleton loading state visually -- shimmer should look identical (highlight sweeping left to right)
- [ ] Verify skeleton elements with `overflow: hidden` clip correctly (icon, text, text-sm variants)
- [ ] Confirm 133 unit tests still pass (`pnpm run test:unit --run`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)