### PR TITLE
fix(pwa): fix SW navigation preload warning, defer non-critical CSS

### DIFF
--- a/docker/all-in-one/nginx.conf
+++ b/docker/all-in-one/nginx.conf
@@ -3,7 +3,7 @@ server {
     root /usr/share/nginx/html;
     index index.html;
 
-    add_header Content-Security-Policy "default-src 'none'; base-uri 'self'; object-src 'none'; frame-ancestors 'none'; form-action 'self'; frame-src 'none'; child-src 'none'; navigate-to 'self'; script-src 'self'; script-src-elem 'self'; script-src-attr 'none'; style-src 'self'; style-src-elem 'self'; style-src-attr 'none'; img-src 'self' data: https://a.tile.openstreetmap.org https://b.tile.openstreetmap.org https://c.tile.openstreetmap.org; font-src 'self'; connect-src 'self'; manifest-src 'self'; worker-src 'self'; media-src 'none'; prefetch-src 'self'; upgrade-insecure-requests; block-all-mixed-content" always;
+    add_header Content-Security-Policy "default-src 'none'; base-uri 'self'; object-src 'none'; frame-ancestors 'none'; form-action 'self'; frame-src 'none'; child-src 'none'; navigate-to 'self'; script-src 'self' 'sha256-MsyHDz2Q9MM6DjmYjpACXTrSgtFF+tutkPYzSbPmHwA='; script-src-elem 'self' 'sha256-MsyHDz2Q9MM6DjmYjpACXTrSgtFF+tutkPYzSbPmHwA='; script-src-attr 'none'; style-src 'self'; style-src-elem 'self' 'sha256-IjDBH01/QEhAptpG1bqDVKT5WXiu63d/qZH2r6WdVO0='; style-src-attr 'none'; img-src 'self' data: https://a.tile.openstreetmap.org https://b.tile.openstreetmap.org https://c.tile.openstreetmap.org; font-src 'self'; connect-src 'self'; manifest-src 'self'; worker-src 'self'; media-src 'none'; prefetch-src 'self'; upgrade-insecure-requests; block-all-mixed-content" always;
     add_header X-Content-Type-Options "nosniff" always;
     add_header X-Frame-Options "DENY" always;
     add_header Referrer-Policy "strict-origin-when-cross-origin" always;

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -7,7 +7,7 @@ server {
     # pinned to a stale container IP (which causes intermittent 502 errors).
     resolver 127.0.0.11 ipv6=off valid=30s;
 
-    add_header Content-Security-Policy "default-src 'none'; base-uri 'self'; object-src 'none'; frame-ancestors 'none'; form-action 'self'; frame-src 'none'; child-src 'none'; navigate-to 'self'; script-src 'self'; script-src-elem 'self'; script-src-attr 'none'; style-src 'self'; style-src-elem 'self'; style-src-attr 'none'; img-src 'self' data: https://a.tile.openstreetmap.org https://b.tile.openstreetmap.org https://c.tile.openstreetmap.org; font-src 'self'; connect-src 'self'; manifest-src 'self'; worker-src 'self'; media-src 'none'; prefetch-src 'self'; upgrade-insecure-requests; block-all-mixed-content" always;
+    add_header Content-Security-Policy "default-src 'none'; base-uri 'self'; object-src 'none'; frame-ancestors 'none'; form-action 'self'; frame-src 'none'; child-src 'none'; navigate-to 'self'; script-src 'self' 'sha256-MsyHDz2Q9MM6DjmYjpACXTrSgtFF+tutkPYzSbPmHwA='; script-src-elem 'self' 'sha256-MsyHDz2Q9MM6DjmYjpACXTrSgtFF+tutkPYzSbPmHwA='; script-src-attr 'none'; style-src 'self'; style-src-elem 'self' 'sha256-IjDBH01/QEhAptpG1bqDVKT5WXiu63d/qZH2r6WdVO0='; style-src-attr 'none'; img-src 'self' data: https://a.tile.openstreetmap.org https://b.tile.openstreetmap.org https://c.tile.openstreetmap.org; font-src 'self'; connect-src 'self'; manifest-src 'self'; worker-src 'self'; media-src 'none'; prefetch-src 'self'; upgrade-insecure-requests; block-all-mixed-content" always;
     add_header X-Content-Type-Options "nosniff" always;
     add_header X-Frame-Options "DENY" always;
     add_header Referrer-Policy "strict-origin-when-cross-origin" always;

--- a/frontend/src/sw.ts
+++ b/frontend/src/sw.ts
@@ -9,7 +9,7 @@ precacheAndRoute(self.__WB_MANIFEST)
 // Activate the new SW immediately instead of waiting for all tabs to close
 self.addEventListener('install', () => self.skipWaiting())
 self.addEventListener('activate', (event) => {
-  event.waitUntil(self.registration.navigationPreload?.enable() ?? Promise.resolve())
+  event.waitUntil(self.clients.claim())
 })
 
 type BadgingNavigator = WorkerNavigator & {

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,7 +1,66 @@
 import { fileURLToPath, URL } from 'node:url'
-import { defineConfig } from 'vite'
+import { defineConfig, type Plugin } from 'vite'
 import vue from '@vitejs/plugin-vue'
 import { VitePWA } from 'vite-plugin-pwa'
+
+/**
+ * Converts the main CSS bundle from render-blocking to non-blocking.
+ *
+ * Strategy (no external deps, strict-CSP-compatible):
+ *   1. Inline a tiny <style> that sets the dark background so there is no
+ *      white flash before the full CSS activates.  Its SHA-256 hash is fixed
+ *      and added to style-src-elem in both nginx.conf files.
+ *   2. Change <link rel="stylesheet"> → <link rel="preload" as="style"> so
+ *      the browser fetches CSS at high priority without blocking the
+ *      first paint.
+ *   3. Inject a small <script defer> (hash in script-src / script-src-elem)
+ *      that promotes the preload back to a stylesheet.  defer means it runs
+ *      before the Vue module but after HTML parsing, so the CSS is almost
+ *      always already in the preload cache when it fires.
+ *   4. Add a <noscript> fallback for the (theoretical) no-JS case.
+ *
+ * Inline style hash  (style-src-elem):
+ *   sha256-IjDBH01/QEhAptpG1bqDVKT5WXiu63d/qZH2r6WdVO0=
+ * Inline script hash (script-src / script-src-elem):
+ *   sha256-MsyHDz2Q9MM6DjmYjpACXTrSgtFF+tutkPYzSbPmHwA=
+ */
+function deferNonCriticalCss(): Plugin {
+  const INLINE_STYLE = 'body,html{background:#0f1117}'
+  const ACTIVATION_SCRIPT =
+    "document.querySelectorAll('link[rel=preload][as=style]').forEach(function(l){l.rel='stylesheet'})"
+
+  return {
+    name: 'defer-non-critical-css',
+    apply: 'build',
+    transformIndexHtml: {
+      order: 'post',
+      handler(html: string): string {
+        const cssLinkRe = /<link rel="stylesheet" crossorigin href="([^"]+\.css)">/g
+        const hrefs: string[] = []
+        let m: RegExpExecArray | null
+        while ((m = cssLinkRe.exec(html)) !== null) hrefs.push(m[1])
+        if (hrefs.length === 0) return html
+
+        html = html.replace(
+          /<link rel="stylesheet" crossorigin href="([^"]+\.css)">/g,
+          '<link rel="preload" as="style" crossorigin href="$1">',
+        )
+
+        const noscriptLinks = hrefs
+          .map((h) => `<link rel="stylesheet" crossorigin href="${h}">`)
+          .join('')
+
+        const injection = [
+          `<style>${INLINE_STYLE}</style>`,
+          `<script defer>${ACTIVATION_SCRIPT}</script>`,
+          `<noscript>${noscriptLinks}</noscript>`,
+        ].join('\n    ')
+
+        return html.replace('\n  </head>', `\n    ${injection}\n  </head>`)
+      },
+    },
+  }
+}
 
 export default defineConfig({
   plugins: [
@@ -81,6 +140,7 @@ export default defineConfig({
         globPatterns: ['**/*.{js,css,html,ico,png,svg}'],
       },
     }),
+    deferNonCriticalCss(),
   ],
   server: {
     proxy: {


### PR DESCRIPTION
## Summary

- **SW navigation preload warning fixed**: replaced `navigationPreload.enable()` with `clients.claim()` in the service worker `activate` handler. `preloadResponse` was never consumed by any fetch handler (workbox manages its own), so the browser cancelled the preload and emitted a console warning on every page load.
- **Non-blocking CSS**: added a `deferNonCriticalCss` Vite plugin that converts the main CSS bundle from render-blocking `<link rel="stylesheet">` to `<link rel="preload" as="style">`, with a tiny `defer`red script to activate it and an inline `<style>` to prevent a white flash on dark-mode load.
- **CSP hashes updated**: both nginx configs (`docker/all-in-one` and standalone) now include the SHA-256 hashes for the injected inline style and script so the strict Content-Security-Policy remains intact.

## Test plan

- [ ] Build the frontend (`pnpm build`) and confirm no CSP violations in the browser console
- [ ] Open the dashboard and confirm the SW navigation preload warning is gone from the console
- [ ] Confirm no white flash on initial load (dark background appears immediately)
- [ ] Verify CSS loads correctly (no flash of unstyled content)
- [ ] Check PWA still installs and works offline

🤖 Generated with [Claude Code](https://claude.com/claude-code)