### PR TITLE
fix(security): upgrade OS packages and schedule weekly image rebuilds

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -2,6 +2,8 @@ name: Build and publish Docker images
 
 on:
   workflow_dispatch:
+  schedule:
+    - cron: '0 5 * * 1'
   push:
     branches:
       - main

--- a/docker/all-in-one/Dockerfile
+++ b/docker/all-in-one/Dockerfile
@@ -53,6 +53,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
     apt-get update \
+    && apt-get upgrade -y --no-install-recommends \
     && apt-get install -y --no-install-recommends \
         bash curl gnupg ca-certificates gosu supervisor \
         nginx mosquitto mosquitto-clients \


### PR DESCRIPTION
## Summary

- Added `apt-get upgrade -y --no-install-recommends` to `docker/all-in-one/Dockerfile` to patch `linux-libc-dev` CVEs (12x medium severity) that were not being upgraded from the `python:3.14-slim` base image
- Added a weekly Monday 5am UTC rebuild schedule to `docker-publish.yml` so all images automatically pick up OS security patches without requiring a code push

## Background

All 30+ GitHub code scanning alerts are OS-level container package CVEs from Trivy:
- **`garagestack` (all-in-one)**: `linux-libc-dev` 6.12.90-2, fixed in 6.12.94-1 — the all-in-one Dockerfile was missing `apt-get upgrade`, which the API/Worker Dockerfiles already had
- **`garagestack-frontend`**: `libexpat` 2.7.5-r0, fixed in 2.8.1-r0 — `apk upgrade --no-cache` was already in place; fixed on next rebuild

## Test plan

- [ ] Verify the all-in-one Docker image builds successfully in CI
- [ ] Confirm Trivy scan no longer reports `linux-libc-dev` CVEs after rebuild
- [ ] Confirm `libexpat` CVEs are cleared in the frontend image after rebuild

🤖 Generated with [Claude Code](https://claude.com/claude-code)