### PR TITLE
feat(map): replace fuel brand checkbox list with multiselect

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -21,6 +21,7 @@
     "@fortawesome/vue-fontawesome": "^3.2.0",
     "@microsoft/signalr": "^10.0.0",
     "@vue-leaflet/vue-leaflet": "^0.10.1",
+    "@vueform/multiselect": "^2.6.11",
     "@vueform/slider": "^2.1.10",
     "chart.js": "^4.5.1",
     "flag-icons": "^7.5.0",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       '@vue-leaflet/vue-leaflet':
         specifier: ^0.10.1
         version: 0.10.1(@types/leaflet@1.9.21)(leaflet@1.9.4)(typescript@6.0.3)
+      '@vueform/multiselect':
+        specifier: ^2.6.11
+        version: 2.6.11
       '@vueform/slider':
         specifier: ^2.1.10
         version: 2.1.10
@@ -1766,6 +1769,9 @@ packages:
         optional: true
       vue:
         optional: true
+
+  '@vueform/multiselect@2.6.11':
+    resolution: {integrity: sha512-iG4TGfqE3baftbSGF0PhoS+xZOCnV0ChkDo9rwhJ/Qi2YlCdb6tyQCjvyug3jnzncga8+d85kx0WvG7rDYFqiA==}
 
   '@vueform/slider@2.1.10':
     resolution: {integrity: sha512-L2G3Ju51Yq6yWF2wzYYsicUUaH56kL1QKGVtimUVHT1K1ADcRT94xVyIeJpS0klliVEeF6iMZFbdXtHq8AsDHw==}
@@ -5503,6 +5509,8 @@ snapshots:
     optionalDependencies:
       typescript: 6.0.3
       vue: 3.5.38(typescript@6.0.3)
+
+  '@vueform/multiselect@2.6.11': {}
 
   '@vueform/slider@2.1.10': {}
 

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -230,6 +230,7 @@
     "fuelBrandFilterDesc": "Show only selected fuel station brands. Only available after loading stations.",
     "fuelBrandSelected": "selected",
     "fuelBrandNoneLoaded": "Enable fuel stations on the map to load available brands.",
+    "fuelBrandPlaceholder": "Filter brands...",
     "fuelBrandClear": "Clear selection",
     "findCar": "Find car",
     "points": "pts"

--- a/frontend/src/locales/nl.json
+++ b/frontend/src/locales/nl.json
@@ -230,6 +230,7 @@
     "fuelBrandFilterDesc": "Toon alleen geselecteerde tankstationmerken. Beschikbaar nadat stations zijn geladen.",
     "fuelBrandSelected": "geselecteerd",
     "fuelBrandNoneLoaded": "Schakel tankstations in op de kaart om beschikbare merken te laden.",
+    "fuelBrandPlaceholder": "Merken filteren...",
     "fuelBrandClear": "Selectie wissen",
     "findCar": "Vind auto",
     "points": "ptn"

--- a/frontend/src/views/MapView.vue
+++ b/frontend/src/views/MapView.vue
@@ -8,6 +8,7 @@ import { useSettingsStore } from '@/stores/settings'
 import { LMap, LTileLayer, LMarker, LPopup } from '@vue-leaflet/vue-leaflet'
 import FiltersPanel from '@/components/FiltersPanel.vue'
 import Slider from '@vueform/slider'
+import Multiselect from '@vueform/multiselect'
 import * as LModule from 'leaflet'
 import type { Map as LeafletMap } from 'leaflet'
 import 'leaflet.heat'
@@ -494,13 +495,6 @@ function redrawFuelMarkers() {
     marker.bindPopup(buildPoiPopup(item))
     fuelCluster.addLayer(marker)
   }
-}
-
-function toggleFuelBrand(brand: string) {
-  const current = fuelBrandFilter.value
-  fuelBrandFilter.value = current.includes(brand)
-    ? current.filter((b) => b !== brand)
-    : [...current, brand]
 }
 
 function buildPoiPopup(item: PoiItem): string {
@@ -1129,42 +1123,25 @@ onUnmounted(() => {
           <template v-if="!isBev && fuelStationsEnabled">
             <div class="fuel-brand-filter">
               <div class="fuel-brand-filter__header">
-                <div>
-                  <span class="settings-toggle__label">
-                    <font-awesome-icon icon="tag" class="settings-toggle__icon" />
-                    {{ t('trips.fuelBrandFilter') }}
-                  </span>
-                  <span class="settings-toggle__desc">{{ t('trips.fuelBrandFilterDesc') }}</span>
-                </div>
-                <button
-                  v-if="fuelBrandFilter.length > 0"
-                  class="btn btn-sm btn-link fuel-brand-filter__clear"
-                  @click="fuelBrandFilter = []"
-                >
-                  {{ t('trips.fuelBrandClear') }}
-                </button>
+                <span class="settings-toggle__label">
+                  <font-awesome-icon icon="tag" class="settings-toggle__icon" />
+                  {{ t('trips.fuelBrandFilter') }}
+                </span>
+                <span class="settings-toggle__desc">{{ t('trips.fuelBrandFilterDesc') }}</span>
               </div>
-              <div v-if="availableFuelBrands.length === 0" class="fuel-brand-filter__empty">
-                {{ t('trips.fuelBrandNoneLoaded') }}
-              </div>
-              <div v-else class="fuel-brand-filter__list">
-                <label
-                  v-for="brand in availableFuelBrands"
-                  :key="brand"
-                  class="fuel-brand-filter__item form-check"
-                >
-                  <input
-                    type="checkbox"
-                    class="form-check-input"
-                    :checked="fuelBrandFilter.includes(brand)"
-                    @change="toggleFuelBrand(brand)"
-                  />
-                  <span class="form-check-label">{{ brand }}</span>
-                </label>
-              </div>
-              <div v-if="fuelBrandFilter.length > 0" class="fuel-brand-filter__summary">
-                {{ fuelBrandFilter.length }} {{ t('trips.fuelBrandSelected') }}
-              </div>
+              <Multiselect
+                v-model="fuelBrandFilter"
+                :options="availableFuelBrands"
+                :placeholder="t('trips.fuelBrandPlaceholder')"
+                :searchable="true"
+                :close-on-select="false"
+                :clear-on-select="false"
+                mode="tags"
+                :no-results-text="t('trips.fuelBrandNoneLoaded')"
+                :no-options-text="t('trips.fuelBrandNoneLoaded')"
+                append-to="body"
+                class="fuel-brand-multiselect"
+              />
             </div>
           </template>
           <template v-if="!isHev && chargingStationsEnabled">
@@ -1339,6 +1316,7 @@ onUnmounted(() => {
 
 <style>
 @import '@vueform/slider/themes/default.css';
+@import '@vueform/multiselect/themes/default.css';
 
 /* Leaflet injects divIcon HTML outside Vue's rendering pipeline so these cannot be scoped */
 
@@ -1439,50 +1417,80 @@ onUnmounted(() => {
   --slider-handle-ring-color: rgba(34, 197, 94, 0.2);
 }
 
+/* --ms-* vars set on :root so they cascade to the body-teleported dropdown too */
+:root {
+  --ms-bg: var(--color-surface-2);
+  --ms-bg-disabled: var(--color-surface);
+  --ms-border-color: var(--color-border);
+  --ms-border-width: 1px;
+  --ms-radius: 6px;
+  --ms-py: 0.375rem;
+  --ms-px: 0.625rem;
+  --ms-font-size: 0.875rem;
+  --ms-line-height: 1.375;
+  --ms-spinner-color: var(--color-primary);
+  --ms-caret-color: var(--color-text-muted);
+  --ms-clear-color: var(--color-text-muted);
+  --ms-clear-color-hover: var(--color-text);
+
+  --ms-tag-font-size: 0.8rem;
+  --ms-tag-font-weight: 500;
+  --ms-tag-line-height: 1.25;
+  --ms-tag-py: 0.2rem;
+  --ms-tag-px: 0.5rem;
+  --ms-tag-my: 0.2rem;
+  --ms-tag-mx: 0.2rem;
+  --ms-tag-bg: var(--color-primary);
+  --ms-tag-bg-disabled: var(--color-surface);
+  --ms-tag-color: #fff;
+  --ms-tag-color-disabled: var(--color-text-muted);
+  --ms-tag-radius: 4px;
+  --ms-tag-remove-radius: 3px;
+  --ms-tag-remove-py: 0.2rem;
+  --ms-tag-remove-px: 0.2rem;
+
+  --ms-dropdown-bg: var(--color-surface);
+  --ms-dropdown-border-color: var(--color-border);
+  --ms-dropdown-border-width: 1px;
+  --ms-dropdown-radius: 6px;
+
+  --ms-placeholder-color: var(--color-text-muted);
+
+  --ms-option-font-size: 0.875rem;
+  --ms-option-bg-pointed: var(--color-surface-2);
+  --ms-option-color-pointed: var(--color-text);
+  --ms-option-bg-selected: var(--color-primary);
+  --ms-option-color-selected: #fff;
+  --ms-option-bg-selected-pointed: color-mix(in srgb, var(--color-primary) 85%, #000);
+  --ms-option-color-selected-pointed: #fff;
+  --ms-option-bg-disabled: transparent;
+  --ms-option-color-disabled: var(--color-text-muted);
+  --ms-option-py: 0.5rem;
+  --ms-option-px: 0.75rem;
+
+  --ms-empty-color: var(--color-text-muted);
+
+  --ms-ring-width: 2px;
+  --ms-ring-color: color-mix(in srgb, var(--color-primary) 30%, transparent);
+}
+
+/* Teleported dropdown must sit above the modal (z-index 1100) */
+.multiselect-dropdown {
+  z-index: 1200;
+}
+
+/* Ensure the search input inside the multiselect also uses the theme background */
+.multiselect-search,
+.multiselect-tags-search {
+  background: var(--color-surface-2);
+  color: var(--color-text);
+}
+
 .fuel-brand-filter {
   padding: 0.25rem 0 0.5rem;
 }
 
 .fuel-brand-filter__header {
-  display: flex;
-  justify-content: space-between;
-  align-items: flex-start;
   margin-bottom: 0.5rem;
-}
-
-.fuel-brand-filter__clear {
-  font-size: 0.75rem;
-  padding: 0;
-  color: var(--color-text-muted, #888);
-  flex-shrink: 0;
-}
-
-.fuel-brand-filter__list {
-  display: flex;
-  flex-direction: column;
-  gap: 0.25rem;
-  max-height: 180px;
-  overflow-y: auto;
-}
-
-.fuel-brand-filter__item {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-  font-size: 0.875rem;
-  cursor: pointer;
-  margin: 0;
-}
-
-.fuel-brand-filter__empty {
-  font-size: 0.8rem;
-  color: var(--color-text-muted, #888);
-  font-style: italic;
-}
-
-.fuel-brand-filter__summary {
-  margin-top: 0.4rem;
-  font-size: 0.75rem;
-  color: #d97706;
 }
 </style>


### PR DESCRIPTION
## Summary

- Replaces the custom scrollable checkbox list for fuel brand filtering with `@vueform/multiselect` in tags mode (same ecosystem as the existing `@vueform/slider`)
- Selected brands show as removable pill/tag chips — touch-friendly and easy to dismiss
- Dropdown teleports to `<body>` via `append-to="body"` so it overlays the modal instead of pushing it taller and causing scroll
- Z-index set to 1200 to sit above the modal backdrop (1100)
- `--ms-*` CSS variables scoped to `:root` so dark/light theme applies correctly to the teleported dropdown element
- Adds a short `fuelBrandPlaceholder` i18n key (EN + NL) so the input stays single-line; the longer explanation text is preserved in the dropdown empty-state

## Test plan

- [ ] Open the Filters panel on the map view with fuel stations enabled
- [ ] Confirm the brand multiselect renders correctly in dark mode (no white background)
- [ ] Open the dropdown — confirm it overlays the modal without causing scroll
- [ ] Select a brand — confirm it appears as a removable pill
- [ ] Tap the × on a pill to deselect
- [ ] Test on a mobile/touch device
- [ ] Switch to light mode and confirm theming still looks correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)