### PR TITLE
fix: show steering wheel heating alongside rear defroster in climate modal

### DIFF
--- a/frontend/src/components/ClimateDetailCard.vue
+++ b/frontend/src/components/ClimateDetailCard.vue
@@ -35,7 +35,7 @@ const seatLabels = computed(() => [
 
 const localClimateOn = ref<boolean | null>(props.climateOn)
 const localRearDefroster = ref<boolean | null>(props.rearWindowDefroster)
-const localSteeringWheel = ref<boolean | null>(props.steeringWheelHeating)
+const localSteeringWheel = ref<boolean | null>(props.steeringWheelHeating ?? false)
 const sliderTemp = ref<number>(props.remoteTemperature ?? 22)
 const seatLeftLocal = ref<number>(props.heatedSeatFrontLeft ?? 0)
 const seatRightLocal = ref<number>(props.heatedSeatFrontRight ?? 0)
@@ -44,7 +44,7 @@ watch(modalOpen, (open) => {
   if (open) {
     localClimateOn.value = props.climateOn
     localRearDefroster.value = props.rearWindowDefroster
-    localSteeringWheel.value = props.steeringWheelHeating
+    localSteeringWheel.value = props.steeringWheelHeating ?? false
     sliderTemp.value = props.remoteTemperature ?? 22
     seatLeftLocal.value = props.heatedSeatFrontLeft ?? 0
     seatRightLocal.value = props.heatedSeatFrontRight ?? 0
@@ -88,8 +88,8 @@ const hasPendingChanges = computed(() => {
   if (props.rearWindowDefroster !== null && localRearDefroster.value !== props.rearWindowDefroster)
     return true
   if (
-    props.steeringWheelHeating !== null &&
-    localSteeringWheel.value !== props.steeringWheelHeating
+    (props.steeringWheelHeating !== null || props.rearWindowDefroster !== null) &&
+    localSteeringWheel.value !== (props.steeringWheelHeating ?? false)
   )
     return true
   if (
@@ -128,8 +128,8 @@ async function applyAll() {
     )
   }
   if (
-    props.steeringWheelHeating !== null &&
-    localSteeringWheel.value !== props.steeringWheelHeating
+    (props.steeringWheelHeating !== null || props.rearWindowDefroster !== null) &&
+    localSteeringWheel.value !== (props.steeringWheelHeating ?? false)
   ) {
     const target = localSteeringWheel.value
     await send(
@@ -227,9 +227,9 @@ function onSeatRightChange(e: Event) {
         </div>
       </div>
 
-      <!-- Steering wheel heating toggle -->
+      <!-- Steering wheel heating toggle; shows with rear defroster since they share the same SAIC extra-heating API -->
       <div
-        v-if="steeringWheelHeating !== null"
+        v-if="steeringWheelHeating !== null || rearWindowDefroster !== null"
         class="detail-list__item detail-list__item--control"
       >
         <font-awesome-icon icon="life-ring" class="detail-list__item-icon" />

--- a/src/GarageStack.Tests/TelemetryMapperTests.cs
+++ b/src/GarageStack.Tests/TelemetryMapperTests.cs
@@ -369,6 +369,17 @@ public class TelemetryMapperTests
         Assert.True(snapshot.RearWindowDefroster);
     }
 
+    [Theory]
+    [InlineData("climate/steeringWheelHeating")]
+    [InlineData("climate/heatedSteeringWheel")]
+    [InlineData("climate/steeringWheelHeat")]
+    public void ApplyMessage_SteeringWheelHeatingAliases_SetsSteeringWheelHeating(string subtopic)
+    {
+        var snapshot = new TelemetrySnapshot();
+        TelemetryMapper.ApplyMessage(snapshot, subtopic, "true");
+        Assert.True(snapshot.SteeringWheelHeating);
+    }
+
     [Fact]
     public void ApplyMessage_HeatedSeatFrontLeft_SetsLevel()
     {

--- a/src/GarageStack.Worker/Mqtt/TelemetryMapper.cs
+++ b/src/GarageStack.Worker/Mqtt/TelemetryMapper.cs
@@ -223,6 +223,7 @@ public static class TelemetryMapper
                 break;
             case "climate/steeringWheelHeating":
             case "climate/heatedSteeringWheel":
+            case "climate/steeringWheelHeat":
                 snapshot.SteeringWheelHeating = asBool;
                 break;
 


### PR DESCRIPTION
## Summary

- **Steering wheel missing in staging**: The SAIC gateway only publishes `climate/steeringWheelHeating` as part of an extra-heating API response (triggered by a command), not in the initial vehicle state poll. The control was hidden behind `v-if="steeringWheelHeating !== null"`, so it never appeared until after a rear defroster or steering wheel command was sent.
- **Rear defroster "activating" steering wheel**: Rear window defroster and steering wheel heating are a combined feature in the SAIC protocol. When the rear defroster command is processed, the car responds with the state of both fields. Since `steeringWheelHeating` was previously null, it appeared for the first time (often as `true`) after the rear defroster toggle — making it look like the rear defroster caused it. This is car/API behaviour; the fix makes both controls visible together so the relationship is clear.

## Changes

- **`ClimateDetailCard.vue`**: Steering wheel toggle now shows whenever `rearWindowDefroster !== null`. Both fields come from the same SAIC extra-heating API call, so they belong together. Null `steeringWheelHeating` defaults to `false` in local state; `hasPendingChanges` and `applyAll` updated accordingly.
- **`TelemetryMapper.cs`**: Added `climate/steeringWheelHeat` alias to cover alternate topic names used by some gateway versions.
- **`TelemetryMapperTests.cs`**: Theory test covering all three steering wheel topic aliases (`steeringWheelHeating`, `heatedSteeringWheel`, `steeringWheelHeat`).

## Test plan

- [ ] In staging with real telemetry: open climate modal — steering wheel heating toggle is now visible (shown alongside rear defroster) even before any command is sent
- [ ] Toggle steering wheel heating independently and confirm it sends `steering-wheel` command without affecting rear defroster state
- [ ] Toggle rear defroster and confirm it sends `rear-defroster` command (steering wheel activation after this is SAIC API behaviour, not a bug)
- [ ] In demo mode: both controls still visible and behave as before
- [ ] All 225 .NET tests and 133 frontend tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)