### PR TITLE
fix(all-in-one): fresh-install crash from log permissions, mosquitto pwfile, and CRLF

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,8 @@
+# Scripts and config copied into Linux containers must keep LF line endings
+# regardless of the contributor's platform or core.autocrlf setting --
+# CRLF breaks shebangs ("no such file or directory") when the image is
+# built locally on Windows.
+*.sh text eol=lf
+docker/**/*.conf text eol=lf
+mosquitto/**/*.conf text eol=lf
+Dockerfile text eol=lf

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,9 @@ node_modules/
 frontend/dist/
 frontend/.env.local
 
+# local all-in-one container testing data (see docker/all-in-one/README.md)
+garagestack-data/
+
 CLAUDE.md
 dev.ps1
 example_data.txt

--- a/docker/all-in-one/README.md
+++ b/docker/all-in-one/README.md
@@ -75,6 +75,8 @@ docker build \
 
 ## Running locally for testing
 
+macOS/Linux (bash):
+
 ```bash
 docker run -d \
   --name garagestack \
@@ -85,6 +87,22 @@ docker run -d \
   -e SAIC_REGION=eu \
   -e JWT_SECRET="$(openssl rand -base64 32)" \
   -e CORS_ORIGIN=http://localhost:8080 \
+  ghcr.io/joszz/garagestack:latest
+```
+
+Windows (PowerShell -- `openssl` is not available by default and `$()` substitution is bash-only):
+
+```powershell
+$jwtSecret = [Convert]::ToBase64String((1..32 | ForEach-Object { Get-Random -Minimum 0 -Maximum 256 }))
+docker run -d `
+  --name garagestack `
+  -p 8080:80 `
+  -v ${PWD}/garagestack-data:/data `
+  -e SAIC_USER=your@email.com `
+  -e SAIC_PASSWORD=yourpassword `
+  -e SAIC_REGION=eu `
+  -e JWT_SECRET=$jwtSecret `
+  -e CORS_ORIGIN=http://localhost:8080 `
   ghcr.io/joszz/garagestack:latest
 ```
 

--- a/docker/all-in-one/entrypoint.sh
+++ b/docker/all-in-one/entrypoint.sh
@@ -76,7 +76,7 @@ chmod 600 /etc/mosquitto/conf.d/passwd /etc/mosquitto/conf.d/acl
 # ── PostgreSQL initialisation ──────────────────────────────────────────────────
 if [ ! -f "$PGDATA/PG_VERSION" ]; then
     echo "[garagestack] Initialising PostgreSQL data directory..."
-    chown -R postgres:postgres /data/db
+    chown -R postgres:postgres /data/db /data/logs
     gosu postgres /usr/lib/postgresql/18/bin/initdb \
         -D "$PGDATA" --auth-host=md5 --auth-local=trust -E UTF8 --locale=C
 
@@ -97,7 +97,7 @@ EOSQL
     echo "[garagestack] PostgreSQL initialised."
 fi
 
-chown -R postgres:postgres /data/db
+chown -R postgres:postgres /data/db /data/logs
 
 echo "[garagestack] Starting all services via supervisord..."
 exec /usr/bin/supervisord -n -c /etc/supervisor/supervisord.conf

--- a/docker/all-in-one/entrypoint.sh
+++ b/docker/all-in-one/entrypoint.sh
@@ -69,14 +69,18 @@ mkdir -p /data/dataprotection /root/.aspnet
 ln -sfn /data/dataprotection /root/.aspnet/DataProtection-Keys
 
 # Generate Mosquitto password and ACL files from SAIC credentials.
+# Mosquitto 2.x refuses to load password/ACL files unless they are owned by
+# the user it runs as (it checks the literal "mosquitto" account via getpwnam,
+# not the process's actual uid) -- run the broker as that user via gosu below.
 mosquitto_passwd -b -c /etc/mosquitto/conf.d/passwd "${MQTT_BROKER_USERNAME}" "${MQTT_BROKER_PASSWORD}"
 printf 'user %s\ntopic readwrite #\n' "${MQTT_BROKER_USERNAME}" > /etc/mosquitto/conf.d/acl
+chown mosquitto:mosquitto /etc/mosquitto/conf.d/passwd /etc/mosquitto/conf.d/acl /data/db/mosquitto
 chmod 600 /etc/mosquitto/conf.d/passwd /etc/mosquitto/conf.d/acl
 
 # ── PostgreSQL initialisation ──────────────────────────────────────────────────
 if [ ! -f "$PGDATA/PG_VERSION" ]; then
     echo "[garagestack] Initialising PostgreSQL data directory..."
-    chown -R postgres:postgres /data/db /data/logs
+    chown -R postgres:postgres /data/db/postgres /data/logs
     gosu postgres /usr/lib/postgresql/18/bin/initdb \
         -D "$PGDATA" --auth-host=md5 --auth-local=trust -E UTF8 --locale=C
 
@@ -97,7 +101,7 @@ EOSQL
     echo "[garagestack] PostgreSQL initialised."
 fi
 
-chown -R postgres:postgres /data/db /data/logs
+chown -R postgres:postgres /data/db/postgres /data/logs
 
 echo "[garagestack] Starting all services via supervisord..."
 exec /usr/bin/supervisord -n -c /etc/supervisor/supervisord.conf

--- a/docker/all-in-one/supervisord.conf
+++ b/docker/all-in-one/supervisord.conf
@@ -29,7 +29,7 @@ stderr_logfile=/data/logs/postgresql.log
 
 ; ── Mosquitto MQTT broker ──────────────────────────────────────────────────────
 [program:mosquitto]
-command=/usr/sbin/mosquitto -c /etc/mosquitto/conf.d/garagestack.conf
+command=gosu mosquitto /usr/sbin/mosquitto -c /etc/mosquitto/conf.d/garagestack.conf
 priority=20
 autostart=true
 autorestart=true


### PR DESCRIPTION
## Summary
Fresh-install testing of the All-in-One container on Windows surfaced three independent crash-on-first-run bugs:

- `chown -R postgres:postgres /data/db` never covered `/data/logs`, so `pg_ctl`'s own `gosu postgres ... -l /data/logs/postgres-init.log start` failed with `Permission denied` and the entrypoint exited under `set -e` before ever reaching `supervisord`.
- Mosquitto 2.x's password/ACL file hardening checks the literal `mosquitto` system account via `getpwnam`, not the broker process's actual uid -- so the root-owned, `600`-permission passwd/acl files this entrypoint generated were rejected with `Error: Unable to open pwfile`, crash-looping mosquitto. Fixed by running mosquitto via `gosu mosquitto`, like postgres already runs via `gosu postgres`, with matching file ownership.
- `core.autocrlf=true` (common default on Windows) silently converts `entrypoint.sh` to CRLF in the working tree since the repo has no `.gitattributes`. CRLF breaks the shebang (`no such file or directory`) -- this would hit anyone who builds the AIO image locally on Windows, a documented workflow in the README.
- Bonus: added a PowerShell-native `docker run` example to the README, since the existing one relies on bash-only `$()` substitution and `openssl`, neither available in a default Windows PowerShell shell.

## Test plan
- [x] `docker build -f docker/all-in-one/Dockerfile -t garagestack-aio-test:local .` from repo root
- [x] Fresh bind-mounted `/data` dir, `docker run` with required env vars
- [x] All six supervisord-managed services (postgresql, mosquitto, saic-gateway, api, worker, nginx) reach `RUNNING` state with no restarts
- [x] `mosquitto.log` shows no permission warnings; SAIC gateway connects and authenticates
- [x] Web UI responds `200 OK` on the mapped port