### PR TITLE
docs: add Docker-based VAPID key generation alternative

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,12 @@ To generate a VAPID key pair (requires Node.js):
 npx web-push generate-vapid-keys
 ```
 
+No Node.js installed? Use a temporary Docker container instead:
+
+```bash
+docker run --rm node:lts-alpine npx --yes web-push generate-vapid-keys
+```
+
 Copy the public key to `VAPID_PUBLIC_KEY` and the private key to `VAPID_PRIVATE_KEY` in your `.env` file (or as container environment variables). Keep the private key secret -- regenerating it invalidates all existing push subscriptions, requiring users to re-enable notifications in the browser.
 
 Note: "keys left in the car" is not currently supported because the SAIC MQTT gateway does not expose a key-in-vehicle sensor.


### PR DESCRIPTION
## Summary

- Adds a `docker run --rm node:lts-alpine npx --yes web-push generate-vapid-keys` snippet as an alternative to the local `npx` command for users who don't have Node.js installed

## Test plan

- [ ] Verify the Docker command renders correctly in the README on GitHub
- [ ] Optionally run the command to confirm it prints a valid VAPID key pair

🤖 Generated with [Claude Code](https://claude.com/claude-code)