### PR TITLE
fix(frontend): add missing info icon to parking locations card

### DIFF
--- a/frontend/src/views/StatisticsView.vue
+++ b/frontend/src/views/StatisticsView.vue
@@ -770,13 +770,18 @@ const skeletonChartCount = computed(
             <template v-for="item in settings.statsInsights" :key="item.id">
               <template v-if="item.visible && insightDefMap.get(item.id)?.applicable">
                 <template v-if="item.id === 'parkingLocations'">
-                  <StatusCard
-                    :icon="insightDefMap.get(item.id)!.icon"
-                    :label="insightDefMap.get(item.id)!.title"
-                    :value="insightDefMap.get(item.id)!.value"
-                    clickable
-                    @click="parkingModalOpen = true"
-                  />
+                  <CardInfoWrap
+                    :title="insightDefMap.get(item.id)!.title"
+                    :description="insightDefMap.get(item.id)!.description"
+                  >
+                    <StatusCard
+                      :icon="insightDefMap.get(item.id)!.icon"
+                      :label="insightDefMap.get(item.id)!.title"
+                      :value="insightDefMap.get(item.id)!.value"
+                      clickable
+                      @click="parkingModalOpen = true"
+                    />
+                  </CardInfoWrap>
                 </template>
                 <template v-else>
                   <CardInfoWrap


### PR DESCRIPTION
## Summary
- The parking locations insight card on the Statistics page was rendered as a bare `StatusCard`, skipping the `CardInfoWrap` that every other insight card uses.
- Wrapped it in `CardInfoWrap` so it gets the info icon and description modal, while keeping its existing click-to-open-map behavior (the info button sits outside the clickable card as an absolutely-positioned sibling, so it doesn't intercept the card's click).

## Test plan
- [x] `pnpm test:unit run` (133 tests passed)
- [x] `pnpm exec prettier --write` on the changed file
- [ ] Manually verify in browser: info icon appears on the parking locations card, opens description modal, and clicking the rest of the card still opens the parking map modal

🤖 Generated with [Claude Code](https://claude.com/claude-code)