### PR TITLE
ci: fix image scan racing ahead of docker publish

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -5,6 +5,10 @@ on:
     branches: [main]
   push:
     branches: [main]
+  workflow_run:
+    workflows: ["Build and publish Docker images"]
+    types: [completed]
+    branches: [main]
   schedule:
     - cron: '0 7 * * 1'
 
@@ -52,7 +56,7 @@ jobs:
   trivy-image:
     name: Trivy image scan (${{ matrix.label }})
     runs-on: ubuntu-latest
-    if: github.event_name != 'pull_request'
+    if: github.event_name != 'pull_request' && (github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success')
     permissions:
       contents: read
       security-events: write


### PR DESCRIPTION
## Problem
`security.yml` and `docker-publish.yml` both trigger simultaneously on push to `main`. The Trivy image scan immediately pulls `:latest` from GHCR -- but that image hasn't been rebuilt yet, so it always scans the **previous** version and reports stale CVEs even after the fix has been published.

## Fix
Add a `workflow_run` trigger on `Build and publish Docker images` so the image scan only starts once the publish has successfully completed. The `push`/`PR` triggers are kept so the filesystem scan still runs immediately on every commit.

The `trivy-image` job guard is updated to skip the scan if the triggering publish workflow failed (no point scanning an image that wasn't updated).