### PR TITLE
feat(frontend): add location map widget to dashboard

### DIFF
--- a/frontend/src/assets/main.css
+++ b/frontend/src/assets/main.css
@@ -728,13 +728,17 @@ body,
 }
 
 .location-map-card__canvas {
-  height: 100%;
-  width: 100%;
+  /* absolute + inset instead of height:100% - the edit-mode layout only gives
+     this element's ancestors a min-height (not a definite height), which a
+     percentage height cannot resolve against, leaving Leaflet's container at
+     0 height. Absolute positioning sizes against the laid-out box instead. */
+  position: absolute;
+  inset: 0;
 }
 
 .location-map-card__empty {
-  height: 100%;
-  min-height: 180px;
+  position: absolute;
+  inset: 0;
   display: flex;
   flex-direction: column;
   align-items: center;

--- a/frontend/src/assets/main.css
+++ b/frontend/src/assets/main.css
@@ -668,10 +668,171 @@ body,
 }
 
 .tyre-diagram {
+  position: relative;
   background: var(--color-surface);
   border: 1px solid var(--color-border);
   border-radius: var(--radius);
   padding: 1.25rem;
+}
+
+/* ── Overview row: car diagram + location map ─────────────── */
+
+.overview-row {
+  display: flex;
+  align-items: stretch;
+  gap: 1rem;
+}
+
+.overview-row__car {
+  flex: 2 1 320px;
+  min-width: 0;
+}
+
+.overview-row__map {
+  flex: 1 1 260px;
+  min-width: 220px;
+  max-width: 380px;
+  display: flex;
+  flex-direction: column;
+}
+
+@media (max-width: 767px) {
+  .overview-row {
+    flex-direction: column;
+  }
+
+  .overview-row__map {
+    max-width: none;
+  }
+}
+
+.location-map-card {
+  position: relative;
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius);
+  padding: 1.25rem;
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-height: 0;
+}
+
+.location-map-card__map {
+  position: relative;
+  flex: 1;
+  min-height: 180px;
+  border-radius: var(--radius);
+  overflow: hidden;
+  cursor: pointer;
+}
+
+.location-map-card__canvas {
+  height: 100%;
+  width: 100%;
+}
+
+.location-map-card__empty {
+  height: 100%;
+  min-height: 180px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  color: var(--color-text-muted);
+  background: var(--color-surface-2);
+  font-size: 0.85rem;
+}
+
+.location-map-card__expand {
+  position: absolute;
+  bottom: 8px;
+  right: 8px;
+  z-index: 1000;
+  width: 32px;
+  height: 32px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: 6px;
+  color: var(--color-text);
+  cursor: pointer;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.2);
+  transition: background 0.15s;
+}
+
+.location-map-card__expand:hover {
+  background: var(--color-surface-2);
+}
+
+/* ── Speedometer gauge ───────────────────────────────────── */
+
+.speed-gauge {
+  position: absolute;
+  top: 0;
+  right: 0;
+  width: 80px;
+  pointer-events: auto;
+  user-select: none;
+  z-index: 1;
+}
+
+.speed-gauge__svg {
+  width: 100%;
+  display: block;
+  overflow: visible;
+}
+
+.speed-gauge__track {
+  fill: none;
+  stroke: var(--color-border);
+  stroke-width: 7;
+  stroke-linecap: round;
+}
+
+.speed-gauge__progress {
+  fill: none;
+  stroke-width: 7;
+  stroke-linecap: round;
+  transition:
+    stroke-dashoffset 0.7s cubic-bezier(0.4, 0, 0.2, 1),
+    stroke 0.5s ease;
+}
+
+.speed-gauge__needle {
+  stroke: var(--color-primary-light);
+  stroke-width: 2.5;
+  stroke-linecap: round;
+  transform-origin: 50px 48px;
+  transition: transform 0.7s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.speed-gauge__pivot {
+  fill: var(--color-text-muted);
+}
+
+.speed-gauge__value {
+  font-size: 24px;
+  font-weight: 700;
+  fill: var(--color-text);
+}
+
+.speed-gauge__unit {
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  fill: var(--color-text-muted);
+  text-transform: uppercase;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .speed-gauge__progress,
+  .speed-gauge__needle {
+    transition: none;
+  }
 }
 
 .tyre-diagram__title {
@@ -775,6 +936,8 @@ body,
   background: var(--color-surface);
   border: 1px solid var(--color-border);
   white-space: nowrap;
+  pointer-events: auto;
+  user-select: none;
 }
 
 .tyre-label--fl {
@@ -835,7 +998,8 @@ body,
   border-radius: 20px;
   padding: 3px 10px;
   white-space: nowrap;
-  pointer-events: none;
+  pointer-events: auto;
+  user-select: none;
 }
 
 .diagram-level--fuel {
@@ -859,7 +1023,6 @@ body,
 .charge-entry-glow {
   fill: var(--charge-color);
   opacity: 0;
-  pointer-events: none;
 }
 
 .charge-group--active .charge-entry-glow {
@@ -881,7 +1044,6 @@ body,
   stroke: var(--charge-color);
   stroke-width: 1.5;
   opacity: 0.65;
-  pointer-events: none;
 }
 
 .charge-group--active .charge-socket {
@@ -897,7 +1059,6 @@ body,
   stroke-linecap: round;
   stroke-dasharray: 3 7;
   opacity: 0.45;
-  pointer-events: none;
 }
 
 .charge-group--active .charge-cable {
@@ -934,32 +1095,6 @@ body,
 
 .diagram-level--connected {
   box-shadow: 0 0 0 1.5px rgba(59, 130, 246, 0.6);
-}
-
-/* ── Legend ───────────────────────────────────────────────── */
-
-.tyre-legend {
-  display: flex;
-  gap: 1rem;
-  margin-top: 1rem;
-  font-size: 0.75rem;
-  flex-wrap: wrap;
-}
-
-.tyre-legend__item {
-  display: flex;
-  align-items: center;
-  gap: 0.3rem;
-}
-
-.tyre-legend__item--ok {
-  color: var(--color-success);
-}
-.tyre-legend__item--warning {
-  color: var(--color-warning);
-}
-.tyre-legend__item--danger {
-  color: var(--color-danger-text);
 }
 
 /* ── Car diagram light beams ──────────────────────────────── */
@@ -1016,7 +1151,8 @@ body,
   align-items: center;
   justify-content: center;
   font-size: 0.65rem;
-  pointer-events: none;
+  pointer-events: auto;
+  user-select: none;
   border: 2px solid var(--color-surface);
   box-shadow: 0 1px 4px rgba(0, 0, 0, 0.4);
 }
@@ -1050,36 +1186,6 @@ body,
   top: 56%;
   left: 62.6%;
   transform: translate(-50%, -50%);
-}
-
-/* ── Active state legend ──────────────────────────────────── */
-
-.vehicle-state-legend {
-  display: flex;
-  gap: 0.75rem;
-  margin-top: 0.5rem;
-  padding-top: 0.5rem;
-  border-top: 1px solid var(--color-border);
-  font-size: 0.75rem;
-  flex-wrap: wrap;
-}
-
-.vehicle-state-legend__item {
-  display: flex;
-  align-items: center;
-  gap: 0.3rem;
-}
-
-.vehicle-state-legend__item--lights {
-  color: #fde047;
-}
-
-.vehicle-state-legend__item--charging {
-  color: var(--color-success);
-}
-
-.vehicle-state-legend__item--connected {
-  color: var(--color-primary-light);
 }
 
 /* ── Buttons ──────────────────────────────────────────────── */

--- a/frontend/src/assets/main.css
+++ b/frontend/src/assets/main.css
@@ -706,6 +706,36 @@ body,
   }
 }
 
+/* Edit mode wraps each slot in extra card-slot/card-slot__content layers, which
+   otherwise break the height stretch and leave the map shorter than the car
+   diagram. Propagate flex sizing all the way down to each card's content so
+   both slots stay the same height whether editing or not. The child selector
+   also reaches .card-info-btn, but it's position:absolute so flex sizing is a
+   no-op for it. */
+.overview-row > .card-slot {
+  display: flex;
+  flex-direction: column;
+}
+
+.overview-row > .card-slot > .card-slot__content {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-height: 0;
+}
+
+.overview-row > .card-slot > .card-slot__content > .card-info-wrap {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-height: 0;
+}
+
+.overview-row > .card-slot > .card-slot__content > .card-info-wrap > * {
+  flex: 1;
+  min-height: 0;
+}
+
 .location-map-card {
   position: relative;
   background: var(--color-surface);

--- a/frontend/src/components/CarDiagram.vue
+++ b/frontend/src/components/CarDiagram.vue
@@ -66,6 +66,43 @@ const fuelColor = computed(() => {
 
 const isMoving = computed(() => (props.speed ?? 0) > 0)
 
+// Speedometer gauge: 270° arc opening at the bottom, needle sweeps from
+// -135deg (0 km/h) to +135deg (MAX_SPEED_KMH) through the top of the dial.
+const MAX_SPEED_KMH = 200
+const GAUGE_CX = 50
+const GAUGE_CY = 48
+const GAUGE_R = 36
+const GAUGE_ARC_LENGTH = 1.5 * Math.PI * GAUGE_R
+
+function polarToCartesian(cx: number, cy: number, r: number, bearingDeg: number) {
+  const rad = (bearingDeg * Math.PI) / 180
+  return { x: cx + r * Math.sin(rad), y: cy - r * Math.cos(rad) }
+}
+
+const gaugeArcPath = (() => {
+  const start = polarToCartesian(GAUGE_CX, GAUGE_CY, GAUGE_R, -135)
+  const end = polarToCartesian(GAUGE_CX, GAUGE_CY, GAUGE_R, 135)
+  return `M ${start.x} ${start.y} A ${GAUGE_R} ${GAUGE_R} 0 1 1 ${end.x} ${end.y}`
+})()
+
+const showSpeedGauge = computed(() => (props.speed ?? 0) > 0)
+
+const speedFraction = computed(() => {
+  const s = props.speed ?? 0
+  return Math.min(1, Math.max(0, s / MAX_SPEED_KMH))
+})
+
+const needleRotation = computed(() => -135 + speedFraction.value * 270)
+
+const gaugeDashOffset = computed(() => GAUGE_ARC_LENGTH * (1 - speedFraction.value))
+
+const gaugeColor = computed(() => {
+  const s = props.speed ?? 0
+  if (s >= 140) return 'var(--color-danger)'
+  if (s >= 100) return 'var(--color-warning)'
+  return 'var(--color-primary-light)'
+})
+
 const roadAnimDuration = computed(() => {
   const s = props.speed ?? 0
   if (s <= 0) return '2s'
@@ -133,6 +170,7 @@ const activeLightKey = computed(() => {
         <font-awesome-icon icon="car-side" />
         {{ t('vehicle.overview') }}
       </p>
+
       <div class="tyre-diagram__wrap">
         <div class="tyre-car-wrap">
           <!--
@@ -253,21 +291,22 @@ const activeLightKey = computed(() => {
               so the car SVG layer on top masks them, making beams appear to emerge from the headlights.
               Gradient anchored at y=138 (car front edge) fades toward each tip.
             -->
-            <template v-if="lightsMainBeam">
-              <polygon
-                points="132,145 162,140 148,52 102,62"
-                class="car-light-beam car-light-beam--main"
-              />
-              <polygon
-                points="208,145 178,140 192,52 238,62"
-                class="car-light-beam car-light-beam--main"
-              />
-            </template>
-            <template v-else-if="lightsDippedBeam">
-              <polygon points="130,145 148,140 144,80 118,85" class="car-light-beam" />
-              <polygon points="210,145 192,140 196,80 222,85" class="car-light-beam" />
-            </template>
-            <template v-if="lightsSide || lightsDippedBeam || lightsMainBeam">
+            <g v-if="hasLights">
+              <title>{{ t(activeLightKey) }}</title>
+              <template v-if="lightsMainBeam">
+                <polygon
+                  points="132,145 162,140 148,52 102,62"
+                  class="car-light-beam car-light-beam--main"
+                />
+                <polygon
+                  points="208,145 178,140 192,52 238,62"
+                  class="car-light-beam car-light-beam--main"
+                />
+              </template>
+              <template v-else-if="lightsDippedBeam">
+                <polygon points="130,145 148,140 144,80 118,85" class="car-light-beam" />
+                <polygon points="210,145 192,140 196,80 222,85" class="car-light-beam" />
+              </template>
               <!--
                 Side marker pie-sectors. Centers sit inside car body (y=145) so the car SVG masks
                 the source; only the outward crescent is visible. Positioned on the front fender,
@@ -285,7 +324,7 @@ const activeLightKey = computed(() => {
                 d="M 219,145 L 221,131 A 14,14 0 0 1 219,159 Z"
                 class="car-light-beam--side-r"
               />
-            </template>
+            </g>
 
             <!-- Orange car illustration (top-view) -->
             <g :filter="motionBlurAmount > 0 ? 'url(#motion-blur)' : undefined">
@@ -420,6 +459,9 @@ const activeLightKey = computed(() => {
               class="charge-group"
               :class="{ 'charge-group--active': isCharging }"
             >
+              <title>
+                {{ isCharging ? t('vehicle.chargingYes') : t('vehicle.hvBattery.pluggedIn') }}
+              </title>
               <circle cx="170" cy="367" r="16" class="charge-entry-glow" />
               <rect x="162" y="362" width="16" height="8" rx="2" class="charge-socket" />
               <!-- Cable enters the battery badge from below; endpoint inside badge so nothing shows under it -->
@@ -427,66 +469,90 @@ const activeLightKey = computed(() => {
             </g>
 
             <!-- Tyre pressure indicator lines -->
-            <line
-              x1="110"
-              y1="145"
-              x2="72"
-              y2="131"
-              class="tyre-indicator-line"
-              :stroke="pressureColor(frontLeft)"
-            />
-            <circle
-              cx="110"
-              cy="145"
-              r="5"
-              class="tyre-indicator-dot"
-              :fill="pressureColor(frontLeft)"
-            />
-            <line
-              x1="230"
-              y1="145"
-              x2="268"
-              y2="131"
-              class="tyre-indicator-line"
-              :stroke="pressureColor(frontRight)"
-            />
-            <circle
-              cx="230"
-              cy="145"
-              r="5"
-              class="tyre-indicator-dot"
-              :fill="pressureColor(frontRight)"
-            />
-            <line
-              x1="110"
-              y1="327"
-              x2="72"
-              y2="341"
-              class="tyre-indicator-line"
-              :stroke="pressureColor(rearLeft)"
-            />
-            <circle
-              cx="110"
-              cy="327"
-              r="5"
-              class="tyre-indicator-dot"
-              :fill="pressureColor(rearLeft)"
-            />
-            <line
-              x1="230"
-              y1="327"
-              x2="268"
-              y2="341"
-              class="tyre-indicator-line"
-              :stroke="pressureColor(rearRight)"
-            />
-            <circle
-              cx="230"
-              cy="327"
-              r="5"
-              class="tyre-indicator-dot"
-              :fill="pressureColor(rearRight)"
-            />
+            <g>
+              <title>
+                {{ t('vehicle.diagram.tyrePosition.frontLeft') }}: {{ fmt(frontLeft) }}
+                {{ t('common.bar') }}
+              </title>
+              <line
+                x1="110"
+                y1="145"
+                x2="72"
+                y2="131"
+                class="tyre-indicator-line"
+                :stroke="pressureColor(frontLeft)"
+              />
+              <circle
+                cx="110"
+                cy="145"
+                r="5"
+                class="tyre-indicator-dot"
+                :fill="pressureColor(frontLeft)"
+              />
+            </g>
+            <g>
+              <title>
+                {{ t('vehicle.diagram.tyrePosition.frontRight') }}: {{ fmt(frontRight) }}
+                {{ t('common.bar') }}
+              </title>
+              <line
+                x1="230"
+                y1="145"
+                x2="268"
+                y2="131"
+                class="tyre-indicator-line"
+                :stroke="pressureColor(frontRight)"
+              />
+              <circle
+                cx="230"
+                cy="145"
+                r="5"
+                class="tyre-indicator-dot"
+                :fill="pressureColor(frontRight)"
+              />
+            </g>
+            <g>
+              <title>
+                {{ t('vehicle.diagram.tyrePosition.rearLeft') }}: {{ fmt(rearLeft) }}
+                {{ t('common.bar') }}
+              </title>
+              <line
+                x1="110"
+                y1="327"
+                x2="72"
+                y2="341"
+                class="tyre-indicator-line"
+                :stroke="pressureColor(rearLeft)"
+              />
+              <circle
+                cx="110"
+                cy="327"
+                r="5"
+                class="tyre-indicator-dot"
+                :fill="pressureColor(rearLeft)"
+              />
+            </g>
+            <g>
+              <title>
+                {{ t('vehicle.diagram.tyrePosition.rearRight') }}: {{ fmt(rearRight) }}
+                {{ t('common.bar') }}
+              </title>
+              <line
+                x1="230"
+                y1="327"
+                x2="268"
+                y2="341"
+                class="tyre-indicator-line"
+                :stroke="pressureColor(rearRight)"
+              />
+              <circle
+                cx="230"
+                cy="327"
+                r="5"
+                class="tyre-indicator-dot"
+                :fill="pressureColor(rearRight)"
+              />
+            </g>
           </svg>
 
           <!-- Tyre pressure labels -->
@@ -494,24 +560,28 @@ const activeLightKey = computed(() => {
             <div
               class="tyre-label tyre-label--fl"
               :class="`tyre-label--${pressureVariant(frontLeft)}`"
+              :title="t('vehicle.diagram.tyrePosition.frontLeft')"
             >
               {{ fmt(frontLeft) }} {{ t('common.bar') }}
             </div>
             <div
               class="tyre-label tyre-label--fr"
               :class="`tyre-label--${pressureVariant(frontRight)}`"
+              :title="t('vehicle.diagram.tyrePosition.frontRight')"
             >
               {{ fmt(frontRight) }} {{ t('common.bar') }}
             </div>
             <div
               class="tyre-label tyre-label--rl"
               :class="`tyre-label--${pressureVariant(rearLeft)}`"
+              :title="t('vehicle.diagram.tyrePosition.rearLeft')"
             >
               {{ fmt(rearLeft) }} {{ t('common.bar') }}
             </div>
             <div
               class="tyre-label tyre-label--rr"
               :class="`tyre-label--${pressureVariant(rearRight)}`"
+              :title="t('vehicle.diagram.tyrePosition.rearRight')"
             >
               {{ fmt(rearRight) }} {{ t('common.bar') }}
             </div>
@@ -566,6 +636,7 @@ const activeLightKey = computed(() => {
             v-if="showFuel"
             class="diagram-level diagram-level--fuel"
             :style="{ '--level-color': fuelColor }"
+            :title="`${t('vehicle.fuel')}: ${Math.round(fuelLevelPercent ?? 0)}%`"
           >
             <font-awesome-icon icon="gas-pump" />
             <span>{{ Math.round(fuelLevelPercent ?? 0) }}%</span>
@@ -580,41 +651,46 @@ const activeLightKey = computed(() => {
               'diagram-level--connected': chargerConnected && !isCharging,
             }"
             :style="{ '--level-color': batteryColor }"
+            :title="`${t('vehicle.evSoc')}: ${Math.round(evSocPercent ?? 0)}%`"
           >
             <font-awesome-icon icon="bolt" />
             <span>{{ Math.round(evSocPercent ?? 0) }}%</span>
           </div>
+
+          <div
+            v-if="showSpeedGauge"
+            class="speed-gauge"
+            role="img"
+            :aria-label="`${t('vehicle.speed')}: ${Math.round(speed ?? 0)} km/h`"
+            :title="`${t('vehicle.speed')}: ${Math.round(speed ?? 0)} km/h`"
+          >
+            <svg viewBox="0 0 100 92" class="speed-gauge__svg">
+              <path :d="gaugeArcPath" class="speed-gauge__track" />
+              <path
+                :d="gaugeArcPath"
+                class="speed-gauge__progress"
+                :style="{
+                  strokeDasharray: GAUGE_ARC_LENGTH,
+                  strokeDashoffset: gaugeDashOffset,
+                  stroke: gaugeColor,
+                }"
+              />
+              <line
+                x1="50"
+                y1="48"
+                x2="50"
+                y2="20"
+                class="speed-gauge__needle"
+                :style="{ transform: `rotate(${needleRotation}deg)` }"
+              />
+              <circle cx="50" cy="48" r="3" class="speed-gauge__pivot" />
+              <text x="50" y="64" text-anchor="middle" class="speed-gauge__value">
+                {{ Math.round(speed ?? 0) }}
+              </text>
+              <text x="50" y="78" text-anchor="middle" class="speed-gauge__unit">km/h</text>
+            </svg>
+          </div>
         </div>
-      </div>
-
-      <div class="tyre-legend">
-        <span class="tyre-legend__item tyre-legend__item--ok">&#x2265; 2.6 bar</span>
-        <span class="tyre-legend__item tyre-legend__item--warning">2.2 – 2.6 bar</span>
-        <span class="tyre-legend__item tyre-legend__item--danger">&lt; 2.2 bar</span>
-      </div>
-
-      <div v-if="hasLights || isCharging || chargerConnected" class="vehicle-state-legend">
-        <span
-          v-if="hasLights"
-          class="vehicle-state-legend__item vehicle-state-legend__item--lights"
-        >
-          <font-awesome-icon icon="lightbulb" />
-          {{ t(activeLightKey) }}
-        </span>
-        <span
-          v-if="isCharging"
-          class="vehicle-state-legend__item vehicle-state-legend__item--charging"
-        >
-          <font-awesome-icon icon="bolt" />
-          {{ t('vehicle.chargingYes') }}
-        </span>
-        <span
-          v-else-if="chargerConnected"
-          class="vehicle-state-legend__item vehicle-state-legend__item--connected"
-        >
-          <font-awesome-icon icon="plug" />
-          {{ t('vehicle.hvBattery.pluggedIn') }}
-        </span>
       </div>
     </div>
   </CardInfoWrap>

--- a/frontend/src/components/LocationMapWidget.vue
+++ b/frontend/src/components/LocationMapWidget.vue
@@ -1,0 +1,104 @@
+<script setup lang="ts">
+import { computed, nextTick, onUnmounted, ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { useRouter } from 'vue-router'
+import { LMap, LTileLayer, LMarker } from '@vue-leaflet/vue-leaflet'
+import type { Map as LeafletMap } from 'leaflet'
+import { useVehicleStore } from '@/stores/vehicle'
+import CardInfoWrap from './CardInfoWrap.vue'
+
+const { t } = useI18n()
+const router = useRouter()
+const store = useVehicleStore()
+
+const status = computed(() => store.currentStatus)
+const hasLocation = computed(
+  () => status.value?.latitude != null && status.value?.longitude != null,
+)
+const center = computed<[number, number]>(() => [
+  status.value?.latitude ?? 0,
+  status.value?.longitude ?? 0,
+])
+
+const mapOptions = {
+  zoomControl: false,
+  dragging: false,
+  scrollWheelZoom: false,
+  doubleClickZoom: false,
+  touchZoom: false,
+  boxZoom: false,
+  keyboard: false,
+}
+
+const mapWrapperRef = ref<HTMLElement | null>(null)
+const mapInstance = ref<LeafletMap | null>(null)
+let resizeObserver: ResizeObserver | null = null
+
+function onMapReady(map: LeafletMap) {
+  mapInstance.value = map
+  if (mapWrapperRef.value) {
+    resizeObserver = new ResizeObserver(() => map.invalidateSize())
+    resizeObserver.observe(mapWrapperRef.value)
+  }
+  nextTick(() => {
+    requestAnimationFrame(() => {
+      map.invalidateSize()
+      if (hasLocation.value) map.setView(center.value, 14, { animate: false })
+    })
+  })
+}
+
+// Keep the preview centred on the car as new status updates arrive.
+watch(status, (s) => {
+  if (mapInstance.value && s?.latitude != null && s?.longitude != null) {
+    mapInstance.value.setView([s.latitude, s.longitude], 14, { animate: false })
+  }
+})
+
+onUnmounted(() => resizeObserver?.disconnect())
+
+function openFullMap() {
+  router.push({ name: 'map' })
+}
+</script>
+
+<template>
+  <CardInfoWrap :title="t('vehicle.location')" :description="t('dashboard.cardDesc.location')">
+    <div class="location-map-card">
+      <p class="tyre-diagram__title">
+        <font-awesome-icon icon="location-dot" />
+        {{ t('vehicle.location') }}
+      </p>
+
+      <div ref="mapWrapperRef" class="location-map-card__map" @click="openFullMap">
+        <LMap
+          v-if="hasLocation"
+          :zoom="14"
+          :center="center"
+          :options="mapOptions"
+          class="location-map-card__canvas"
+          @ready="onMapReady"
+        >
+          <LTileLayer
+            url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+            attribution="© OpenStreetMap contributors"
+          />
+          <LMarker :lat-lng="center" />
+        </LMap>
+        <div v-else class="location-map-card__empty">
+          <font-awesome-icon icon="location-dot" />
+          <span>{{ t('vehicle.locationUnavailable') }}</span>
+        </div>
+
+        <button
+          class="location-map-card__expand"
+          :aria-label="t('dashboard.openFullMap')"
+          :title="t('dashboard.openFullMap')"
+          @click.stop="openFullMap"
+        >
+          <font-awesome-icon icon="map" />
+        </button>
+      </div>
+    </div>
+  </CardInfoWrap>
+</template>

--- a/frontend/src/components/SkeletonLocationMap.vue
+++ b/frontend/src/components/SkeletonLocationMap.vue
@@ -1,0 +1,19 @@
+<template>
+  <div class="location-map-card">
+    <div class="map-skel__title skeleton skeleton--text skeleton--text-sm"></div>
+    <div class="map-skel__map skeleton"></div>
+  </div>
+</template>
+
+<style scoped>
+.map-skel__title {
+  height: 0.85rem;
+  margin-bottom: 1rem;
+  max-width: 5rem;
+}
+.map-skel__map {
+  flex: 1;
+  min-height: 180px;
+  border-radius: var(--radius);
+}
+</style>

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -13,7 +13,9 @@
     "hideCard": "Hide card",
     "showCard": "Show card",
     "cardInfoBtn": "Card information",
+    "openFullMap": "Open full map",
     "cardDesc": {
+      "location": "Current location of the car on a small map. Click the map or the expand button to open the full map view.",
       "fuelLevel": "Shows the current fuel tank level as a percentage.",
       "fuelRange": "Estimated remaining driving range based on the current fuel level.",
       "evBattery": "State of charge as a percentage. On a PHEV or BEV this is your electric range gauge. On an HEV the hybrid battery is small and managed automatically by the car, so the exact value is less meaningful day-to-day.",
@@ -91,6 +93,8 @@
     "chargingNo": "Not charging",
     "tyres": "Tyre Pressures",
     "overview": "Overview",
+    "location": "Location",
+    "locationUnavailable": "Location unavailable",
     "diagram": {
       "panelOpen": "Panel open",
       "infoTyreTitle": "Tyre Pressure",
@@ -102,7 +106,13 @@
       "infoLevelTitle": "Fuel & Battery",
       "infoLevelDesc": "When data is available, the fuel level percentage appears at the front and the EV battery percentage appears at the rear of the diagram.",
       "infoChargingTitle": "Charging",
-      "infoChargingDesc": "A cable is shown below the battery indicator when the charger is connected. When actively charging, the cable animates with flowing dashes to show energy entering the car."
+      "infoChargingDesc": "A cable is shown below the battery indicator when the charger is connected. When actively charging, the cable animates with flowing dashes to show energy entering the car.",
+      "tyrePosition": {
+        "frontLeft": "Front left",
+        "frontRight": "Front right",
+        "rearLeft": "Rear left",
+        "rearRight": "Rear right"
+      }
     },
     "temperature": {
       "interior": "Interior temp",

--- a/frontend/src/locales/nl.json
+++ b/frontend/src/locales/nl.json
@@ -13,7 +13,9 @@
     "hideCard": "Kaart verbergen",
     "showCard": "Kaart tonen",
     "cardInfoBtn": "Kaartinformatie",
+    "openFullMap": "Volledige kaart openen",
     "cardDesc": {
+      "location": "Huidige locatie van de auto op een kleine kaart. Klik op de kaart of de uitklapknop om de volledige kaartweergave te openen.",
       "fuelLevel": "Huidig brandstofniveau van de tank als percentage.",
       "fuelRange": "Geschatte resterende rijafstand op basis van het huidige brandstofniveau.",
       "evBattery": "Laadstatus als percentage. Op een PHEV of BEV is dit je elektrisch bereiksmeter. Op een HEV is de hybride accu klein en wordt deze automatisch door de auto beheerd, waardoor de exacte waarde dagelijks minder relevant is.",
@@ -91,6 +93,8 @@
     "chargingNo": "Niet aan het laden",
     "tyres": "Bandenspanning",
     "overview": "Overzicht",
+    "location": "Locatie",
+    "locationUnavailable": "Locatie niet beschikbaar",
     "diagram": {
       "panelOpen": "Paneel open",
       "infoTyreTitle": "Bandenspanning",
@@ -102,7 +106,13 @@
       "infoLevelTitle": "Brandstof & Accu",
       "infoLevelDesc": "Wanneer gegevens beschikbaar zijn, toont het diagram het brandstofpercentage aan de voorkant en het EV-accupercentage aan de achterkant.",
       "infoChargingTitle": "Laden",
-      "infoChargingDesc": "Er wordt een kabel weergegeven onder de accu-indicator wanneer de lader is aangesloten. Als er actief geladen wordt, animeert de kabel met bewegende streepjes om de energiestroom in de auto te tonen."
+      "infoChargingDesc": "Er wordt een kabel weergegeven onder de accu-indicator wanneer de lader is aangesloten. Als er actief geladen wordt, animeert de kabel met bewegende streepjes om de energiestroom in de auto te tonen.",
+      "tyrePosition": {
+        "frontLeft": "Linksvoor",
+        "frontRight": "Rechtsvoor",
+        "rearLeft": "Linksachter",
+        "rearRight": "Rechtsachter"
+      }
     },
     "temperature": {
       "interior": "Interieurtemperatuur",

--- a/frontend/src/stores/__tests__/settings.spec.ts
+++ b/frontend/src/stores/__tests__/settings.spec.ts
@@ -27,9 +27,9 @@ describe('defaultCards', () => {
     expect(cards.find((c) => c.id === 'batteryHeating')!.visible).toBe(false)
   })
 
-  it('bev: shows speed, activeTrip, remainingCharge, chargingSession, batteryHeating', () => {
+  it('bev: hides speed by default (already shown by the overview gauge); shows activeTrip, remainingCharge, chargingSession, batteryHeating', () => {
     const cards = defaultCards('bev')
-    expect(cards.find((c) => c.id === 'speed')!.visible).toBe(true)
+    expect(cards.find((c) => c.id === 'speed')!.visible).toBe(false)
     expect(cards.find((c) => c.id === 'activeTrip')!.visible).toBe(true)
     expect(cards.find((c) => c.id === 'remainingCharge')!.visible).toBe(true)
     expect(cards.find((c) => c.id === 'chargingSession')!.visible).toBe(true)
@@ -74,6 +74,19 @@ describe('useSettingsStore', () => {
     await nextTick()
     const saved = JSON.parse(localStorage.getItem(BASE_KEY)!)
     expect(saved.theme).toBe('light')
+  })
+
+  it('persists location map visibility change to localStorage', async () => {
+    const store = useSettingsStore()
+    store.showLocationMap = false
+    await nextTick()
+    const saved = JSON.parse(localStorage.getItem(BASE_KEY)!)
+    expect(saved.showLocationMap).toBe(false)
+  })
+
+  it('defaults showLocationMap to true when localStorage is empty', () => {
+    const store = useSettingsStore()
+    expect(store.showLocationMap).toBe(true)
   })
 
   it('persists locale change to localStorage', async () => {

--- a/frontend/src/stores/settings.ts
+++ b/frontend/src/stores/settings.ts
@@ -148,6 +148,7 @@ export interface AppSettings {
   statsInsights: StatsItemConfig<StatsInsightId>[]
   statsCharts: StatsItemConfig<StatsChartId>[]
   showTyreDiagram: boolean
+  showLocationMap: boolean
   showCardInfoIcons: boolean
   vehicleTypeOverride: VehicleTypeOverride
   theme: Theme
@@ -193,7 +194,7 @@ export function defaultCards(type: VehicleType | 'unknown' = 'unknown'): CardCon
     { id: 'efficiencyEnergy', visible: true },
     { id: 'efficiencyCharge', visible: type !== 'hev' },
     { id: 'efficiencyRatio', visible: true },
-    { id: 'speed', visible: true },
+    { id: 'speed', visible: false },
     { id: 'activeTrip', visible: true },
     { id: 'remainingCharge', visible: type === 'phev' || type === 'bev' },
     { id: 'chargingSession', visible: type === 'phev' || type === 'bev' },
@@ -210,6 +211,7 @@ const defaults: AppSettings = {
   statsInsights: defaultStatsInsights(),
   statsCharts: defaultStatsCharts(),
   showTyreDiagram: true,
+  showLocationMap: true,
   showCardInfoIcons: true,
   vehicleTypeOverride: 'auto',
   theme: osPreferredTheme(),
@@ -317,6 +319,7 @@ function loadFromKey(key: string): AppSettings {
           statsInsights: defaultStatsInsights(),
           statsCharts: defaultStatsCharts(),
           showTyreDiagram: true,
+          showLocationMap: true,
           showCardInfoIcons: parsed.showCardInfoIcons !== false,
           vehicleTypeOverride: parsed.vehicleTypeOverride ?? defaults.vehicleTypeOverride,
           theme: parsed.theme ?? defaults.theme,
@@ -343,6 +346,7 @@ function loadFromKey(key: string): AppSettings {
           statsInsights: loadStatsItems(parsed.statsInsights, ALL_STATS_INSIGHT_IDS),
           statsCharts: loadStatsItems(parsed.statsCharts, ALL_STATS_CHART_IDS),
           showTyreDiagram: parsed.showTyreDiagram !== false,
+          showLocationMap: parsed.showLocationMap !== false,
           showCardInfoIcons: parsed.showCardInfoIcons !== false,
           vehicleTypeOverride: parsed.vehicleTypeOverride ?? defaults.vehicleTypeOverride,
           theme: parsed.theme ?? defaults.theme,
@@ -395,6 +399,7 @@ export const useSettingsStore = defineStore('settings', () => {
   const statsInsights = ref<StatsItemConfig<StatsInsightId>[]>(loaded.statsInsights)
   const statsCharts = ref<StatsItemConfig<StatsChartId>[]>(loaded.statsCharts)
   const showTyreDiagram = ref<boolean>(loaded.showTyreDiagram)
+  const showLocationMap = ref<boolean>(loaded.showLocationMap)
   const showCardInfoIcons = ref<boolean>(loaded.showCardInfoIcons)
   const carColorScheme = ref<string>(loaded.carColorScheme)
   const routeOutlineEnabled = ref<boolean>(loaded.routeOutlineEnabled)
@@ -418,6 +423,7 @@ export const useSettingsStore = defineStore('settings', () => {
         statsInsights: statsInsights.value,
         statsCharts: statsCharts.value,
         showTyreDiagram: showTyreDiagram.value,
+        showLocationMap: showLocationMap.value,
         showCardInfoIcons: showCardInfoIcons.value,
         vehicleTypeOverride: vehicleTypeOverride.value,
         theme: theme.value,
@@ -441,6 +447,7 @@ export const useSettingsStore = defineStore('settings', () => {
   watch(statsInsights, save, { deep: true })
   watch(statsCharts, save, { deep: true })
   watch(showTyreDiagram, save)
+  watch(showLocationMap, save)
   watch(showCardInfoIcons, save)
   watch(vehicleTypeOverride, save)
   watch(locale, save)
@@ -472,6 +479,7 @@ export const useSettingsStore = defineStore('settings', () => {
     statsInsights,
     statsCharts,
     showTyreDiagram,
+    showLocationMap,
     showCardInfoIcons,
     vehicleTypeOverride,
     theme,

--- a/frontend/src/views/DashboardView.vue
+++ b/frontend/src/views/DashboardView.vue
@@ -10,8 +10,10 @@ import { defaultCards } from '@/stores/settings'
 import DashboardCardContent from '@/components/DashboardCardContent.vue'
 import CardInfoWrap from '@/components/CardInfoWrap.vue'
 import CarDiagram from '@/components/CarDiagram.vue'
+import LocationMapWidget from '@/components/LocationMapWidget.vue'
 import SkeletonCard from '@/components/SkeletonCard.vue'
 import SkeletonCarDiagram from '@/components/SkeletonCarDiagram.vue'
+import SkeletonLocationMap from '@/components/SkeletonLocationMap.vue'
 import { useVehicleAlerts } from '@/composables/useVehicleAlerts'
 
 const { t } = useI18n()
@@ -21,13 +23,6 @@ const settings = useSettingsStore()
 const vin = computed(() => store.vehicles[0]?.vin ?? null)
 const status = computed(() => store.currentStatus)
 const editMode = ref(false)
-const skeletonCards = computed(() => {
-  const visible = settings.cards.filter((c) => c.visible)
-  if (vehicleType.value === 'unknown') return visible
-  const typeDefaults = defaultCards(vehicleType.value)
-  const hiddenByType = new Set(typeDefaults.filter((c) => !c.visible).map((c) => c.id))
-  return visible.filter((c) => !hiddenByType.has(c.id))
-})
 
 const vehicleType = computed((): VehicleType | 'unknown' => {
   const override = settings.vehicleTypeOverride
@@ -36,20 +31,6 @@ const vehicleType = computed((): VehicleType | 'unknown' => {
 })
 
 const isHev = computed(() => vehicleType.value === 'hev')
-
-const hiddenByTypeIds = computed((): Set<CardId> => {
-  if (vehicleType.value === 'unknown') return new Set()
-  const typeDefaults = defaultCards(vehicleType.value)
-  return new Set(typeDefaults.filter((c) => !c.visible).map((c) => c.id))
-})
-
-const editableCards = computed({
-  get: () => settings.cards.filter((c) => !hiddenByTypeIds.value.has(c.id)),
-  set: (newVal) => {
-    const restricted = settings.cards.filter((c) => hiddenByTypeIds.value.has(c.id))
-    settings.cards = [...newVal, ...restricted]
-  },
-})
 
 // Card IDs whose visibility differs between vehicle types (derived from defaultCards).
 // When the override changes these are reset to the new type's defaults.
@@ -64,6 +45,30 @@ const TYPE_SPECIFIC_CARD_IDS = (() => {
     ),
   )
 })()
+
+// Cards that are genuinely inapplicable to the detected vehicle type (e.g. fuelLevel on a
+// BEV). Cards that are merely off by default for every type (e.g. sunRoof, speed) are not
+// included here, so they stay user-togglable and their visibility survives a reload.
+const hiddenByTypeIds = computed((): Set<CardId> => {
+  if (vehicleType.value === 'unknown') return new Set()
+  const typeDefaults = defaultCards(vehicleType.value)
+  return new Set(
+    typeDefaults.filter((c) => !c.visible && TYPE_SPECIFIC_CARD_IDS.has(c.id)).map((c) => c.id),
+  )
+})
+
+const skeletonCards = computed(() => {
+  const visible = settings.cards.filter((c) => c.visible)
+  return visible.filter((c) => !hiddenByTypeIds.value.has(c.id))
+})
+
+const editableCards = computed({
+  get: () => settings.cards.filter((c) => !hiddenByTypeIds.value.has(c.id)),
+  set: (newVal) => {
+    const restricted = settings.cards.filter((c) => hiddenByTypeIds.value.has(c.id))
+    settings.cards = [...newVal, ...restricted]
+  },
+})
 
 watch(
   () => settings.vehicleTypeOverride,
@@ -211,16 +216,12 @@ onMounted(async () => {
   await refresh()
 
   // Hide cards that don't apply to the detected vehicle type so they don't
-  // appear in the skeleton on subsequent loads
-  if (vehicleType.value !== 'unknown') {
-    const typeDefaults = defaultCards(vehicleType.value)
-    const shouldHide = new Set(typeDefaults.filter((c) => !c.visible).map((c) => c.id))
-    if (settings.cards.some((c) => shouldHide.has(c.id) && c.visible)) {
-      const updated = settings.cards.map((c) =>
-        shouldHide.has(c.id) ? { ...c, visible: false } : c,
-      )
-      settings.cards = [...updated.filter((c) => c.visible), ...updated.filter((c) => !c.visible)]
-    }
+  // appear in the skeleton on subsequent loads. Cards merely off by default
+  // (e.g. sunRoof, speed) are left alone so a user's manual toggle survives reloads.
+  const shouldHide = hiddenByTypeIds.value
+  if (settings.cards.some((c) => shouldHide.has(c.id) && c.visible)) {
+    const updated = settings.cards.map((c) => (shouldHide.has(c.id) ? { ...c, visible: false } : c))
+    settings.cards = [...updated.filter((c) => c.visible), ...updated.filter((c) => !c.visible)]
   }
   // On a fresh start (no saved layout), push no-data visible cards to the end
   if (!localStorage.getItem('garagestack-settings') && status.value) {
@@ -262,46 +263,73 @@ onUnmounted(() => {
 
     <!-- Edit mode: same grid with draggable card-slot wrappers -->
     <template v-if="editMode">
-      <!-- Tyre diagram toggle -->
-      <div
-        class="card-slot card-slot--static mt-4 mb-4"
-        :class="{ 'card-slot--hidden': !settings.showTyreDiagram }"
-      >
-        <div class="card-slot__content">
-          <CarDiagram
-            v-if="settings.showTyreDiagram && status"
-            :front-left="status.tyrePressureFrontLeft"
-            :front-right="status.tyrePressureFrontRight"
-            :rear-left="status.tyrePressureRearLeft"
-            :rear-right="status.tyrePressureRearRight"
-            :driver-door-open="status.driverDoorOpen"
-            :passenger-door-open="status.passengerDoorOpen"
-            :rear-left-door-open="status.rearLeftDoorOpen"
-            :rear-right-door-open="status.rearRightDoorOpen"
-            :trunk-open="status.trunkOpen"
-            :bonnet-open="status.bonnetOpen"
-            :lights-main-beam="status.lightsMainBeam"
-            :lights-dipped-beam="status.lightsDippedBeam"
-            :lights-side="status.lightsSide"
-            :ev-soc-percent="status.evSocPercent"
-            :fuel-level-percent="vehicleType === 'bev' ? null : status.fuelLevelPercent"
-            :charger-connected="status.chargerConnected"
-            :is-charging="status.isCharging"
-            :speed="status.speed"
-          />
-          <div v-else class="card-slot__placeholder card-slot__placeholder--chart">
-            <font-awesome-icon icon="car-side" />
-            <span>{{ t('vehicle.overview') }}</span>
-          </div>
-        </div>
-        <button
-          class="card-slot__badge"
-          :class="settings.showTyreDiagram ? 'card-slot__badge--hide' : 'card-slot__badge--show'"
-          :aria-label="settings.showTyreDiagram ? t('dashboard.hideCard') : t('dashboard.showCard')"
-          @click.stop="settings.showTyreDiagram = !settings.showTyreDiagram"
+      <!-- Tyre diagram + location map toggles -->
+      <div class="overview-row overview-row--edit mt-4 mb-4">
+        <div
+          class="card-slot card-slot--static overview-row__car"
+          :class="{ 'card-slot--hidden': !settings.showTyreDiagram }"
         >
-          <font-awesome-icon :icon="settings.showTyreDiagram ? 'xmark' : 'plus'" />
-        </button>
+          <div class="card-slot__content">
+            <CarDiagram
+              v-if="settings.showTyreDiagram && status"
+              :front-left="status.tyrePressureFrontLeft"
+              :front-right="status.tyrePressureFrontRight"
+              :rear-left="status.tyrePressureRearLeft"
+              :rear-right="status.tyrePressureRearRight"
+              :driver-door-open="status.driverDoorOpen"
+              :passenger-door-open="status.passengerDoorOpen"
+              :rear-left-door-open="status.rearLeftDoorOpen"
+              :rear-right-door-open="status.rearRightDoorOpen"
+              :trunk-open="status.trunkOpen"
+              :bonnet-open="status.bonnetOpen"
+              :lights-main-beam="status.lightsMainBeam"
+              :lights-dipped-beam="status.lightsDippedBeam"
+              :lights-side="status.lightsSide"
+              :ev-soc-percent="status.evSocPercent"
+              :fuel-level-percent="vehicleType === 'bev' ? null : status.fuelLevelPercent"
+              :charger-connected="status.chargerConnected"
+              :is-charging="status.isCharging"
+              :speed="status.speed"
+            />
+            <div v-else class="card-slot__placeholder card-slot__placeholder--chart">
+              <font-awesome-icon icon="car-side" />
+              <span>{{ t('vehicle.overview') }}</span>
+            </div>
+          </div>
+          <button
+            class="card-slot__badge"
+            :class="settings.showTyreDiagram ? 'card-slot__badge--hide' : 'card-slot__badge--show'"
+            :aria-label="
+              settings.showTyreDiagram ? t('dashboard.hideCard') : t('dashboard.showCard')
+            "
+            @click.stop="settings.showTyreDiagram = !settings.showTyreDiagram"
+          >
+            <font-awesome-icon :icon="settings.showTyreDiagram ? 'xmark' : 'plus'" />
+          </button>
+        </div>
+
+        <div
+          class="card-slot card-slot--static overview-row__map"
+          :class="{ 'card-slot--hidden': !settings.showLocationMap }"
+        >
+          <div class="card-slot__content">
+            <LocationMapWidget v-if="settings.showLocationMap" />
+            <div v-else class="card-slot__placeholder card-slot__placeholder--chart">
+              <font-awesome-icon icon="location-dot" />
+              <span>{{ t('vehicle.location') }}</span>
+            </div>
+          </div>
+          <button
+            class="card-slot__badge"
+            :class="settings.showLocationMap ? 'card-slot__badge--hide' : 'card-slot__badge--show'"
+            :aria-label="
+              settings.showLocationMap ? t('dashboard.hideCard') : t('dashboard.showCard')
+            "
+            @click.stop="settings.showLocationMap = !settings.showLocationMap"
+          >
+            <font-awesome-icon :icon="settings.showLocationMap ? 'xmark' : 'plus'" />
+          </button>
+        </div>
       </div>
 
       <VueDraggable
@@ -351,7 +379,10 @@ onUnmounted(() => {
     <!-- Normal mode -->
     <template v-else>
       <template v-if="store.loading && !status">
-        <SkeletonCarDiagram v-if="settings.showTyreDiagram" class="mb-4" />
+        <div v-if="settings.showTyreDiagram || settings.showLocationMap" class="overview-row mb-4">
+          <SkeletonCarDiagram v-if="settings.showTyreDiagram" class="overview-row__car" />
+          <SkeletonLocationMap v-if="settings.showLocationMap" class="overview-row__map" />
+        </div>
         <div class="status-grid">
           <SkeletonCard v-for="card in skeletonCards" :key="card.id" :icon="CARD_ICONS[card.id]" />
         </div>
@@ -367,28 +398,31 @@ onUnmounted(() => {
       </div>
 
       <template v-else>
-        <CarDiagram
-          v-if="settings.showTyreDiagram"
-          :front-left="status.tyrePressureFrontLeft"
-          :front-right="status.tyrePressureFrontRight"
-          :rear-left="status.tyrePressureRearLeft"
-          :rear-right="status.tyrePressureRearRight"
-          :driver-door-open="status.driverDoorOpen"
-          :passenger-door-open="status.passengerDoorOpen"
-          :rear-left-door-open="status.rearLeftDoorOpen"
-          :rear-right-door-open="status.rearRightDoorOpen"
-          :trunk-open="status.trunkOpen"
-          :bonnet-open="status.bonnetOpen"
-          :lights-main-beam="status.lightsMainBeam"
-          :lights-dipped-beam="status.lightsDippedBeam"
-          :lights-side="status.lightsSide"
-          :ev-soc-percent="status.evSocPercent"
-          :fuel-level-percent="vehicleType === 'bev' ? null : status.fuelLevelPercent"
-          :charger-connected="status.chargerConnected"
-          :is-charging="status.isCharging"
-          :speed="status.speed"
-          class="mb-4"
-        />
+        <div v-if="settings.showTyreDiagram || settings.showLocationMap" class="overview-row mb-4">
+          <CarDiagram
+            v-if="settings.showTyreDiagram"
+            :front-left="status.tyrePressureFrontLeft"
+            :front-right="status.tyrePressureFrontRight"
+            :rear-left="status.tyrePressureRearLeft"
+            :rear-right="status.tyrePressureRearRight"
+            :driver-door-open="status.driverDoorOpen"
+            :passenger-door-open="status.passengerDoorOpen"
+            :rear-left-door-open="status.rearLeftDoorOpen"
+            :rear-right-door-open="status.rearRightDoorOpen"
+            :trunk-open="status.trunkOpen"
+            :bonnet-open="status.bonnetOpen"
+            :lights-main-beam="status.lightsMainBeam"
+            :lights-dipped-beam="status.lightsDippedBeam"
+            :lights-side="status.lightsSide"
+            :ev-soc-percent="status.evSocPercent"
+            :fuel-level-percent="vehicleType === 'bev' ? null : status.fuelLevelPercent"
+            :charger-connected="status.chargerConnected"
+            :is-charging="status.isCharging"
+            :speed="status.speed"
+            class="overview-row__car"
+          />
+          <LocationMapWidget v-if="settings.showLocationMap" class="overview-row__map" />
+        </div>
 
         <div class="status-grid">
           <template v-for="card in settings.cards" :key="card.id">


### PR DESCRIPTION
## Summary
- Add a small, non-interactive location map preview next to the vehicle overview card on the dashboard, showing the car's current position with a button to open the full map view
- Add a `showLocationMap` setting (persisted, default on) so it can be toggled off in edit layout mode, same UX as the existing tyre diagram toggle; the overview card reclaims the full row width when the map is hidden
- Responsive: side-by-side on desktop/tablet, stacked on mobile (<768px)
- Also includes an in-progress car diagram speedometer gauge rework and hides the `speed` card by default (redundant with the new gauge) that was already staged in the working tree

## Test plan
- [x] `pnpm exec vitest run` — 135 tests pass
- [x] `pnpm exec vue-tsc --noEmit` — no type errors
- [x] `pnpm exec eslint` on changed files — clean
- [x] Verified in a live run against the demo backend (Playwright): desktop side-by-side layout, mobile stacking, edit-mode hide/show toggle (car reclaims full width), and the expand button opens `/map`

🤖 Generated with [Claude Code](https://claude.com/claude-code)