### PR TITLE
ci: make GHA cache write failure non-fatal in docker-publish

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -146,7 +146,7 @@ jobs:
             APP_VERSION=${{ steps.minver.outputs.version }}
           # Each image gets its own GHA cache scope
           cache-from: type=gha,scope=${{ matrix.label }}
-          cache-to: type=gha,scope=${{ matrix.label }},mode=min
+          cache-to: type=gha,scope=${{ matrix.label }},mode=min,ignore-error=true
 
       - name: Sign image with Cosign
         if: github.event_name != 'pull_request'


### PR DESCRIPTION
## Summary

- Adds `ignore-error=true` to the `cache-to` parameter in the Docker publish workflow
- Prevents a full or unavailable GitHub Actions cache (10 GB repo limit) from failing an otherwise-successful build
- The cache write failure that caused the `error writing layer blob: not_found` error is now treated as a warning

## Test plan

- [ ] Trigger a manual `workflow_dispatch` run and confirm all four images build and push successfully
- [ ] Optionally clear stale GHA caches under Actions > Caches to restore effective caching

🤖 Generated with [Claude Code](https://claude.com/claude-code)