### PR TITLE
fix(fresh-install): migration ordering crash and CORS localhost warning

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -51,8 +51,12 @@ FRONTEND_PORT=8080
 API_PORT=5000
 
 # ── CORS ────────────────────────────────────────────────────────────────────
-# The URL your browser uses to reach the frontend - must match exactly including
-# the port. Add more origins by setting Cors__Origins__1 etc. in docker-compose.
+# The URL your browser uses to reach the frontend -- must match exactly including
+# the port. This MUST be the address you type in the browser, not the server's
+# internal address. If you access from another device on the LAN, use the
+# server's LAN IP or hostname (e.g. http://192.168.1.100:8080), NOT localhost.
+# Using localhost here blocks login from any device other than the server itself.
+# Add more origins by setting Cors__Origins__1 etc. in docker-compose.
 CORS_ORIGIN=http://localhost:8080
 
 # ── API Authentication ───────────────────────────────────────────────────────

--- a/src/GarageStack.Api/Program.cs
+++ b/src/GarageStack.Api/Program.cs
@@ -234,6 +234,18 @@ try
     // verify it matches a configured allowed origin. SameSite=Strict is the primary CSRF
     // protection; this adds an explicit server-side check for deployments where that alone
     // is not sufficient (e.g., same-site subdomain compromise).
+    var allowedOrigins = app.Configuration.GetSection("Cors:Origins").Get<string[]>() ?? [];
+    if (!app.Environment.IsDevelopment() &&
+        allowedOrigins.Any(o => o.Contains("localhost", StringComparison.OrdinalIgnoreCase)))
+    {
+        Log.Warning(
+            "CORS_ORIGIN contains 'localhost' ({Origins}). " +
+            "Requests from other devices on the LAN will be rejected with 403. " +
+            "Set CORS_ORIGIN to the address you use to reach the app from those devices, " +
+            "e.g. http://192.168.1.100:8080",
+            string.Join(", ", allowedOrigins));
+    }
+
     app.Use(async (ctx, next) =>
     {
         if (HttpMethods.IsPost(ctx.Request.Method) ||
@@ -244,10 +256,17 @@ try
             var origin = ctx.Request.Headers.Origin.ToString();
             if (!string.IsNullOrEmpty(origin) && !app.Environment.IsDevelopment())
             {
-                var allowed = app.Configuration.GetSection("Cors:Origins").Get<string[]>() ?? [];
-                if (!CsrfPolicy.IsOriginAllowed(origin, allowed))
+                var csrfAllowed = app.Configuration.GetSection("Cors:Origins").Get<string[]>() ?? [];
+                if (!CsrfPolicy.IsOriginAllowed(origin, csrfAllowed))
                 {
+                    Log.Warning(
+                        "CSRF origin check failed: request Origin '{Origin}' not in allowed list ({Allowed}). " +
+                        "If you are accessing from a LAN device, set CORS_ORIGIN to match the address in your browser.",
+                        origin, string.Join(", ", csrfAllowed));
                     ctx.Response.StatusCode = StatusCodes.Status403Forbidden;
+                    ctx.Response.ContentType = "application/json";
+                    await ctx.Response.WriteAsync(
+                        "{\"error\":\"Origin not allowed. Set CORS_ORIGIN to the address you use to reach the app.\"}");
                     return;
                 }
             }

--- a/src/GarageStack.Data/Migrations/20260522112722_AddQueryIndexes.cs
+++ b/src/GarageStack.Data/Migrations/20260522112722_AddQueryIndexes.cs
@@ -10,16 +10,25 @@ namespace GarageStack.Data.Migrations
         /// <inheritdoc />
         protected override void Up(MigrationBuilder migrationBuilder)
         {
-            migrationBuilder.CreateIndex(
-                name: "IX_UserRefreshTokens_Revoked_ExpiresAt",
-                table: "UserRefreshTokens",
-                columns: new[] { "Revoked", "ExpiresAt" });
-
-            migrationBuilder.CreateIndex(
-                name: "IX_UserRefreshTokens_Token",
-                table: "UserRefreshTokens",
-                column: "Token",
-                unique: true);
+            // UserRefreshTokens is created in AddAuthentication (20260522120000), which has a later
+            // timestamp. On a fresh install migrations run in timestamp order, so this migration
+            // runs first and the table does not exist yet. Use conditional SQL so that existing
+            // deployments (where AddAuthentication already ran) get the indexes, while fresh
+            // installs skip them safely -- RemoveAuthentication (20260526) drops the table anyway.
+            migrationBuilder.Sql("""
+                DO $$ BEGIN
+                    IF EXISTS (
+                        SELECT 1 FROM information_schema.tables
+                        WHERE table_schema = 'public'
+                        AND table_name = 'UserRefreshTokens'
+                    ) THEN
+                        CREATE INDEX IF NOT EXISTS "IX_UserRefreshTokens_Revoked_ExpiresAt"
+                            ON "UserRefreshTokens" ("Revoked", "ExpiresAt");
+                        CREATE UNIQUE INDEX IF NOT EXISTS "IX_UserRefreshTokens_Token"
+                            ON "UserRefreshTokens" ("Token");
+                    END IF;
+                END $$;
+                """);
 
             migrationBuilder.CreateIndex(
                 name: "IX_TelemetrySnapshots_VehicleId_LatLon_RecordedAt",
@@ -37,13 +46,10 @@ namespace GarageStack.Data.Migrations
         /// <inheritdoc />
         protected override void Down(MigrationBuilder migrationBuilder)
         {
-            migrationBuilder.DropIndex(
-                name: "IX_UserRefreshTokens_Revoked_ExpiresAt",
-                table: "UserRefreshTokens");
-
-            migrationBuilder.DropIndex(
-                name: "IX_UserRefreshTokens_Token",
-                table: "UserRefreshTokens");
+            migrationBuilder.Sql("""
+                DROP INDEX IF EXISTS "IX_UserRefreshTokens_Revoked_ExpiresAt";
+                DROP INDEX IF EXISTS "IX_UserRefreshTokens_Token";
+                """);
 
             migrationBuilder.DropIndex(
                 name: "IX_TelemetrySnapshots_VehicleId_LatLon_RecordedAt",


### PR DESCRIPTION
## Summary

- **Migration ordering crash**: `AddQueryIndexes` (timestamp `20260522112722`) runs before `AddAuthentication` (`20260522120000`) in EF's timestamp-ordered sequence, so it tries to index `UserRefreshTokens` before the table exists. This causes `42P01: relation "UserRefreshTokens" does not exist` and crashes the API on every fresh install. Fixed by replacing the two `CreateIndex` calls for `UserRefreshTokens` with conditional PL/pgSQL (`DO $$ IF EXISTS ... END $$`) that skips index creation when the table is absent. Existing deployments are unaffected -- the table exists at that point in their migration history.
- **CORS/CSRF 403 with no feedback**: State-changing requests from LAN devices are silently rejected when `CORS_ORIGIN=http://localhost:8080` (the default). The middleware now logs a `Warning` with actionable text and returns a JSON body explaining the fix. Added a startup warning when `CORS_ORIGIN` contains `localhost` in production. Improved `.env.example` wording to make the LAN-access requirement explicit.

Fixes #180

## Test plan

- [ ] `docker compose --profile bundled-postgres up --build` on a fresh install (no pre-existing volumes) -- API should not crash-loop
- [ ] All 247 unit tests pass (`dotnet test`)
- [ ] Log in from a device that doesn't match `CORS_ORIGIN` -- should see `[WRN] CSRF origin check failed` with helpful text instead of a silent 403
- [ ] Startup log shows warning when `CORS_ORIGIN` contains `localhost`

🤖 Generated with [Claude Code](https://claude.com/claude-code)