### PR TITLE
fix(docker): update postgres volume mount for PG18 layout change

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,7 +47,7 @@ services:
       POSTGRES_USER: "${POSTGRES_USER:-garagestack}"
       POSTGRES_PASSWORD: "${POSTGRES_PASSWORD:-garagestack}"
     volumes:
-      - postgres_data:/var/lib/postgresql/data
+      - postgres_data:/var/lib/postgresql
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-garagestack} -d ${POSTGRES_DB:-garagestack}"]
       interval: 10s


### PR DESCRIPTION
## Summary

PostgreSQL 18 changed the default data directory layout. It now expects to be mounted at `/var/lib/postgresql` and manages its own version-specific subdirectory (`18/main`). The previous mount at `/var/lib/postgresql/data` causes the container to fail with:

> Error: in 18+, these Docker images are configured to store database data in a format which is compatible with "pg_ctlcluster" (specifically, using major-version-specific directory names).

This PR updates the volume binding in `docker-compose.yml` from:
```
postgres_data:/var/lib/postgresql/data
```
to:
```
postgres_data:/var/lib/postgresql
```

## Test plan

- [ ] `docker compose --profile bundled-postgres up` starts Postgres successfully
- [ ] Existing installs: remove the old `postgres_data` volume first (`docker volume rm garagestack_postgres_data`) -- data will be re-initialized from migrations on first start

🤖 Generated with [Claude Code](https://claude.ai/claude-code)