### PR TITLE
fix(map): register faTag icon and fix brand filter header layout

### DIFF
--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -106,6 +106,7 @@ import {
   faFlask,
   faGripLines,
   faLifeRing,
+  faTag,
 } from '@fortawesome/free-solid-svg-icons'
 
 import App from './App.vue'
@@ -189,6 +190,7 @@ library.add(
   faFlask,
   faGripLines,
   faLifeRing,
+  faTag,
 )
 
 const i18n = createI18n({

--- a/frontend/src/views/MapView.vue
+++ b/frontend/src/views/MapView.vue
@@ -1123,11 +1123,13 @@ onUnmounted(() => {
           <template v-if="!isBev && fuelStationsEnabled">
             <div class="fuel-brand-filter">
               <div class="fuel-brand-filter__header">
-                <span class="settings-toggle__label">
-                  <font-awesome-icon icon="tag" class="settings-toggle__icon" />
-                  {{ t('trips.fuelBrandFilter') }}
-                </span>
-                <span class="settings-toggle__desc">{{ t('trips.fuelBrandFilterDesc') }}</span>
+                <div class="settings-toggle__info">
+                  <span class="settings-toggle__label">
+                    <font-awesome-icon icon="tag" class="settings-toggle__icon" />
+                    {{ t('trips.fuelBrandFilter') }}
+                  </span>
+                  <span class="settings-toggle__desc">{{ t('trips.fuelBrandFilterDesc') }}</span>
+                </div>
               </div>
               <Multiselect
                 v-model="fuelBrandFilter"


### PR DESCRIPTION
## Summary

- Imports and registers `faTag` from FontAwesome free-solid-svg-icons — it was missing from the library so the brand filter tag icon was invisible
- Wraps the brand filter label + description in `settings-toggle__info` so the description stacks below the title, matching all other rows in the filters panel

## Test plan

- [ ] Open the map Filters panel with fuel stations enabled
- [ ] Confirm the tag icon appears to the left of "Brand filter"
- [ ] Confirm the description text appears on its own line below the title

🤖 Generated with [Claude Code](https://claude.com/claude-code)