### PR TITLE
fix(dashboard): unify last trip logic with map view

### DIFF
--- a/frontend/src/components/DashboardCardContent.vue
+++ b/frontend/src/components/DashboardCardContent.vue
@@ -33,6 +33,7 @@ const vehicleType = computed((): VehicleType | 'unknown' => {
 })
 
 const isHev = computed(() => vehicleType.value === 'hev')
+const latestTrip = computed(() => store.trips[store.trips.length - 1] ?? null)
 const supportsExternalCharge = computed(
   () => vehicleType.value === 'phev' || vehicleType.value === 'bev',
 )
@@ -255,13 +256,13 @@ const supportsExternalCharge = computed(
       :value="
         status.currentJourneyDistance !== null && status.currentJourneyDistance > 0
           ? status.currentJourneyDistance.toFixed(1)
-          : store.lastTrip
-            ? store.lastTrip.distanceKm.toFixed(1)
+          : latestTrip
+            ? latestTrip.distanceKm.toFixed(1)
             : t('vehicle.noTrips')
       "
       :unit="
         (status.currentJourneyDistance !== null && status.currentJourneyDistance > 0) ||
-        store.lastTrip !== null
+        latestTrip !== null
           ? t('common.km')
           : undefined
       "
@@ -272,7 +273,7 @@ const supportsExternalCharge = computed(
       "
       :clickable="
         !(status.currentJourneyDistance !== null && status.currentJourneyDistance > 0) &&
-        store.lastTrip !== null
+        latestTrip !== null
       "
       @click="router.push({ name: 'map', query: { selectLatest: '1' } })"
     />

--- a/frontend/src/stores/vehicle.ts
+++ b/frontend/src/stores/vehicle.ts
@@ -1,12 +1,6 @@
 import { defineStore } from 'pinia'
 import { ref, computed, nextTick } from 'vue'
-import {
-  vehicleApi,
-  type Vehicle,
-  type TelemetrySnapshot,
-  type Trip,
-  type LastTripSummary,
-} from '@/services/api'
+import { vehicleApi, type Vehicle, type TelemetrySnapshot, type Trip } from '@/services/api'
 
 export type VehicleType = 'hev' | 'phev' | 'bev' | 'unknown'
 
@@ -16,7 +10,6 @@ export const useVehicleStore = defineStore('vehicle', () => {
   const vehicleConfig = ref<Record<string, string>>({})
   const history = ref<TelemetrySnapshot[]>([])
   const trips = ref<Trip[]>([])
-  const lastTrip = ref<LastTripSummary | null>(null)
   const loadingCount = ref(0)
   const loading = computed(() => loadingCount.value > 0)
   const sendingCount = ref(0)
@@ -101,14 +94,6 @@ export const useVehicleStore = defineStore('vehicle', () => {
     })
   }
 
-  async function fetchLastTrip(vin: string) {
-    try {
-      lastTrip.value = (await vehicleApi.lastTrip(vin)) ?? null
-    } catch {
-      // non-critical, leave stale value
-    }
-  }
-
   async function fetchTrips(vin: string, from?: string, to?: string) {
     loadingCount.value++
     error.value = null
@@ -138,7 +123,6 @@ export const useVehicleStore = defineStore('vehicle', () => {
     detectedVehicleType,
     history,
     trips,
-    lastTrip,
     loading,
     anySending,
     sendingCount,
@@ -151,7 +135,6 @@ export const useVehicleStore = defineStore('vehicle', () => {
     fetchConfig,
     fetchHistory,
     fetchTrips,
-    fetchLastTrip,
     applyLiveStatus,
     notifyTripCompleted,
   }

--- a/frontend/src/views/DashboardView.vue
+++ b/frontend/src/views/DashboardView.vue
@@ -178,8 +178,14 @@ function resetLayout() {
 async function refresh() {
   await store.fetchVehicles()
   if (vin.value) {
-    await Promise.all([store.fetchStatus(vin.value), store.fetchConfig(vin.value)])
-    store.fetchLastTrip(vin.value)
+    await Promise.all([
+      store.fetchStatus(vin.value),
+      store.fetchConfig(vin.value),
+      store.fetchTrips(
+        vin.value,
+        new Date(Date.now() - settings.filterDays * 86_400_000).toISOString(),
+      ),
+    ])
   }
 }
 


### PR DESCRIPTION
## Summary
- Removes the dedicated `/trips/last` endpoint usage (`fetchLastTrip`) from the dashboard, which used different backend query logic than the map view's trips list
- Dashboard `refresh()` now calls `fetchTrips` in parallel with status/config, using the same `settings.filterDays` date window as MapView
- The `activeTrip` card derives the latest trip from `store.trips[store.trips.length - 1]` (last element = newest trip, same as MapView's sidebar top item) instead of the separate `store.lastTrip` state

## Test plan
- [ ] Dashboard `activeTrip` card shows the same trip as the first entry in the MapView sidebar
- [ ] Clicking the `activeTrip` card still navigates to MapView with `selectLatest=1` and highlights the correct trip
- [ ] All 133 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)