### PR TITLE
fix(frontend): bust apk cache so OS package upgrades actually apply

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -103,6 +103,11 @@ jobs:
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "Resolved MinVer version: $VERSION"
 
+      - name: Compute OS patch date
+        id: patchdate
+        shell: bash
+        run: echo "date=$(date -u +%Y-%m-%d)" >> "$GITHUB_OUTPUT"
+
       - name: Log in to Docker Hub (avoids pull rate limits for moby/buildkit)
         if: github.event_name != 'pull_request'
         continue-on-error: true
@@ -146,6 +151,7 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             APP_VERSION=${{ steps.minver.outputs.version }}
+            OS_PATCH_DATE=${{ steps.patchdate.outputs.date }}
           # Each image gets its own GHA cache scope
           cache-from: type=gha,scope=${{ matrix.label }}
           cache-to: type=gha,scope=${{ matrix.label }},mode=min,ignore-error=true

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -2,14 +2,18 @@ FROM node:24-alpine AS build
 WORKDIR /app
 ARG VITE_DEMO_MODE=false
 ENV VITE_DEMO_MODE=$VITE_DEMO_MODE
-RUN apk upgrade --no-cache && corepack enable && corepack prepare pnpm@11.1.3 --activate
+# OS_PATCH_DATE busts the layer cache so apk upgrade actually re-runs instead of
+# reusing a stale cached layer from before an OS package fix was published.
+ARG OS_PATCH_DATE=0
+RUN echo "os patch date: ${OS_PATCH_DATE}" && apk upgrade --no-cache && corepack enable && corepack prepare pnpm@11.1.3 --activate
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 RUN pnpm config set minimum-release-age 0 && pnpm install --frozen-lockfile --ignore-scripts
 COPY . .
 RUN pnpm run build
 
 FROM nginx:alpine AS runtime
-RUN apk upgrade --no-cache
+ARG OS_PATCH_DATE=0
+RUN echo "os patch date: ${OS_PATCH_DATE}" && apk upgrade --no-cache
 COPY --from=build /app/dist /usr/share/nginx/html
 COPY nginx.conf /etc/nginx/conf.d/default.conf
 EXPOSE 80


### PR DESCRIPTION
## Summary
- All 13 open [code scanning alerts](https://github.com/joszz/GarageStack/security/code-scanning) are the same root cause: `libexpat` in the `garagestack-frontend` image is stuck on `2.8.1-r0` (fix is `2.8.2-r0`).
- The Dockerfile already runs `apk upgrade --no-cache`, but `docker-publish.yml` builds with a persistent GHA layer cache, so that RUN layer was reused from before the fix was published upstream and never actually re-executed, even on the weekly scheduled rebuild meant to catch new OS patches. Confirmed by pulling the published image: it had `libexpat-2.8.1-r0` even though Alpine 3.23's repo already serves `2.8.2-r0`.
- Adds an `OS_PATCH_DATE` build-arg (refreshed daily in CI) referenced inside the `apk upgrade` RUN commands in `frontend/Dockerfile`, so that layer's cache key changes and it actually re-runs.

## Test plan
- [x] Built `frontend/Dockerfile` locally with the new build-arg and confirmed the resulting image reports `libexpat-2.8.2-r0` installed (was `2.8.1-r0` before the change).
- [ ] CI: docker-publish workflow builds and pushes successfully.
- [ ] Security workflow re-scans the new image and the 13 alerts move to "fixed".

🤖 Generated with [Claude Code](https://claude.com/claude-code)