### PR TITLE
feat: add speed overlay and route outline to map

### DIFF
--- a/frontend/src/assets/map.css
+++ b/frontend/src/assets/map.css
@@ -19,6 +19,7 @@
 }
 
 .map-wrapper {
+  position: relative;
   flex: 1;
   min-height: 0;
   border-radius: var(--radius);
@@ -120,6 +121,34 @@
 
 .map-canvas {
   height: 100%;
+}
+
+.speed-legend {
+  position: absolute;
+  bottom: 28px;
+  right: 10px;
+  z-index: 1000;
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius);
+  padding: 6px 8px;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.2);
+  font-size: 0.7rem;
+  min-width: 130px;
+  pointer-events: none;
+}
+
+.speed-legend__bar {
+  height: 8px;
+  border-radius: 4px;
+  background: linear-gradient(to right, #10b981, #84cc16, #f59e0b, #f97316, #ef4444);
+  margin-bottom: 4px;
+}
+
+.speed-legend__labels {
+  display: flex;
+  justify-content: space-between;
+  color: var(--color-text-muted);
 }
 
 .trip-list__info {

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -196,6 +196,8 @@
     "last30days": "Last 30 days",
     "last90days": "Last 90 days",
     "heatmap": "Heatmap",
+    "routeOutline": "Route outline",
+    "speedOverlay": "Speed overlay",
     "findCar": "Find car",
     "points": "pts"
   },

--- a/frontend/src/locales/nl.json
+++ b/frontend/src/locales/nl.json
@@ -196,6 +196,8 @@
     "last30days": "Afgelopen 30 dagen",
     "last90days": "Afgelopen 90 dagen",
     "heatmap": "Heatmap",
+    "routeOutline": "Route omlijning",
+    "speedOverlay": "Snelheidsoverlay",
     "findCar": "Vind auto",
     "points": "ptn"
   },

--- a/frontend/src/views/MapView.vue
+++ b/frontend/src/views/MapView.vue
@@ -29,6 +29,8 @@ const status = computed(() => store.currentStatus)
 const displayLocale = computed(() => (settingsStore.locale === 'nl' ? 'nl-NL' : 'en-US'))
 const selectedTripIndex = ref<number | null>(null)
 const heatmapEnabled = ref(true)
+const speedOverlayEnabled = ref(false)
+const routeOutlineEnabled = ref(true)
 let shouldSelectLatest = route.query.selectLatest === '1'
 
 const dateRangeDays = computed({
@@ -76,6 +78,35 @@ function tripColor(index: number): string {
 
 function tripColorClass(index: number): string {
   return `trip-list__dot--${index % tripColors.length}`
+}
+
+const speedStops: Array<{ speed: number; r: number; g: number; b: number }> = [
+  { speed: 0, r: 16, g: 185, b: 129 },
+  { speed: 50, r: 132, g: 204, b: 22 },
+  { speed: 90, r: 245, g: 158, b: 11 },
+  { speed: 120, r: 249, g: 115, b: 22 },
+  { speed: 150, r: 239, g: 68, b: 68 },
+]
+
+function speedToColor(speed: number | null, fallback: string): string {
+  if (speed === null) return fallback
+  const s = Math.max(0, speed)
+  const last = speedStops[speedStops.length - 1]!
+  if (s >= last.speed) return `rgb(${last.r},${last.g},${last.b})`
+  let lo = speedStops[0]!
+  let hi = last
+  for (let i = 0; i < speedStops.length - 1; i++) {
+    if (s >= speedStops[i]!.speed && s < speedStops[i + 1]!.speed) {
+      lo = speedStops[i]!
+      hi = speedStops[i + 1]!
+      break
+    }
+  }
+  const t = (s - lo.speed) / (hi.speed - lo.speed)
+  const r = Math.round(lo.r + t * (hi.r - lo.r))
+  const g = Math.round(lo.g + t * (hi.g - lo.g))
+  const b = Math.round(lo.b + t * (hi.b - lo.b))
+  return `rgb(${r},${g},${b})`
 }
 
 // Static initial centre - controlled by fitAll/flyToStatus after data loads.
@@ -143,6 +174,12 @@ function buildRouteLines() {
   store.trips.forEach((trip, i) => {
     const pts = trip.points.map((p) => [p.latitude, p.longitude] as [number, number])
     if (pts.length < 2) return
+    if (routeOutlineEnabled.value) {
+      const border = L.polyline(pts, { color: '#111', weight: 7, opacity: 0.4 })
+      border.on('click', () => selectTrip(i))
+      border.addTo(map)
+      routeLines.push(border)
+    }
     const line = L.polyline(pts, { color: tripColor(i), weight: 3, opacity: 0.75 })
     line.on('click', () => selectTrip(i))
     line.addTo(map)
@@ -157,11 +194,38 @@ function buildSelectedLine() {
   clearRouteLines()
   const trip = store.trips[idx]
   if (!trip) return
-  const pts = trip.points.map((p) => [p.latitude, p.longitude] as [number, number])
+  const pts = trip.points
   if (pts.length < 2) return
-  const line = L.polyline(pts, { color: tripColor(idx), weight: 5, opacity: 1 })
-  line.addTo(map)
-  routeLines.push(line)
+
+  const coords = pts.map((p) => [p.latitude, p.longitude] as [number, number])
+
+  if (routeOutlineEnabled.value) {
+    const border = L.polyline(coords, { color: '#111', weight: 9, opacity: 0.4 })
+    border.addTo(map)
+    routeLines.push(border)
+  }
+
+  if (speedOverlayEnabled.value) {
+    for (let i = 0; i < pts.length - 1; i++) {
+      const p0 = pts[i]!
+      const p1 = pts[i + 1]!
+      const color = speedToColor(p0.speed, tripColor(idx))
+      const segment = L.polyline(
+        [
+          [p0.latitude, p0.longitude],
+          [p1.latitude, p1.longitude],
+        ],
+        { color, weight: 5, opacity: 1, lineCap: 'square' },
+      )
+      segment.addTo(map)
+      routeLines.push(segment)
+    }
+  } else {
+    const line = L.polyline(coords, { color: tripColor(idx), weight: 5, opacity: 1 })
+    line.addTo(map)
+    routeLines.push(line)
+  }
+
   buildTripMarkers(trip)
 }
 
@@ -307,6 +371,26 @@ watch(heatmapEnabled, (enabled) => {
   else removeHeatLayer()
 })
 
+// Speed overlay toggle while a trip is selected
+watch(speedOverlayEnabled, () => {
+  if (selectedTripIndex.value === null) return
+  if (mapUpdateRaf !== null) cancelAnimationFrame(mapUpdateRaf)
+  mapUpdateRaf = requestAnimationFrame(() => {
+    mapUpdateRaf = null
+    buildSelectedLine()
+  })
+})
+
+// Route outline toggle: rebuild whichever layer is currently active
+watch(routeOutlineEnabled, () => {
+  if (mapUpdateRaf !== null) cancelAnimationFrame(mapUpdateRaf)
+  mapUpdateRaf = requestAnimationFrame(() => {
+    mapUpdateRaf = null
+    if (selectedTripIndex.value === null) buildRouteLines()
+    else buildSelectedLine()
+  })
+})
+
 // Date range change: reload trips and reset state
 watch(dateRangeDays, async (days) => {
   displayCount.value = LOAD_MORE_SIZE
@@ -420,6 +504,33 @@ onUnmounted(() => {
               />
             </div>
           </div>
+          <div class="settings-toggle">
+            <div class="settings-toggle__info">
+              <span class="settings-toggle__label">{{ t('trips.routeOutline') }}</span>
+            </div>
+            <div class="settings-toggle__control form-check form-switch">
+              <input
+                v-model="routeOutlineEnabled"
+                type="checkbox"
+                class="form-check-input"
+                :aria-label="t('trips.routeOutline')"
+              />
+            </div>
+          </div>
+          <div class="settings-toggle">
+            <div class="settings-toggle__info">
+              <span class="settings-toggle__label">{{ t('trips.speedOverlay') }}</span>
+            </div>
+            <div class="settings-toggle__control form-check form-switch">
+              <input
+                v-model="speedOverlayEnabled"
+                type="checkbox"
+                class="form-check-input"
+                :disabled="selectedTripIndex === null"
+                :aria-label="t('trips.speedOverlay')"
+              />
+            </div>
+          </div>
         </FiltersPanel>
         <button
           class="btn btn-sm btn-outline-secondary"
@@ -513,6 +624,20 @@ onUnmounted(() => {
             <LPopup>{{ store.vehicles[0]?.model ?? store.vehicles[0]?.vin }}</LPopup>
           </LMarker>
         </LMap>
+
+        <div
+          v-if="speedOverlayEnabled && selectedTripIndex !== null"
+          class="speed-legend"
+          :aria-label="t('trips.speedOverlay')"
+        >
+          <div class="speed-legend__bar"></div>
+          <div class="speed-legend__labels">
+            <span>0</span>
+            <span>50</span>
+            <span>90</span>
+            <span>130+ km/h</span>
+          </div>
+        </div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Summary

- **Speed overlay** -- new filter toggle (active only when a trip is selected) that replaces the single-colour route line with per-segment polylines colour-coded by speed: green (0 km/h) through amber to red (130+ km/h). A small gradient legend appears on the map while the overlay is on.
- **Route outline** -- draws a dark casing polyline (2 px wider on each side, `#111` at 40% opacity) under every route line for contrast against light map tiles. On by default, toggled independently. Works with both single-colour and speed-overlay modes.
- i18n keys added for EN (`routeOutline`, `speedOverlay`) and NL (`Route omlijning`, `Snelheidsoverlay`).

## Test plan

- [ ] Open the Map view -- all trip routes should have a visible dark outline by default
- [ ] Toggle **Route outline** off -- outlines disappear instantly, routes revert to flat colour lines
- [ ] Select a trip -- route is highlighted, outline still shows correctly
- [ ] Toggle **Speed overlay** on (only enabled when a trip is selected) -- route repaints with green/amber/red gradient segments; speed legend appears bottom-right of the map
- [ ] Toggle **Route outline** off while speed overlay is active -- casing under the gradient segments disappears
- [ ] Deselect the trip -- speed overlay toggle becomes disabled, all-trips view rebuilds with current outline setting
- [ ] Verify legend and toggles in both light and dark theme
- [ ] Verify layout on mobile (sidebar stacked above map)

🤖 Generated with [Claude Code](https://claude.com/claude-code)