### PR TITLE
feat: add icons to map filter panel toggles

### DIFF
--- a/frontend/src/assets/main.css
+++ b/frontend/src/assets/main.css
@@ -1297,6 +1297,12 @@ body,
   font-weight: 500;
 }
 
+.settings-toggle__icon {
+  width: 0.85em;
+  margin-right: 0.35rem;
+  color: var(--color-text-muted);
+}
+
 .settings-toggle__desc {
   font-size: 0.78rem;
   color: var(--color-text-muted);

--- a/frontend/src/views/MapView.vue
+++ b/frontend/src/views/MapView.vue
@@ -496,7 +496,10 @@ onUnmounted(() => {
         <FiltersPanel>
           <div class="settings-toggle">
             <div class="settings-toggle__info">
-              <span class="settings-toggle__label">{{ t('trips.dateRange') }}</span>
+              <span class="settings-toggle__label">
+                <font-awesome-icon icon="calendar-check" class="settings-toggle__icon" />
+                {{ t('trips.dateRange') }}
+              </span>
             </div>
             <div class="settings-toggle__control">
               <select v-model="dateRangeDays" class="form-select form-select-sm">
@@ -508,7 +511,10 @@ onUnmounted(() => {
           </div>
           <div class="settings-toggle">
             <div class="settings-toggle__info">
-              <span class="settings-toggle__label">{{ t('trips.heatmap') }}</span>
+              <span class="settings-toggle__label">
+                <font-awesome-icon icon="fire" class="settings-toggle__icon" />
+                {{ t('trips.heatmap') }}
+              </span>
             </div>
             <div class="settings-toggle__control form-check form-switch">
               <input
@@ -521,7 +527,10 @@ onUnmounted(() => {
           </div>
           <div class="settings-toggle">
             <div class="settings-toggle__info">
-              <span class="settings-toggle__label">{{ t('trips.routeOutline') }}</span>
+              <span class="settings-toggle__label">
+                <font-awesome-icon icon="route" class="settings-toggle__icon" />
+                {{ t('trips.routeOutline') }}
+              </span>
             </div>
             <div class="settings-toggle__control form-check form-switch">
               <input
@@ -534,7 +543,10 @@ onUnmounted(() => {
           </div>
           <div class="settings-toggle">
             <div class="settings-toggle__info">
-              <span class="settings-toggle__label">{{ t('trips.speedOverlay') }}</span>
+              <span class="settings-toggle__label">
+                <font-awesome-icon icon="gauge" class="settings-toggle__icon" />
+                {{ t('trips.speedOverlay') }}
+              </span>
             </div>
             <div class="settings-toggle__control form-check form-switch">
               <input


### PR DESCRIPTION
## Summary

Each row in the map FiltersPanel now has a muted Font Awesome icon before the label, consistent with the icon treatment seen in other parts of the UI:

| Toggle | Icon |
|---|---|
| Date range | `calendar-check` |
| Heatmap | `fire` |
| Route outline | `route` |
| Speed overlay | `gauge` |

All four icons were already registered in the FA library (`main.ts`). A single new CSS class `.settings-toggle__icon` in `main.css` sets the fixed width and muted colour.

## Test plan

- [ ] Open the map filters panel -- all four rows show their icon at the left of the label
- [ ] Icons are muted (match `--color-text-muted`) in both dark and light theme
- [ ] Layout is not broken on mobile (sidebar stacked above map)

🤖 Generated with [Claude Code](https://claude.com/claude-code)