### PR TITLE
feat(dashboard,stats): add top speed and average speed cards

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ GarageStack is a free, open-source vehicle monitoring dashboard for **modern MG 
 
 - **Live dashboard** -- Real-time vehicle telemetry displayed as configurable cards. Cards are automatically shown or hidden based on your vehicle type (HEV, PHEV, BEV) and can be reordered or toggled individually in the dashboard's edit mode.
 - **Trip history** -- Browse past journeys on an interactive map with route playback and heatmap visualisation to identify frequently driven roads.
-- **Energy statistics** -- Track daily energy consumption, efficiency (Wh/km), fuel use, and electric share over time.
+- **Energy statistics** -- Track daily energy consumption, efficiency (Wh/km), fuel use, electric share, average driving speed, and more over a configurable time window.
 - **Remote commands** -- Trigger climate pre-conditioning, lock or unlock the car, and activate the horn and lights remotely from the dashboard.
 - **Push notifications** -- Browser and in-app alerts for key events: engine started, low tyre pressure, low EV battery, car left unlocked, and doors or windows left open.
 - **Homepage widget** -- A read-only API endpoint for the [gethomepage.dev](https://gethomepage.dev) Custom API widget, exposing key vehicle stats at a glance.
@@ -24,7 +24,7 @@ GarageStack is a free, open-source vehicle monitoring dashboard for **modern MG 
 Cards are shown or hidden automatically based on vehicle type (HEV / PHEV / BEV). You can also reorder and toggle individual cards in the dashboard's edit mode.
 
 | Card | Description | Vehicle types |
-|------|-------------|---------------|
+| ---- | ----------- | ------------- |
 | Fuel Level | Tank level as a percentage | HEV, PHEV |
 | Fuel Range | Estimated remaining range | HEV, PHEV |
 | EV Battery | State of charge (%) | All |
@@ -43,17 +43,36 @@ Cards are shown or hidden automatically based on vehicle type (HEV / PHEV / BEV)
 | Since Charge | Distance since last charge session | PHEV, BEV |
 | Efficiency | Energy per km (Wh/km) | All |
 | Speed | Current vehicle speed | All |
+| Top Speed | Highest speed recorded in the most recent completed trip | All |
 | Active Trip | Distance covered in the current trip | All |
 | Online Status | Whether the car is reachable via SAIC cloud | All |
 | Charge Time | Estimated minutes remaining to charge limit | PHEV, BEV |
 | Charging Session | OBC power, cable lock, charging type | PHEV, BEV |
 | Battery Heating | Pre-heating status and schedule | PHEV, BEV |
 
+### Statistics insights
+
+The Statistics view shows insight cards and charts for a configurable period (7, 30, or 90 days). Cards are draggable and individually toggleable.
+
+| Insight | Description |
+| ------- | ----------- |
+| Distance in period | Total distance across all trips in the selected window |
+| Avg trip length | Average distance per trip |
+| Remote preconditioning | Percentage of snapshots with remote climate active |
+| Peak drive time | Hour of day with the most trip starts |
+| 12V trend | Change in average 12V battery voltage over the period |
+| Parking locations | Number of distinct parking spots (rounded GPS) |
+| Electric share today | Estimated share of today's driving on electric power (PHEV only) |
+| Avg speed | Average moving speed across all GPS points in the period, excluding stopped moments |
+
 ## Screenshots
 
-| Desktop | Mobile |
-|---------|--------|
-| ![Desktop dashboard](frontend/public/screenshot-desktop-home.webp) | ![Mobile dashboard](frontend/public/screenshot-mobile-home.webp) |
+| Desktop          | Mobile         |
+| ---------------- | -------------- |
+| ![Desktop][desk] | ![Mobile][mob] |
+
+[desk]: frontend/public/screenshot-desktop-home.webp "Desktop dashboard"
+[mob]: frontend/public/screenshot-mobile-home.webp "Mobile dashboard"
 
 ---
 
@@ -82,7 +101,7 @@ Choose the method that fits your environment.
 
 A single Docker image that bundles every service -- nginx, the .NET API + worker, PostgreSQL, Mosquitto, and the SAIC gateway. No Compose file or external database needed. Ideal for Unraid and similar NAS environments where running multiple containers is inconvenient.
 
-**Quick start**
+#### Quick start
 
 ```bash
 docker run -d \
@@ -111,7 +130,7 @@ See [`docker/all-in-one/README.md`](docker/all-in-one/README.md) for the full va
 
 Separate containers for each service. More flexible -- you can swap in your own PostgreSQL or MQTT broker, and containers update independently.
 
-**1. Clone the repository**
+#### 1. Clone the repository
 
 ```bash
 git clone https://github.com/joszz/garagestack.git
@@ -127,7 +146,7 @@ cp .env.example .env
 Then open `.env` and fill in at minimum:
 
 | Variable | Description |
-|----------|-------------|
+| ---------- | ----------- |
 | `SAIC_USER` | MG iSmart account email |
 | `SAIC_PASSWORD` | MG iSmart account password |
 | `SAIC_REGION` | `eu`, `cn`, or `row` |
@@ -137,7 +156,7 @@ Then open `.env` and fill in at minimum:
 
 `VAPID_PUBLIC_KEY` / `VAPID_PRIVATE_KEY` are optional; leave them empty to disable push notifications.
 
-**3. Start the stack**
+#### 3. Start the stack
 
 With the bundled PostgreSQL container:
 
@@ -160,7 +179,7 @@ The frontend is served on port `8080` by default (configurable via `FRONTEND_POR
 GarageStack checks your vehicle's state every 5 minutes and sends both a browser push notification and an in-app notification (bell icon) when any of the following conditions are detected. Each alert has a 1-hour cooldown per vehicle to avoid repeated notifications.
 
 | Alert | Condition |
-|-------|-----------|
+| ------- | --------- |
 | Engine started | Engine transitions from off to running |
 | Low tyre pressure | Any tyre below 2.2 bar |
 | Low EV battery | EV state-of-charge below 20 % |
@@ -224,7 +243,7 @@ Add the following block to your Homepage `services.yaml`, replacing `YOUR_GARAGE
 The endpoint returns a flat JSON object. Numeric fields are `null` when the vehicle has not reported that value yet. String state fields are also `null` when unreported, except `anyDoorOpen` and `anyWindowOpen` which are always present. String values are localized: the language is resolved from the request in this order: query string, cookie, `Accept-Language` header, falling back to `en`. Supported languages are `en` and `nl`. To pin a language regardless of the Homepage container's locale, append `?culture=nl&ui-culture=nl` (or `en`) to the widget URL.
 
 | Field | Type | Description |
-|-------|------|-------------|
+| ------- | ------ | ----------- |
 | `recordedAt` | string (ISO 8601) | Timestamp of the most recent telemetry |
 | `fuelLevelPercent` | number | Fuel tank level (%) |
 | `fuelRangeKm` | number | Estimated fuel range (km) |
@@ -348,10 +367,8 @@ All three POI types share the same tile-based PostgreSQL cache:
 
 The Docker build workflow requires two repository secrets to avoid Docker Hub anonymous pull rate limits (GitHub runners share IPs and exhaust the limit quickly):
 
-| Secret | Description |
-|--------|-------------|
-| `DOCKERHUB_USERNAME` | Your Docker Hub username |
-| `DOCKERHUB_TOKEN` | A Docker Hub access token (hub.docker.com > Account Settings > Security > New Access Token) |
+- **`DOCKERHUB_USERNAME`** - Your Docker Hub username
+- **`DOCKERHUB_TOKEN`** - A Docker Hub access token (hub.docker.com > Account Settings > Security > New Access Token)
 
 Add them under **Settings > Secrets and variables > Actions** in your fork. A free Docker Hub account is sufficient.
 

--- a/frontend/src/components/DashboardCardContent.vue
+++ b/frontend/src/components/DashboardCardContent.vue
@@ -34,6 +34,11 @@ const vehicleType = computed((): VehicleType | 'unknown' => {
 
 const isHev = computed(() => vehicleType.value === 'hev')
 const latestTrip = computed(() => store.trips[store.trips.length - 1] ?? null)
+const topSpeedKmh = computed(() => {
+  if (!latestTrip.value) return null
+  const speeds = latestTrip.value.points.map((p) => p.speed).filter((s): s is number => s !== null)
+  return speeds.length ? Math.round(Math.max(...speeds)) : null
+})
 const supportsExternalCharge = computed(
   () => vehicleType.value === 'phev' || vehicleType.value === 'bev',
 )
@@ -314,6 +319,15 @@ const supportsExternalCharge = computed(
       :battery-heating="status.batteryHeating"
       :schedule-mode="status.batteryHeatingScheduleMode"
       :schedule-start-time="status.batteryHeatingScheduleStartTime"
+    />
+
+    <!-- topSpeed -->
+    <StatusCard
+      v-else-if="cardId === 'topSpeed' && topSpeedKmh !== null"
+      icon="gauge-high"
+      :label="t('vehicle.topSpeed')"
+      :value="topSpeedKmh"
+      unit="km/h"
     />
   </template>
 </template>

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -32,6 +32,7 @@
       "efficiencyCharge": "Distance driven since the last charge session.",
       "efficiencyRatio": "Energy today divided by distance today (Wh/km). Lower is better. On a BEV or PHEV in EV mode this translates directly to electricity cost per km. On an HEV it shows how efficiently the hybrid system ran - motorway driving gives a lower figure than stop-start city traffic. When no driving data is available yet, HEV and PHEV fall back to showing estimated fuel economy (km/%) derived from the car's own range computer: higher is more efficient.",
       "speed": "Current vehicle speed as reported by the gateway.",
+      "topSpeed": "Highest speed recorded across all GPS points in the most recent completed trip.",
       "activeTrip": "Distance covered in the current trip while active, or the distance of the last completed trip when parked.",
       "onlineStatus": "Whether the car is currently reachable via the SAIC cloud. Goes offline when the car is parked and the gateway stops polling.",
       "remainingCharge": "Estimated minutes remaining until the battery reaches the configured charge limit. Only relevant for PHEV and BEV while charging.",
@@ -49,7 +50,8 @@
       "commutePattern": "Peak drive time",
       "batteryVoltageTrend": "12V trend",
       "parkingLocations": "Parking locations",
-      "electricShare": "Electric share today"
+      "electricShare": "Electric share today",
+      "avgSpeed": "Avg speed"
     },
     "cardDesc": {
       "distanceInRange": "Total distance across all trips in the selected time window.",
@@ -58,7 +60,8 @@
       "commutePattern": "The hour of day with the most trip starts in the selected period - your most common time to drive.",
       "batteryVoltageTrend": "Change in average 12V battery voltage from the start to the end of the selected period. Shows current voltage when less than two days of data are available.",
       "parkingLocations": "Number of distinct parking spots used across all trips in the selected period, based on rounded GPS coordinates.",
-      "electricShare": "Estimated share of today's driving on electric power, derived from km since last charge versus total km today. Only meaningful for PHEV, where the battery can be charged from the grid."
+      "electricShare": "Estimated share of today's driving on electric power, derived from km since last charge versus total km today. Only meaningful for PHEV, where the battery can be charged from the grid.",
+      "avgSpeed": "Average moving speed across all recorded GPS points in the selected period, excluding stopped moments."
     },
     "chartDesc": {
       "evChart": "Daily average EV battery state-of-charge over the selected period.",
@@ -146,6 +149,7 @@
       "seatRight": "Passenger seat heat"
     },
     "speed": "Speed",
+    "topSpeed": "Top speed (last trip)",
     "activeTrip": "Active trip",
     "lastTrip": "Last trip",
     "noTrips": "No trips",
@@ -307,6 +311,7 @@
       "efficiencyCharge": "Since Charge",
       "efficiencyRatio": "Efficiency",
       "speed": "Speed",
+      "topSpeed": "Top Speed",
       "activeTrip": "Active Trip",
       "onlineStatus": "Online Status",
       "remainingCharge": "Charge Time",

--- a/frontend/src/locales/nl.json
+++ b/frontend/src/locales/nl.json
@@ -32,6 +32,7 @@
       "efficiencyCharge": "Afstand gereden sinds de laatste laadsessie.",
       "efficiencyRatio": "Energie vandaag gedeeld door afstand vandaag (Wh/km). Lager is beter. Op een BEV of PHEV in EV-modus vertaalt dit zich direct naar elektriciteitskosten per km. Op een HEV toont het hoe efficiënt het hybridesysteem werkte -- snelwegrijden geeft een lagere waarde dan stop-and-go stadsverkeer. Als er nog geen rijgegevens beschikbaar zijn, vallen HEV en PHEV terug op een geschat brandstofverbruik (km/%) afgeleid van de rangecalculator van de auto: hoger is zuiniger.",
       "speed": "Actuele rijsnelheid zoals gerapporteerd door de gateway.",
+      "topSpeed": "Hoogste gemeten snelheid over alle GPS-punten van de meest recente rit.",
       "activeTrip": "Afstand afgelegd tijdens de huidige rit, of de afstand van de laatste afgesloten rit als de auto geparkeerd staat.",
       "onlineStatus": "Of de auto momenteel bereikbaar is via de SAIC-cloud. Gaat offline als de auto geparkeerd staat en de gateway stopt met polling.",
       "remainingCharge": "Geschatte resterende laadtijd in minuten tot de accu de ingestelde limiet bereikt. Alleen relevant voor PHEV en BEV tijdens het laden.",
@@ -49,7 +50,8 @@
       "commutePattern": "Piek rijtijd",
       "batteryVoltageTrend": "12V-trend",
       "parkingLocations": "Parkeerlocaties",
-      "electricShare": "Elektrisch aandeel vandaag"
+      "electricShare": "Elektrisch aandeel vandaag",
+      "avgSpeed": "Gem. snelheid"
     },
     "cardDesc": {
       "distanceInRange": "Totale afstand over alle ritten in de geselecteerde periode.",
@@ -58,7 +60,8 @@
       "commutePattern": "Het uur van de dag met de meeste ritstarts in de geselecteerde periode - jouw meest voorkomende rijtijd.",
       "batteryVoltageTrend": "Verandering in gemiddelde 12V-accuspanning van het begin tot het einde van de geselecteerde periode. Toont de huidige spanning als er minder dan twee dagen aan data beschikbaar is.",
       "parkingLocations": "Aantal unieke parkeerplaatsen gebruikt over alle ritten in de geselecteerde periode, gebaseerd op afgeronde GPS-coordinaten.",
-      "electricShare": "Geschat aandeel van de ritten vandaag op elektrisch vermogen, afgeleid van km sinds laatste laadbeurt versus totaal km vandaag. Alleen zichtbaar voor HEV en PHEV."
+      "electricShare": "Geschat aandeel van de ritten vandaag op elektrisch vermogen, afgeleid van km sinds laatste laadbeurt versus totaal km vandaag. Alleen zichtbaar voor HEV en PHEV.",
+      "avgSpeed": "Gemiddelde rijsnelheid over alle geregistreerde GPS-punten in de geselecteerde periode, exclusief stilstaande momenten."
     },
     "chartDesc": {
       "evChart": "Dagelijks gemiddeld EV-accuniveau in de geselecteerde periode.",
@@ -146,6 +149,7 @@
       "seatRight": "Passagiersstoel verwarming"
     },
     "speed": "Snelheid",
+    "topSpeed": "Topsnelheid (laatste rit)",
     "activeTrip": "Actieve rit",
     "lastTrip": "Laatste rit",
     "noTrips": "Geen ritten",
@@ -307,6 +311,7 @@
       "efficiencyCharge": "Sinds lading",
       "efficiencyRatio": "Verbruik",
       "speed": "Snelheid",
+      "topSpeed": "Topsnelheid",
       "activeTrip": "Actieve rit",
       "onlineStatus": "Online status",
       "remainingCharge": "Laadtijd",

--- a/frontend/src/stores/__tests__/settings.spec.ts
+++ b/frontend/src/stores/__tests__/settings.spec.ts
@@ -7,7 +7,7 @@ const BASE_KEY = 'garagestack-settings'
 
 describe('defaultCards', () => {
   it('includes all 22 card ids', () => {
-    expect(defaultCards()).toHaveLength(22)
+    expect(defaultCards()).toHaveLength(23)
   })
 
   it('places visible cards before hidden ones', () => {
@@ -117,7 +117,7 @@ describe('useSettingsStore', () => {
   it('falls back to defaults when localStorage is empty', () => {
     const store = useSettingsStore()
     expect(store.vehicleTypeOverride).toBe('auto')
-    expect(store.cards).toHaveLength(22)
+    expect(store.cards).toHaveLength(23)
     expect(store.cards.find((c) => c.id === 'sunRoof')!.visible).toBe(false)
   })
 
@@ -201,8 +201,8 @@ describe('useSettingsStore', () => {
         }),
       )
       const store = useSettingsStore()
-      // All 22 card ids should be present after migration fills in the gaps
-      expect(store.cards).toHaveLength(22)
+      // All 23 card ids should be present after migration fills in the gaps
+      expect(store.cards).toHaveLength(23)
       expect(store.cards.find((c) => c.id === 'sunRoof')!.visible).toBe(false)
     })
   })

--- a/frontend/src/stores/settings.ts
+++ b/frontend/src/stores/settings.ts
@@ -31,6 +31,7 @@ export type StatsInsightId =
   | 'batteryVoltageTrend'
   | 'parkingLocations'
   | 'electricShare'
+  | 'avgSpeed'
 
 export type StatsChartId = 'evChart' | 'tyreChart' | 'hybridSocChart' | 'dailyKwhChart'
 
@@ -47,6 +48,7 @@ const ALL_STATS_INSIGHT_IDS: StatsInsightId[] = [
   'batteryVoltageTrend',
   'parkingLocations',
   'electricShare',
+  'avgSpeed',
 ]
 
 const ALL_STATS_CHART_IDS: StatsChartId[] = [
@@ -108,6 +110,7 @@ export type CardId =
   | 'remainingCharge'
   | 'chargingSession'
   | 'batteryHeating'
+  | 'topSpeed'
 
 const ALL_CARD_IDS: CardId[] = [
   'fuelLevel',
@@ -132,6 +135,7 @@ const ALL_CARD_IDS: CardId[] = [
   'remainingCharge',
   'chargingSession',
   'batteryHeating',
+  'topSpeed',
 ]
 
 export interface CardConfig {
@@ -194,6 +198,7 @@ export function defaultCards(type: VehicleType | 'unknown' = 'unknown'): CardCon
     { id: 'remainingCharge', visible: type === 'phev' || type === 'bev' },
     { id: 'chargingSession', visible: type === 'phev' || type === 'bev' },
     { id: 'batteryHeating', visible: type === 'phev' || type === 'bev' },
+    { id: 'topSpeed', visible: true },
   ]
   return [...all.filter((c) => c.visible), ...all.filter((c) => !c.visible)]
 }

--- a/frontend/src/views/DashboardView.vue
+++ b/frontend/src/views/DashboardView.vue
@@ -136,6 +136,10 @@ function cardHasData(id: CardId): boolean {
     case 'chargingSession':
     case 'batteryHeating':
       return vehicleType.value === 'phev' || vehicleType.value === 'bev'
+    case 'topSpeed': {
+      const trip = store.trips[store.trips.length - 1]
+      return trip != null && trip.points.some((p) => p.speed !== null)
+    }
     default:
       return true
   }
@@ -164,6 +168,7 @@ const CARD_ICONS: Record<CardId, string> = {
   remainingCharge: 'clock',
   chargingSession: 'plug-circle-bolt',
   batteryHeating: 'temperature-arrow-up',
+  topSpeed: 'gauge-high',
 }
 
 function resetLayout() {

--- a/frontend/src/views/StatisticsView.vue
+++ b/frontend/src/views/StatisticsView.vue
@@ -129,6 +129,7 @@ const INSIGHT_ICONS: Record<StatsInsightId, string> = {
   batteryVoltageTrend: 'battery-three-quarters',
   parkingLocations: 'location-dot',
   electricShare: 'leaf',
+  avgSpeed: 'gauge-high',
 }
 
 const CHART_ICONS: Record<StatsChartId, string> = {
@@ -246,6 +247,17 @@ const batteryVoltageDisplay = computed(() => {
   if (batteryVoltageTrend.value !== null) return batteryVoltageTrend.value
   const v = status.value?.batteryVoltage
   return v != null ? `${v.toFixed(1)} V` : null
+})
+
+const avgSpeedKmh = computed(() => {
+  const speeds: number[] = []
+  for (const trip of store.trips) {
+    for (const point of trip.points) {
+      if (point.speed !== null && point.speed > 0) speeds.push(point.speed)
+    }
+  }
+  if (!speeds.length) return null
+  return round2(speeds.reduce((sum, s) => sum + s, 0) / speeds.length)
 })
 
 const electricShareToday = computed(() => {
@@ -367,6 +379,16 @@ const insightDefs = computed(() => [
     value: electricShareToday.value !== null ? `${electricShareToday.value}%` : null,
     vehicleApplicable: isPhev.value,
     applicable: isPhev.value && status.value != null,
+  },
+  {
+    id: 'avgSpeed' as StatsInsightId,
+    icon: INSIGHT_ICONS.avgSpeed,
+    title: t('statistics.insights.avgSpeed'),
+    description: t('statistics.cardDesc.avgSpeed'),
+    value: avgSpeedKmh.value !== null ? String(avgSpeedKmh.value) : null,
+    unit: 'km/h',
+    vehicleApplicable: true,
+    applicable: store.trips.some((trip) => trip.points.some((p) => p.speed !== null)),
   },
 ])
 


### PR DESCRIPTION
## Summary

- Adds **Top Speed** dashboard card: highest GPS-recorded speed from the most recent completed trip (`topSpeed` card ID)
- Adds **Average Speed** statistics insight: mean moving speed across all non-zero GPS points in the selected date range (`avgSpeed` insight)
- Both cards include info-icon tooltips via `CardInfoWrap` with translated descriptions (EN + NL)
- Fixes all markdownlint warnings in `README.md` (MD033 HTML, MD036 bold-as-heading, MD060 compact table separators and misaligned pipes)

## Test plan

- [ ] `topSpeed` card appears in Dashboard when a trip with GPS speed data exists
- [ ] `avgSpeed` insight appears in Statistics when trips with GPS speed data are in range
- [ ] Info icon on both cards shows the correct description modal
- [ ] Both cards are hidden when no qualifying data is available (`cardHasData` / `applicable` guards)
- [ ] `pnpm exec vitest run` passes (133 tests)
- [ ] `README.md` has no markdownlint warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)