### PR TITLE
fix(frontend): prevent map view header layout shift and fix heading order

### DIFF
--- a/frontend/src/views/MapView.vue
+++ b/frontend/src/views/MapView.vue
@@ -41,6 +41,11 @@ const vehicleType = computed((): VehicleType | 'unknown' => {
 })
 const isHev = computed(() => vehicleType.value === 'hev')
 const isBev = computed(() => vehicleType.value === 'bev')
+// Until vehicleType resolves from 'unknown', neither flag is true, which would show
+// both layer-toggle buttons and then remove one once the type is known - a visible
+// layout shift. Keep both hidden while unknown so the header never shows more
+// buttons than its final, resolved state.
+const vehicleTypeKnown = computed(() => vehicleType.value !== 'unknown')
 const displayLocale = computed(() => (settingsStore.locale === 'nl' ? 'nl-NL' : 'en-US'))
 const selectedTripIndex = ref<number | null>(null)
 const heatmapEnabled = computed({
@@ -1197,7 +1202,7 @@ onUnmounted(() => {
           </template>
         </FiltersPanel>
         <button
-          v-if="!isBev"
+          v-if="vehicleTypeKnown && !isBev"
           class="btn btn-sm map-layer-btn"
           :class="{ 'map-layer-btn--active map-layer-btn--fuel': fuelStationsEnabled }"
           :aria-pressed="fuelStationsEnabled"
@@ -1207,7 +1212,7 @@ onUnmounted(() => {
           {{ t('trips.fuelStations') }}
         </button>
         <button
-          v-if="!isHev"
+          v-if="vehicleTypeKnown && !isHev"
           class="btn btn-sm map-layer-btn"
           :class="{ 'map-layer-btn--active map-layer-btn--charging': chargingStationsEnabled }"
           :aria-pressed="chargingStationsEnabled"
@@ -1231,7 +1236,7 @@ onUnmounted(() => {
       <!-- Trip sidebar -->
       <aside ref="tripSidebarRef" class="trip-sidebar">
         <div class="trip-sidebar__header">
-          <h3 class="trip-sidebar__title">{{ t('trips.title') }}</h3>
+          <h2 class="trip-sidebar__title">{{ t('trips.title') }}</h2>
         </div>
 
         <div v-if="store.loading" class="trip-list">


### PR DESCRIPTION
## Summary
- A Lighthouse mobile audit on `/map` reported CLS 0.286 (score 0.42) and a `heading-order` a11y violation.
- Reproduced the CLS locally (Demo backend + production build + throttled Playwright session): the fuel/charging station header toggle buttons are gated on `isBev`/`isHev`, which are both `false` while `vehicleType` is still `'unknown'` (before `fetchConfig()` resolves after mount) — so both buttons render, wrapping the header to two lines, then one disappears once the real type is known, collapsing the header back to one line and shifting the map area. This isn't just a Lighthouse artifact: the PWA manifest has a home-screen shortcut straight to `/map`, so a cold load of that route without visiting Dashboard first is a normal path.
- Fix: added a `vehicleTypeKnown` computed guard so neither button renders until the type is actually resolved — the header never shows more buttons than its final state.
- Also fixed the sidebar's "Trip History" heading, which was an `<h3>` with no `<h2>` in between the page's `<h1>`.

## Test plan
- [x] Reproduced the original CLS locally with a throttled Playwright session mirroring Lighthouse's mobile CPU/network params — measured 0.2867, matching the reported 0.286.
- [x] Re-ran the same repro after the fix — CLS dropped to 0.0038 (76x improvement, under the 0.1 "good" threshold).
- [x] `pnpm run type-check` passes
- [x] `pnpm lint` passes
- [x] `pnpm test:unit` — all 133 tests pass