### PR TITLE
feat(login): autofocus username input on page load

### DIFF
--- a/frontend/src/views/LoginView.vue
+++ b/frontend/src/views/LoginView.vue
@@ -64,6 +64,7 @@ async function submitLogin() {
               :aria-label="t('auth.username')"
               :placeholder="t('auth.username')"
               autocomplete="username"
+              autofocus
               required
             />
           </div>


### PR DESCRIPTION
## Summary
- Adds `autofocus` attribute to the username input on the login page so the cursor lands there immediately when the page loads

## Test plan
- [ ] Open the login page and verify the username field is focused without clicking

🤖 Generated with [Claude Code](https://claude.com/claude-code)