### PR TITLE
feat(pwa): add app badge support for push notifications

### DIFF
--- a/frontend/src/composables/useNotifications.ts
+++ b/frontend/src/composables/useNotifications.ts
@@ -4,6 +4,20 @@ import { useAuthStore } from '@/stores/auth'
 
 const notifications = ref<AppNotification[]>([])
 
+type BadgingNavigator = Navigator & {
+  setAppBadge?: (count?: number) => Promise<void>
+  clearAppBadge?: () => Promise<void>
+}
+
+function syncBadge(count: number) {
+  const nav = navigator as BadgingNavigator
+  if (count > 0) {
+    nav.setAppBadge?.(count)
+  } else {
+    nav.clearAppBadge?.()
+  }
+}
+
 export function prependNotification(notification: AppNotification) {
   notifications.value = [notification, ...notifications.value]
 }
@@ -20,6 +34,7 @@ export function useNotifications() {
     fetchError.value = null
     try {
       notifications.value = await notificationsApi.list()
+      syncBadge(unreadCount.value)
     } catch (err) {
       fetchError.value = err instanceof Error ? err.message : 'Failed to load notifications'
     } finally {
@@ -65,16 +80,19 @@ export function useNotifications() {
   async function archiveAllNotifications() {
     await notificationsApi.archiveAll()
     notifications.value.forEach((n) => (n.isArchived = true))
+    syncBadge(0)
   }
 
   async function deleteNotification(id: number) {
     await notificationsApi.delete(id)
     notifications.value = notifications.value.filter((n) => n.id !== id)
+    syncBadge(unreadCount.value)
   }
 
   async function deleteAllNotifications() {
     await notificationsApi.deleteAll()
     notifications.value = []
+    syncBadge(0)
   }
 
   function togglePanel() {

--- a/frontend/src/sw.ts
+++ b/frontend/src/sw.ts
@@ -12,10 +12,21 @@ self.addEventListener('activate', (event) => {
   event.waitUntil(self.registration.navigationPreload?.enable() ?? Promise.resolve())
 })
 
+type BadgingNavigator = WorkerNavigator & {
+  setAppBadge?: (count?: number) => Promise<void>
+  clearAppBadge?: () => Promise<void>
+}
+
 self.addEventListener('push', (event) => {
   if (!event.data) return
 
-  let payload: { title?: string; body?: string; url?: string; category?: string } = {}
+  let payload: {
+    title?: string
+    body?: string
+    url?: string
+    category?: string
+    unreadCount?: number
+  } = {}
   try {
     payload = event.data.json() as typeof payload
   } catch {
@@ -33,8 +44,14 @@ self.addEventListener('push', (event) => {
     data: { url: payload.url ?? '/' },
   }
 
+  const badgeNav = self.navigator as BadgingNavigator
+  const badgePromise =
+    payload.unreadCount !== undefined
+      ? (badgeNav.setAppBadge?.(payload.unreadCount) ?? Promise.resolve())
+      : (badgeNav.setAppBadge?.() ?? Promise.resolve())
+
   event.waitUntil(
-    self.registration.showNotification(title, options).then(() =>
+    Promise.all([self.registration.showNotification(title, options), badgePromise]).then(() =>
       self.clients.matchAll({ type: 'window', includeUncontrolled: true }).then((clientList) => {
         for (const client of clientList) {
           client.postMessage({ type: 'NOTIFICATION_RECEIVED', category: payload.category })
@@ -57,14 +74,21 @@ self.addEventListener('notificationclick', (event) => {
     }
   })()
 
+  // Clear the badge — the app will re-sync the correct count after it loads
+  const badgeNav = self.navigator as BadgingNavigator
+  const clearPromise = badgeNav.clearAppBadge?.() ?? Promise.resolve()
+
   event.waitUntil(
-    self.clients.matchAll({ type: 'window', includeUncontrolled: true }).then((clientList) => {
-      const existing = clientList.find((c) => c.url.includes(self.location.origin))
-      if (existing) {
-        existing.focus()
-        return existing.navigate(targetUrl)
-      }
-      return self.clients.openWindow(targetUrl)
-    }),
+    Promise.all([
+      clearPromise,
+      self.clients.matchAll({ type: 'window', includeUncontrolled: true }).then((clientList) => {
+        const existing = clientList.find((c) => c.url.includes(self.location.origin))
+        if (existing) {
+          existing.focus()
+          return existing.navigate(targetUrl)
+        }
+        return self.clients.openWindow(targetUrl)
+      }),
+    ]),
   )
 })

--- a/src/GarageStack.Worker/Services/PushSenderService.cs
+++ b/src/GarageStack.Worker/Services/PushSenderService.cs
@@ -64,6 +64,9 @@ public sealed class PushSenderService : IPushSender, IDisposable
             recordDb.AppNotifications.Add(record);
             await recordDb.SaveChangesAsync(ct);
 
+            var unreadCount = await recordDb.AppNotifications
+                .CountAsync(n => !n.IsArchived && !n.IsDeleted, ct);
+
             // Signal the API process via PostgreSQL so connected browser clients get
             // an immediate notificationReceived push without polling.
             var notifyJson = JsonSerializer.Serialize(new
@@ -74,6 +77,7 @@ public sealed class PushSenderService : IPushSender, IDisposable
                 createdAt = record.CreatedAt.ToString("O"),
                 category = record.Category,
                 vehicleId = record.VehicleId,
+                unreadCount,
             });
             await recordDb.Database.ExecuteSqlInterpolatedAsync(
                 $"SELECT pg_notify('notification_created', {notifyJson})", ct);
@@ -90,7 +94,9 @@ public sealed class PushSenderService : IPushSender, IDisposable
         var subscriptions = await db.PushSubscriptions.AsNoTracking().ToListAsync(ct);
         if (subscriptions.Count == 0) return;
 
-        var payload = System.Text.Json.JsonSerializer.Serialize(new { title, body, icon = "/icons/icon-192.png", category });
+        var unreadCountForPayload = await db.AppNotifications
+            .CountAsync(n => !n.IsArchived && !n.IsDeleted, ct);
+        var payload = System.Text.Json.JsonSerializer.Serialize(new { title, body, icon = "/icons/icon-192.png", category, unreadCount = unreadCountForPayload });
         var message = new PushMessage(payload) { TimeToLive = 3600 };
         var dead = new List<ModelPushSubscription>();
 


### PR DESCRIPTION
## Summary

- Includes `unreadCount` in the web push payload (backend) and PostgreSQL NOTIFY payload so both SW and SignalR paths carry the count
- Service worker calls `navigator.setAppBadge(unreadCount)` on each incoming push and `clearAppBadge()` when the user taps a notification
- Frontend (`useNotifications`) calls `setAppBadge`/`clearAppBadge` from the main thread after fetching notifications or after archive-all/delete-all, keeping the badge in sync while the app is open

## Test plan

- [ ] Install the PWA on Android (Chrome) and subscribe to push notifications
- [ ] Trigger a push notification — badge count should appear on the launcher icon
- [ ] Trigger multiple notifications — badge should reflect the cumulative unread count
- [ ] Tap the notification — badge should clear; opening the app re-syncs the correct count
- [ ] Archive all / delete all in the notification panel — badge clears immediately
- [ ] Verify no TypeScript errors (`pnpm exec tsc --noEmit`)
- [ ] Verify all 133 frontend unit tests pass (`pnpm exec vitest run`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)