### PR TITLE
feat: add calendar icon and subtext to statistics date range filter

### DIFF
--- a/frontend/src/views/StatisticsView.vue
+++ b/frontend/src/views/StatisticsView.vue
@@ -631,7 +631,11 @@ const skeletonChartCount = computed(
         <FiltersPanel>
           <div class="settings-toggle">
             <div class="settings-toggle__info">
-              <span class="settings-toggle__label">{{ t('trips.dateRange') }}</span>
+              <span class="settings-toggle__label">
+                <font-awesome-icon icon="calendar-check" class="settings-toggle__icon" />
+                {{ t('trips.dateRange') }}
+              </span>
+              <span class="settings-toggle__desc">{{ t('trips.dateRangeDesc') }}</span>
             </div>
             <div class="settings-toggle__control">
               <select v-model="days" class="form-select form-select-sm">


### PR DESCRIPTION
## Summary
- Adds `calendar-check` icon to the date range label in the Statistics view FiltersPanel
- Adds `dateRangeDesc` subtext below the label
- Aligns the Statistics filter UI with the identical pattern already used in MapView

## Test plan
- [ ] Open the Statistics page and click the filter icon
- [ ] Confirm the date range control shows the calendar icon and description subtext
- [ ] Confirm the MapView filter still looks unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)