### PR TITLE
ci: add workflow_dispatch trigger to docker-publish workflow

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,6 +1,7 @@
 name: Build and publish Docker images
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main


### PR DESCRIPTION
Adds a `workflow_dispatch` trigger so the Docker image build can be manually triggered from the GitHub UI or via `gh workflow run` -- useful for forcing a rebuild to pick up base image security patches without needing a code change.