### PR TITLE
fix: remove clients.claim() to eliminate 1.8s SW redirect

### DIFF
--- a/frontend/src/sw.ts
+++ b/frontend/src/sw.ts
@@ -9,15 +9,7 @@ precacheAndRoute(self.__WB_MANIFEST)
 // Activate the new SW immediately instead of waiting for all tabs to close
 self.addEventListener('install', () => self.skipWaiting())
 self.addEventListener('activate', (event) => {
-  event.waitUntil(
-    Promise.all([
-      // Enable navigation preload so the browser starts the network fetch in
-      // parallel with SW activation -- prevents the ~1.8s self-redirect that
-      // occurs when clients.claim() retriggers a navigation through the SW.
-      self.registration.navigationPreload?.enable() ?? Promise.resolve(),
-      self.clients.claim(),
-    ]),
-  )
+  event.waitUntil(self.registration.navigationPreload?.enable() ?? Promise.resolve())
 })
 
 self.addEventListener('push', (event) => {


### PR DESCRIPTION
## Summary

- `clients.claim()` in the SW `activate` handler caused Chrome to issue a second navigation fetch for the same URL immediately after SW activation
- Workbox's `precacheAndRoute` served that second fetch from precache (`transferSize: 0`), but Lighthouse still recorded two document requests to the same URL and modelled a 1,808ms redirect chain
- `navigationPreload` (added in #134) did not help because workbox serves the second navigation from cache without ever awaiting `event.preloadResponse`
- Removing `clients.claim()` eliminates the second document fetch entirely; the SW takes control naturally on the next navigation
- Push notifications are unaffected: the push handler already uses `clients.matchAll({ includeUncontrolled: true })`, which reaches uncontrolled clients fine

## Test plan

- [ ] Deploy and run Lighthouse mobile simulation on `/` -- `redirects` audit should pass (no wasted ms)
- [ ] Verify push notifications still arrive and trigger in-app badge/toast on first-load tabs
- [ ] Confirm SW still serves app offline (precache intact, only `clients.claim()` removed)
- [ ] All 133 unit tests pass (`pnpm test:unit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)