### PR TITLE
fix(docker): make POSTGRES_PASSWORD and MQTT_BROKER_PASSWORD optional

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,7 +21,9 @@ POSTGRES_HOST=postgres
 POSTGRES_PORT=5432
 POSTGRES_DB=garagestack
 POSTGRES_USER=garagestack
-POSTGRES_PASSWORD=changeme_use_something_strong
+# Optional when using the bundled postgres profile -- defaults to "garagestack".
+# Set explicitly if you want stronger credentials or connect from external tools.
+POSTGRES_PASSWORD=
 
 # ── MQTT ────────────────────────────────────────────────────────────────────
 # Defaults to the bundled Mosquitto broker running inside Docker Compose.
@@ -30,11 +32,13 @@ MQTT_HOST=mosquitto
 MQTT_PORT=1883
 # Host port Mosquitto is published on (only relevant for the bundled broker).
 MQTT_EXTERNAL_PORT=1883
-# Dedicated broker credentials — decoupled from your SAIC/MG account so a
+# Dedicated broker credentials -- decoupled from your SAIC/MG account so a
 # LAN-exposed broker does not leak your cloud account password.
+# Optional when using the bundled Mosquitto -- defaults to "garagestack".
+# Set explicitly if you expose port 1883 to the LAN or use an external broker.
 # Generate a strong password: openssl rand -hex 32
 MQTT_BROKER_USERNAME=garagestack
-MQTT_BROKER_PASSWORD=changeme_use_something_strong
+MQTT_BROKER_PASSWORD=
 
 # ── Ports ───────────────────────────────────────────────────────────────────
 # Host port for the frontend (nginx). Use 8080 by default to avoid clashing

--- a/README.md
+++ b/README.md
@@ -122,13 +122,13 @@ docker run -d \
   -e SAIC_USER=your@email.com \
   -e SAIC_PASSWORD=yourpassword \
   -e SAIC_REGION=eu \
-  -e POSTGRES_PASSWORD=changeme \
   -e JWT_SECRET="$(openssl rand -base64 32)" \
   -e CORS_ORIGIN=http://192.168.1.100:8080 \
   -e AUTH_COOKIE_SECURE=false \
   ghcr.io/joszz/garagestack:latest
 ```
 
+> `POSTGRES_PASSWORD` is omitted -- a strong random password is auto-generated on first start and saved to `/data/.postgres_password`. Pass `-e POSTGRES_PASSWORD=yourpassword` explicitly if you need a known value (e.g. to connect with an external DB tool).
 > **HTTPS proxy:** omit `-e AUTH_COOKIE_SECURE=false` (or set it to `true`) when the container sits behind a TLS-terminating reverse proxy.
 
 **Unraid:** import `unraid/garagestack.xml` from Community Apps and fill in the variables in the template UI.
@@ -161,9 +161,10 @@ Then open `.env` and fill in at minimum:
 | `SAIC_USER` | MG iSmart account email |
 | `SAIC_PASSWORD` | MG iSmart account password |
 | `SAIC_REGION` | `eu`, `cn`, or `row` |
-| `POSTGRES_PASSWORD` | Pick a strong random password |
 | `JWT_SECRET` | At least 32 random characters -- generate with `openssl rand -base64 32` |
 | `CORS_ORIGIN` | The URL you open in your browser, e.g. `http://192.168.1.100:8080` |
+
+`POSTGRES_PASSWORD` and `MQTT_BROKER_PASSWORD` default to `garagestack` when using the bundled services. Set them explicitly if you want stronger credentials or need to connect to the database/broker from outside the stack.
 
 `VAPID_PUBLIC_KEY` / `VAPID_PRIVATE_KEY` are optional; leave them empty to disable push notifications.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       -c "
       set -eu;
       rm -f /mosquitto/data/passwd /mosquitto/data/acl;
-      mosquitto_passwd -b -c /mosquitto/data/passwd \"${MQTT_BROKER_USERNAME:-garagestack}\" \"${MQTT_BROKER_PASSWORD}\";
+      mosquitto_passwd -b -c /mosquitto/data/passwd \"${MQTT_BROKER_USERNAME:-garagestack}\" \"${MQTT_BROKER_PASSWORD:-garagestack}\";
       printf 'user %s\\ntopic readwrite #\\n' \"${MQTT_BROKER_USERNAME:-garagestack}\" > /mosquitto/data/acl;
       chown mosquitto:mosquitto /mosquitto/data/passwd /mosquitto/data/acl;
       chmod 600 /mosquitto/data/passwd /mosquitto/data/acl;
@@ -31,7 +31,7 @@ services:
       SAIC_PASSWORD: "${SAIC_PASSWORD}"
       MQTT_URI: "tcp://mosquitto:1883"
       MQTT_USER: "${MQTT_BROKER_USERNAME:-garagestack}"
-      MQTT_PASSWORD: "${MQTT_BROKER_PASSWORD}"
+      MQTT_PASSWORD: "${MQTT_BROKER_PASSWORD:-garagestack}"
       SAIC_REGION: "${SAIC_REGION:-eu}"
 
   # Bundled Postgres - only starts when you pass --profile bundled-postgres.
@@ -45,7 +45,7 @@ services:
     environment:
       POSTGRES_DB: "${POSTGRES_DB:-garagestack}"
       POSTGRES_USER: "${POSTGRES_USER:-garagestack}"
-      POSTGRES_PASSWORD: "${POSTGRES_PASSWORD}"
+      POSTGRES_PASSWORD: "${POSTGRES_PASSWORD:-garagestack}"
     volumes:
       - postgres_data:/var/lib/postgresql/data
     healthcheck:
@@ -74,11 +74,11 @@ services:
       - .env
     environment:
       ASPNETCORE_ENVIRONMENT: "Production"
-      ConnectionStrings__DefaultConnection: "Host=${POSTGRES_HOST:-postgres};Port=${POSTGRES_PORT:-5432};Database=${POSTGRES_DB:-garagestack};Username=${POSTGRES_USER:-garagestack};Password=${POSTGRES_PASSWORD}"
+      ConnectionStrings__DefaultConnection: "Host=${POSTGRES_HOST:-postgres};Port=${POSTGRES_PORT:-5432};Database=${POSTGRES_DB:-garagestack};Username=${POSTGRES_USER:-garagestack};Password=${POSTGRES_PASSWORD:-garagestack}"
       Mqtt__Host: "${MQTT_HOST:-mosquitto}"
       Mqtt__Port: "${MQTT_PORT:-1883}"
       Mqtt__Username: "${MQTT_BROKER_USERNAME:-garagestack}"
-      Mqtt__Password: "${MQTT_BROKER_PASSWORD}"
+      Mqtt__Password: "${MQTT_BROKER_PASSWORD:-garagestack}"
       Vapid__PublicKey: "${VAPID_PUBLIC_KEY}"
       Vapid__PrivateKey: "${VAPID_PRIVATE_KEY}"
       Vapid__Subject: "mailto:${SAIC_USER}"
@@ -103,7 +103,7 @@ services:
       - .env
     environment:
       ASPNETCORE_ENVIRONMENT: "Production"
-      ConnectionStrings__DefaultConnection: "Host=${POSTGRES_HOST:-postgres};Port=${POSTGRES_PORT:-5432};Database=${POSTGRES_DB:-garagestack};Username=${POSTGRES_USER:-garagestack};Password=${POSTGRES_PASSWORD}"
+      ConnectionStrings__DefaultConnection: "Host=${POSTGRES_HOST:-postgres};Port=${POSTGRES_PORT:-5432};Database=${POSTGRES_DB:-garagestack};Username=${POSTGRES_USER:-garagestack};Password=${POSTGRES_PASSWORD:-garagestack}"
       Cors__Origins__0: "${CORS_ORIGIN:-http://localhost:8080}"
       Jwt__Secret: "${JWT_SECRET}"
       SAIC_USER: "${SAIC_USER}"
@@ -113,7 +113,7 @@ services:
       Mqtt__Host: "${MQTT_HOST:-mosquitto}"
       Mqtt__Port: "${MQTT_PORT:-1883}"
       Mqtt__Username: "${MQTT_BROKER_USERNAME:-garagestack}"
-      Mqtt__Password: "${MQTT_BROKER_PASSWORD}"
+      Mqtt__Password: "${MQTT_BROKER_PASSWORD:-garagestack}"
       Vapid__PublicKey: "${VAPID_PUBLIC_KEY}"
       Vapid__PrivateKey: "${VAPID_PRIVATE_KEY}"
       Vapid__Subject: "mailto:${SAIC_USER}"

--- a/docker/all-in-one/README.md
+++ b/docker/all-in-one/README.md
@@ -9,7 +9,7 @@ Single container that bundles every GarageStack service. Designed for Unraid and
 | **nginx** | Serves the Vue SPA on port 80; proxies `/api/` to the .NET API |
 | **GarageStack.Api** | ASP.NET Core REST API (localhost:9000, not directly exposed) |
 | **GarageStack.Worker** | .NET background service -- MQTT consumer, push notifications |
-| **PostgreSQL 17** | Embedded database (localhost:5432, not directly exposed) |
+| **PostgreSQL 18** | Embedded database (localhost:5432, not directly exposed) |
 | **Mosquitto** | MQTT broker on port 1883 with username/password auth and ACL |
 | **SAIC MQTT Gateway** | Python 3.14 service that polls the MG iSmart cloud and publishes telemetry to Mosquitto. Copied directly from the official `saicismartapi/saic-python-mqtt-gateway` image. |
 
@@ -44,7 +44,6 @@ Mount a single volume at `/data`. The container creates the following layout ins
 | `SAIC_USER` | MG iSmart account email (must be the vehicle owner account) |
 | `SAIC_PASSWORD` | MG iSmart account password |
 | `SAIC_REGION` | Region: `eu`, `cn`, or `row` (default: `eu`) |
-| `POSTGRES_PASSWORD` | Password for the embedded database. Set once and do not change. |
 | `JWT_SECRET` | Token signing key, minimum 32 characters. Generate: `openssl rand -base64 32` |
 | `CORS_ORIGIN` | Exact URL you use to open the app, e.g. `http://192.168.1.100:8080` |
 
@@ -54,6 +53,7 @@ The web login uses the same `SAIC_USER` and `SAIC_PASSWORD` credentials. There i
 
 | Variable | Description |
 |----------|-------------|
+| `POSTGRES_PASSWORD` | Password for the embedded database. If not set, a random password is auto-generated on first start and saved to `/data/.postgres_password`. Set explicitly if you need a known value (e.g. for external tools that connect directly to the database). |
 | `VAPID_PUBLIC_KEY` | Web Push VAPID public key. Leave empty to disable push notifications. Generate: `npx web-push generate-vapid-keys` |
 | `VAPID_PRIVATE_KEY` | Web Push VAPID private key |
 | `WIDGET_API_KEY` | Static API key for the Homepage dashboard widget endpoint (`/api/widget/{vin}/status`). Leave empty to disable. Generate: `openssl rand -base64 32` |
@@ -83,20 +83,22 @@ docker run -d \
   -e SAIC_USER=your@email.com \
   -e SAIC_PASSWORD=yourpassword \
   -e SAIC_REGION=eu \
-  -e POSTGRES_PASSWORD=changeme \
   -e JWT_SECRET="$(openssl rand -base64 32)" \
   -e CORS_ORIGIN=http://localhost:8080 \
   ghcr.io/joszz/garagestack:latest
 ```
+
+> `POSTGRES_PASSWORD` is omitted here -- a random password is auto-generated on first start and saved to `/data/.postgres_password`. Pass `-e POSTGRES_PASSWORD=yourpassword` explicitly if you need a known value.
 
 ## Unraid Community Apps
 
 Import the template from `unraid/garagestack.xml`. Fill in at minimum:
 
 1. **MG iSmart Email / Password / Region**
-2. **Database Password** -- pick a strong random value
-3. **JWT Secret** -- generate with `openssl rand -base64 32`
-4. **App URL** -- the address you use in your browser (e.g. `http://192.168.1.50:8080`)
+2. **JWT Secret** -- generate with `openssl rand -base64 32`
+3. **App URL** -- the address you use in your browser (e.g. `http://192.168.1.50:8080`)
+
+**Database Password** is optional -- if left blank a strong random password is auto-generated on first start and saved to `/data/.postgres_password`. You only need to set it explicitly if you want to connect to the embedded database with an external tool.
 
 VAPID keys are optional; leave them blank to skip push notifications.
 

--- a/docker/all-in-one/entrypoint.sh
+++ b/docker/all-in-one/entrypoint.sh
@@ -7,11 +7,23 @@ mkdir -p /data/db/postgres /data/db/mosquitto /data/logs /data/dataprotection
 PGDATA="/data/db/postgres"
 POSTGRES_DB="${POSTGRES_DB:-garagestack}"
 POSTGRES_USER="${POSTGRES_USER:-garagestack}"
-POSTGRES_PASSWORD="${POSTGRES_PASSWORD:?POSTGRES_PASSWORD environment variable is required}"
 SAIC_USER="${SAIC_USER:?SAIC_USER environment variable is required}"
 SAIC_PASSWORD="${SAIC_PASSWORD:?SAIC_PASSWORD environment variable is required}"
 
-# Dedicated internal MQTT broker credentials — decoupled from SAIC account credentials
+# Auto-generate POSTGRES_PASSWORD on first run and persist it so subsequent
+# restarts use the same password as the already-initialised database cluster.
+if [ -z "${POSTGRES_PASSWORD:-}" ]; then
+    if [ -f "/data/.postgres_password" ]; then
+        POSTGRES_PASSWORD="$(cat /data/.postgres_password)"
+    else
+        POSTGRES_PASSWORD="$(openssl rand -hex 32)"
+        echo "${POSTGRES_PASSWORD}" > /data/.postgres_password
+        chmod 600 /data/.postgres_password
+        echo "[garagestack] POSTGRES_PASSWORD not set -- auto-generated and saved to /data/.postgres_password"
+    fi
+fi
+
+# Dedicated internal MQTT broker credentials -- decoupled from SAIC account credentials
 # so a LAN-exposed broker does not leak the user's cloud account password.
 MQTT_BROKER_USERNAME="${MQTT_BROKER_USERNAME:-garagestack}"
 if [ -z "${MQTT_BROKER_PASSWORD:-}" ]; then

--- a/unraid/garagestack.xml
+++ b/unraid/garagestack.xml
@@ -106,10 +106,10 @@
     Target="POSTGRES_PASSWORD"
     Default=""
     Mode=""
-    Description="Password for the embedded PostgreSQL database. Set a strong random value -- you will not need to enter this again. Generate one with: openssl rand -base64 24"
+    Description="Password for the embedded PostgreSQL database. If left empty a strong random password is auto-generated on first start and saved to /data/.postgres_password inside the data directory. Set explicitly only if you need to connect to the database directly with external tools. Generate with: openssl rand -base64 24"
     Type="Variable"
-    Display="always"
-    Required="true"
+    Display="advanced"
+    Required="false"
     Mask="true"/>
 
   <Config


### PR DESCRIPTION
## Summary

- **`docker-compose.yml`**: all `POSTGRES_PASSWORD` and `MQTT_BROKER_PASSWORD` references now use `:-garagestack` fallbacks, so the bundled Postgres and Mosquitto services start without those variables being set in `.env`
- **`docker/all-in-one/entrypoint.sh`**: `POSTGRES_PASSWORD` is no longer required — if unset, a strong 32-byte random password is auto-generated on first start and persisted to `/data/.postgres_password`; subsequent restarts read from that file so the password always matches the already-initialised cluster (`MQTT_BROKER_PASSWORD` already had similar behaviour)
- **`unraid/garagestack.xml`**: `POSTGRES_PASSWORD` moved from required/always to optional/advanced
- **Docs**: `README.md`, `docker/all-in-one/README.md`, and `.env.example` updated to reflect that both passwords are optional for the bundled setup

## Test plan

- [ ] `docker compose --profile bundled-postgres up` starts cleanly with no `POSTGRES_PASSWORD` or `MQTT_BROKER_PASSWORD` in `.env`
- [ ] Postgres initialises and the API/worker connect successfully
- [ ] `saic-mqtt` connects to Mosquitto without auth errors
- [ ] Setting explicit values in `.env` still takes precedence over defaults
- [ ] AIO container first-start generates `/data/.postgres_password` and Postgres initialises with it
- [ ] AIO container restart reads the persisted password and connects successfully

🤖 Generated with [Claude Code](https://claude.ai/claude-code)