### PR TITLE
feat: make speed overlay toggle always interactive

### DIFF
--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -198,6 +198,7 @@
     "heatmap": "Heatmap",
     "routeOutline": "Route outline",
     "speedOverlay": "Speed overlay",
+    "speedOverlayDesc": "Visible when a single trip is selected",
     "findCar": "Find car",
     "points": "pts"
   },

--- a/frontend/src/locales/nl.json
+++ b/frontend/src/locales/nl.json
@@ -198,6 +198,7 @@
     "heatmap": "Heatmap",
     "routeOutline": "Route omlijning",
     "speedOverlay": "Snelheidsoverlay",
+    "speedOverlayDesc": "Zichtbaar wanneer een enkele rit is geselecteerd",
     "findCar": "Vind auto",
     "points": "ptn"
   },

--- a/frontend/src/views/MapView.vue
+++ b/frontend/src/views/MapView.vue
@@ -547,13 +547,13 @@ onUnmounted(() => {
                 <font-awesome-icon icon="gauge" class="settings-toggle__icon" />
                 {{ t('trips.speedOverlay') }}
               </span>
+              <span class="settings-toggle__desc">{{ t('trips.speedOverlayDesc') }}</span>
             </div>
             <div class="settings-toggle__control form-check form-switch">
               <input
                 v-model="speedOverlayEnabled"
                 type="checkbox"
                 class="form-check-input"
-                :disabled="selectedTripIndex === null"
                 :aria-label="t('trips.speedOverlay')"
               />
             </div>


### PR DESCRIPTION
## Summary

- Speed overlay checkbox is no longer disabled when no trip is selected, so users can pre-enable it before tapping a trip.
- The overlay still only renders when a single trip is active (existing watch + `buildSelectedLine` logic unchanged).
- Added muted subtext under the toggle label: *"Visible when a single trip is selected"* (EN) / *"Zichtbaar wanneer een enkele rit is geselecteerd"* (NL).

## Test plan

- [ ] Open filters panel with no trip selected -- Speed overlay toggle is now interactive (not greyed out)
- [ ] Enable speed overlay, then select a trip -- route immediately renders with speed colour-coding
- [ ] Deselect the trip -- speed overlay gradient disappears, all-trips view is unaffected
- [ ] Subtext is visible under the Speed overlay label in both EN and NL

🤖 Generated with [Claude Code](https://claude.com/claude-code)