### PR TITLE
fix(a11y): WCAG badge contrast, aria-hidden badge count, COOP header

### DIFF
--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -12,6 +12,7 @@ server {
     add_header X-Frame-Options "DENY" always;
     add_header Referrer-Policy "strict-origin-when-cross-origin" always;
     add_header Permissions-Policy "camera=(), microphone=(), geolocation=()" always;
+    add_header Cross-Origin-Opener-Policy "same-origin" always;
 
     gzip on;
     gzip_types text/plain text/css application/json application/javascript text/xml application/xml image/svg+xml;

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -162,7 +162,9 @@ watch(
       </RouterLink>
       <button class="notif-bell" :aria-label="t('notifications.title')" @click="togglePanel">
         <font-awesome-icon icon="bell" />
-        <span v-if="unreadCount > 0" class="notif-bell__badge">{{ unreadCount }}</span>
+        <span v-if="unreadCount > 0" class="notif-bell__badge" aria-hidden="true">{{
+          unreadCount
+        }}</span>
       </button>
     </header>
 
@@ -269,7 +271,9 @@ watch(
           <button class="sidebar-notif-btn" @click="togglePanel">
             <font-awesome-icon icon="bell" />
             <span>{{ t('notifications.title') }}</span>
-            <span v-if="unreadCount > 0" class="notif-bell__badge">{{ unreadCount }}</span>
+            <span v-if="unreadCount > 0" class="notif-bell__badge" aria-hidden="true">{{
+              unreadCount
+            }}</span>
           </button>
 
           <button class="sidebar-logout-btn" @click="logout">

--- a/frontend/src/assets/main.css
+++ b/frontend/src/assets/main.css
@@ -10,6 +10,7 @@
   --color-success: #22c55e;
   --color-warning: #f59e0b;
   --color-danger: #ef4444;
+  --color-danger-badge: #b91c1c;
   --color-danger-text: #f87171;
   --color-info: #06b6d4;
   --sidebar-width: 220px;
@@ -2123,7 +2124,7 @@ body,
   min-width: 16px;
   height: 16px;
   padding: 0 3px;
-  background: var(--color-danger);
+  background: var(--color-danger-badge);
   color: #fff;
   font-size: 0.6rem;
   font-weight: 700;


### PR DESCRIPTION
## Summary

- **Badge color contrast**: Added `--color-danger-badge: #b91c1c` CSS variable and applied it to `.notif-bell__badge`. White text on this color achieves 6.1:1 contrast (was 3.58:1 with `#ef4444`, failing the 4.5:1 WCAG AA threshold).
- **Notification bell aria-label mismatch**: Added `aria-hidden="true"` to both badge `<span>` elements (mobile topbar and desktop sidebar). Removes the badge count from the accessible name computation, resolving the Lighthouse `label-content-name-mismatch` violation.
- **Missing COOP header**: Added `Cross-Origin-Opener-Policy: same-origin` to `frontend/nginx.conf` (Docker Compose config). It was already present in the all-in-one config.

## Test plan

- [ ] Verify notification badge is visually readable with the darker red
- [ ] Confirm Lighthouse accessibility audit no longer reports the badge contrast or aria-label violations
- [ ] Confirm `Cross-Origin-Opener-Policy` header is present in HTTP responses from the Docker Compose deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)