### PR TITLE
fix(security): pin Microsoft.OpenApi and bust OS package cache in Dockerfiles

### DIFF
--- a/docker/all-in-one/Dockerfile
+++ b/docker/all-in-one/Dockerfile
@@ -3,7 +3,10 @@
 # ── Stage 1: Build frontend ───────────────────────────────────────────────────
 FROM node:24-alpine AS frontend-build
 WORKDIR /app
-RUN apk upgrade --no-cache && corepack enable && corepack prepare pnpm@11.1.3 --activate
+# OS_PATCH_DATE busts the layer cache so apk upgrade actually re-runs instead of
+# reusing a stale cached layer from before an OS package fix was published.
+ARG OS_PATCH_DATE=0
+RUN echo "os patch date: ${OS_PATCH_DATE}" && apk upgrade --no-cache && corepack enable && corepack prepare pnpm@11.1.3 --activate
 COPY frontend/package.json frontend/pnpm-lock.yaml frontend/pnpm-workspace.yaml ./
 RUN --mount=type=cache,id=pnpm-store,target=/pnpm/store \
     pnpm config set store-dir /pnpm/store && \
@@ -47,12 +50,17 @@ FROM python:3.14-slim
 
 ARG DEBIAN_FRONTEND=noninteractive
 
+# OS_PATCH_DATE busts the layer cache so apt-get upgrade actually re-runs instead of
+# reusing a stale cached layer from before an OS package fix was published.
+ARG OS_PATCH_DATE=0
+
 # bash          -- required by entrypoint.sh and dotnet-install.sh (slim images ship dash only)
 # libgssapi-krb5-2 -- required by the .NET runtime
 # libicu-dev    -- required by .NET globalization (UseRequestLocalization uses CultureInfo)
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
-    apt-get update \
+    echo "os patch date: ${OS_PATCH_DATE}" \
+    && apt-get update \
     && apt-get upgrade -y --no-install-recommends \
     && apt-get install -y --no-install-recommends \
         bash curl gnupg ca-certificates gosu supervisor \

--- a/src/GarageStack.Api/Dockerfile
+++ b/src/GarageStack.Api/Dockerfile
@@ -13,7 +13,11 @@ RUN dotnet publish -c Release -o /app /p:MinVerVersionOverride=${APP_VERSION}
 
 FROM mcr.microsoft.com/dotnet/aspnet:10.0 AS runtime
 WORKDIR /app
-RUN apt-get update \
+# OS_PATCH_DATE busts the layer cache so apt-get upgrade actually re-runs instead of
+# reusing a stale cached layer from before an OS package fix was published.
+ARG OS_PATCH_DATE=0
+RUN echo "os patch date: ${OS_PATCH_DATE}" \
+	&& apt-get update \
 	&& apt-get upgrade -y \
 	&& apt-get install -y --no-install-recommends libgssapi-krb5-2 \
 	&& rm -rf /var/lib/apt/lists/*

--- a/src/GarageStack.Api/GarageStack.Api.csproj
+++ b/src/GarageStack.Api/GarageStack.Api.csproj
@@ -13,6 +13,8 @@
     <PackageReference Include="MinVer" Version="7.0.0" PrivateAssets="all" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.9" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.9" />
+    <!-- Pinned above the transitive 2.0.0 pulled in by Microsoft.AspNetCore.OpenApi 10.0.9 to avoid CVE-2026-49451 (stack overflow on circular schema refs). -->
+    <PackageReference Include="Microsoft.OpenApi" Version="2.7.6" />
     <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="8.19.1" />
     <PackageReference Include="MQTTnet" Version="5.1.0.1559" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.9">

--- a/src/GarageStack.Worker/Dockerfile
+++ b/src/GarageStack.Worker/Dockerfile
@@ -13,7 +13,11 @@ RUN dotnet publish -c Release -o /app /p:MinVerVersionOverride=${APP_VERSION}
 
 FROM mcr.microsoft.com/dotnet/aspnet:10.0 AS runtime
 WORKDIR /app
-RUN apt-get update \
+# OS_PATCH_DATE busts the layer cache so apt-get upgrade actually re-runs instead of
+# reusing a stale cached layer from before an OS package fix was published.
+ARG OS_PATCH_DATE=0
+RUN echo "os patch date: ${OS_PATCH_DATE}" \
+	&& apt-get update \
 	&& apt-get upgrade -y \
 	&& apt-get install -y --no-install-recommends libgssapi-krb5-2 \
 	&& rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## Summary
- Pins `Microsoft.OpenApi` to `2.7.6` in `GarageStack.Api.csproj`, overriding the vulnerable `2.0.0` pulled in transitively by `Microsoft.AspNetCore.OpenApi 10.0.9` (CVE-2026-49451, stack overflow on circular schema refs).
- Adds the `OS_PATCH_DATE` cache-busting arg (already used in `frontend/Dockerfile`) to `docker/all-in-one/Dockerfile`, `src/GarageStack.Api/Dockerfile`, and `src/GarageStack.Worker/Dockerfile`. Without it, `docker-publish.yml`'s daily `OS_PATCH_DATE` build-arg was never referenced, so the GHA layer cache kept reusing a stale `apt-get upgrade` layer and never picked up the patched nginx package (CVE-2026-42055, CVE-2026-48142).

Resolves code-scanning alerts #446-#451.

## Test plan
- [x] `dotnet restore` confirms `Microsoft.OpenApi` resolves to `2.7.6` (was `2.0.0`)
- [ ] Next scheduled/triggered image build re-runs OS upgrade layers and re-scan clears the nginx alerts