### PR TITLE
refactor(frontend): replace notification paginator with infinite scroll

### DIFF
--- a/frontend/src/components/NotificationPanel.vue
+++ b/frontend/src/components/NotificationPanel.vue
@@ -1,8 +1,8 @@
 <script setup lang="ts">
-import { onMounted, onUnmounted, ref, computed, watch } from 'vue'
+import { onMounted, onUnmounted, ref, computed, watch, nextTick } from 'vue'
 import { useI18n } from 'vue-i18n'
 import type { AppNotification } from '@/services/api'
-import AppPaginator from '@/components/AppPaginator.vue'
+import { useInfiniteScroll } from '@/composables/useInfiniteScroll'
 
 const PAGE_SIZE = 10
 
@@ -35,9 +35,9 @@ const emit = defineEmits<{
 
 const { t } = useI18n()
 
-const page = ref(1)
 const showArchived = ref(false)
 const pendingAction = ref<'archiveAll' | 'deleteAll' | null>(null)
+const bodyRef = ref<HTMLElement | null>(null)
 
 const hasUnarchived = computed(() => props.notifications.some((n) => !n.isArchived))
 
@@ -58,30 +58,36 @@ function cancelBulkAction() {
 const filteredNotifications = computed(() =>
   props.notifications.filter((n) => n.isArchived === showArchived.value),
 )
-const totalPages = computed(() =>
-  Math.max(1, Math.ceil(filteredNotifications.value.length / PAGE_SIZE)),
-)
-const pagedNotifications = computed(() =>
-  filteredNotifications.value.slice((page.value - 1) * PAGE_SIZE, page.value * PAGE_SIZE),
-)
+
+const {
+  displayItems: pagedNotifications,
+  sentinelRef,
+  reset,
+  observe,
+  disconnect,
+} = useInfiniteScroll(filteredNotifications, PAGE_SIZE)
 
 watch(
   () => props.notifications.length,
   () => {
-    page.value = 1
+    reset()
   },
 )
 watch(
   () => props.open,
-  (v) => {
+  async (v) => {
     if (v) {
-      page.value = 1
+      reset()
       showArchived.value = false
+      await nextTick()
+      observe(bodyRef.value)
+    } else {
+      disconnect()
     }
   },
 )
 watch(showArchived, () => {
-  page.value = 1
+  reset()
 })
 
 function formatTime(iso: string) {
@@ -140,7 +146,7 @@ onUnmounted(() => document.removeEventListener('keydown', onKey))
             </button>
           </div>
 
-          <div class="notif-panel__body">
+          <div ref="bodyRef" class="notif-panel__body">
             <div v-if="loading" class="notif-panel__empty text-muted">
               <font-awesome-icon icon="spinner" spin />
               {{ t('common.loading') }}
@@ -191,6 +197,7 @@ onUnmounted(() => document.removeEventListener('keydown', onKey))
                   </button>
                 </div>
               </li>
+              <li ref="sentinelRef" aria-hidden="true" />
             </ul>
           </div>
 
@@ -229,10 +236,6 @@ onUnmounted(() => document.removeEventListener('keydown', onKey))
                   <font-awesome-icon icon="box-archive" class="me-1" />
                   {{ t('notifications.archiveAll') }}
                 </button>
-              </div>
-
-              <div class="notif-panel__footer-center">
-                <AppPaginator v-if="totalPages > 1" v-model="page" :total-pages="totalPages" />
               </div>
 
               <div class="notif-panel__footer-side notif-panel__footer-side--right">

--- a/frontend/src/composables/useInfiniteScroll.ts
+++ b/frontend/src/composables/useInfiniteScroll.ts
@@ -1,0 +1,37 @@
+import { ref, computed, onUnmounted } from 'vue'
+import type { Ref } from 'vue'
+
+export function useInfiniteScroll<T>(items: Ref<T[]>, pageSize: number) {
+  const displayCount = ref(pageSize)
+  const sentinelRef = ref<HTMLElement | null>(null)
+  let observer: IntersectionObserver | null = null
+
+  const displayItems = computed(() => items.value.slice(0, displayCount.value))
+
+  function reset() {
+    displayCount.value = pageSize
+  }
+
+  function observe(scrollRoot: HTMLElement | null) {
+    observer?.disconnect()
+    if (!sentinelRef.value) return
+    observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry?.isIntersecting && displayCount.value < items.value.length) {
+          displayCount.value += pageSize
+        }
+      },
+      { root: scrollRoot },
+    )
+    observer.observe(sentinelRef.value)
+  }
+
+  function disconnect() {
+    observer?.disconnect()
+    observer = null
+  }
+
+  onUnmounted(disconnect)
+
+  return { displayItems, sentinelRef, reset, observe, disconnect }
+}

--- a/frontend/src/views/MapView.vue
+++ b/frontend/src/views/MapView.vue
@@ -7,6 +7,7 @@ import type { VehicleType } from '@/stores/vehicle'
 import { useSettingsStore } from '@/stores/settings'
 import { LMap, LTileLayer, LMarker, LPopup } from '@vue-leaflet/vue-leaflet'
 import FiltersPanel from '@/components/FiltersPanel.vue'
+import { useInfiniteScroll } from '@/composables/useInfiniteScroll'
 import Slider from '@vueform/slider'
 import Multiselect from '@vueform/multiselect'
 import * as LModule from 'leaflet'
@@ -155,8 +156,6 @@ const dateRangeDays = computed({
   },
 })
 const LOAD_MORE_SIZE = 10
-const displayCount = ref(LOAD_MORE_SIZE)
-const sentinelRef = ref<HTMLElement | null>(null)
 
 const mapWrapperRef = ref<HTMLElement | null>(null)
 const tripSidebarRef = ref<HTMLElement | null>(null)
@@ -188,7 +187,6 @@ const chargingAllStations = new Map<string, ChargingStation>()
 const poiLoadingCount = ref(0)
 const poiLoading = computed(() => poiLoadingCount.value > 0)
 let resizeObserver: ResizeObserver | null = null
-let infiniteScrollObserver: IntersectionObserver | null = null
 let mapUpdateRaf: number | null = null
 let hasCenteredOnStatus = false
 
@@ -261,7 +259,13 @@ const center: [number, number] = [52.3676, 4.9041]
 
 // Trips displayed newest-first in the sidebar; selectedTripIndex is always the real store.trips index.
 const newestFirstTrips = computed(() => [...store.trips].reverse())
-const displayTrips = computed(() => newestFirstTrips.value.slice(0, displayCount.value))
+
+const {
+  displayItems: displayTrips,
+  sentinelRef,
+  reset: resetTripScroll,
+  observe: observeTrips,
+} = useInfiniteScroll(newestFirstTrips, LOAD_MORE_SIZE)
 
 function realIndex(newestFirstIdx: number): number {
   return store.trips.length - 1 - newestFirstIdx
@@ -966,7 +970,7 @@ watch(routeOutlineEnabled, () => {
 
 // Date range change: reload trips and reset state
 watch(dateRangeDays, async (days) => {
-  displayCount.value = LOAD_MORE_SIZE
+  resetTripScroll()
   selectedTripIndex.value = null
   if (vin.value) {
     await store.fetchTrips(vin.value, new Date(Date.now() - days * 86_400_000).toISOString())
@@ -1028,17 +1032,7 @@ onMounted(async () => {
     loadFuelBrands()
   }
   nextTick(() => {
-    if (sentinelRef.value && tripSidebarRef.value) {
-      infiniteScrollObserver = new IntersectionObserver(
-        ([entry]) => {
-          if (entry?.isIntersecting && displayCount.value < store.trips.length) {
-            displayCount.value += LOAD_MORE_SIZE
-          }
-        },
-        { root: tripSidebarRef.value },
-      )
-      infiniteScrollObserver.observe(sentinelRef.value)
-    }
+    observeTrips(tripSidebarRef.value)
   })
 })
 
@@ -1052,7 +1046,6 @@ onUnmounted(() => {
   clearPoiMarkers('fuel')
   clearPoiMarkers('service_area')
   resizeObserver?.disconnect()
-  infiniteScrollObserver?.disconnect()
 })
 </script>
 


### PR DESCRIPTION
## Summary
- Extract shared `useInfiniteScroll` composable (`src/composables/useInfiniteScroll.ts`) that wraps `IntersectionObserver` logic — takes a reactive list ref and page size, exposes `displayItems`, `sentinelRef`, `reset`, `observe`, and `disconnect`
- `NotificationPanel`: removes `AppPaginator` and the page/totalPages state; sentinel `<li>` at the bottom of the list triggers load-more as the user scrolls; observer is set up when the panel opens and torn down on close
- `MapView`: replaces the inline `IntersectionObserver` block with the same composable, reducing duplication

## Test plan
- [ ] Open notification panel with >10 notifications — first 10 show, scrolling to the bottom loads the next batch
- [ ] Switch between Active / Archived tabs — display resets to first 10
- [ ] Close and reopen panel — display resets
- [ ] Trip sidebar in MapView still loads more trips on scroll as before
- [ ] All 133 unit tests pass (`pnpm exec vitest run`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)