### PR TITLE
fix(notifications): re-create scroll observer when switching tabs

### DIFF
--- a/frontend/src/components/NotificationPanel.vue
+++ b/frontend/src/components/NotificationPanel.vue
@@ -95,8 +95,10 @@ watch(
     }
   },
 )
-watch(showArchived, () => {
+watch(showArchived, async () => {
   reset()
+  await nextTick()
+  observe(bodyRef.value)
 })
 
 function formatTime(iso: string) {


### PR DESCRIPTION
## Summary

- Switching tabs calls `reset()` to rewind `displayCount` back to the page size, but the `IntersectionObserver` is not re-created. If the sentinel was already visible before the tab switch (e.g. fewer than 10 items in the previous tab), the observer sees no intersection change and never fires -- archived notifications past the first page never load.
- Re-calling `observe(bodyRef.value)` after `nextTick` in the `showArchived` watcher discards the stale observer and creates a fresh one, which fires immediately if the sentinel is currently in view.

## Test plan

- [ ] Open notification panel and switch to the archived tab with >10 archived notifications
- [ ] Scroll to the bottom -- next batch loads
- [ ] Switch back to active and verify active tab still paginates correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)