### PR TITLE
fix(notifications): fix infinite scroll observer never being set up

### DIFF
--- a/frontend/src/assets/main.css
+++ b/frontend/src/assets/main.css
@@ -2333,6 +2333,7 @@ body,
 
 .notif-panel__body {
   flex: 1;
+  min-height: 0;
   overflow-y: auto;
   padding: 0.5rem 0;
 }

--- a/frontend/src/components/NotificationPanel.vue
+++ b/frontend/src/components/NotificationPanel.vue
@@ -74,6 +74,15 @@ watch(
   },
 )
 watch(
+  () => props.loading,
+  async (isLoading) => {
+    if (!isLoading && props.open) {
+      await nextTick()
+      observe(bodyRef.value)
+    }
+  },
+)
+watch(
   () => props.open,
   async (v) => {
     if (v) {


### PR DESCRIPTION
## Summary

- `togglePanel()` sets `panelOpen = true` and calls `fetchNotifications()` simultaneously, so `loading` is already `true` when the `open` watcher fires in `NotificationPanel`. The sentinel `<li>` lives inside the `v-else` branch so it is not in the DOM at that point -- `observe()` checks `if (!sentinelRef.value) return` and exits without creating the `IntersectionObserver`. Scrolling to the bottom then has no effect.
- Added `watch(props.loading)` to re-call `observe(bodyRef.value)` once loading finishes and the list is rendered.
- Added `min-height: 0` to `.notif-panel__body` so the flex child is properly constrained to its allocated height and `overflow-y: auto` creates a real scroll container across all browsers (flex items default to `min-height: auto`, which can prevent overflow from occurring within the element itself).

## Test plan

- [ ] Open notification panel with >10 unread notifications -- first 10 should appear
- [ ] Scroll to the bottom -- next batch should load automatically
- [ ] Confirm scrolling continues loading until all notifications are visible
- [ ] Verify panel scrolls correctly on both mobile and desktop

🤖 Generated with [Claude Code](https://claude.com/claude-code)