### PR TITLE
fix(worker): surface fatal crashes and stop dropping MQTT messages on reconnect

### DIFF
--- a/src/GarageStack.Worker/Mqtt/MqttConsumerService.cs
+++ b/src/GarageStack.Worker/Mqtt/MqttConsumerService.cs
@@ -5,6 +5,7 @@ using GarageStack.Core.Models;
 using GarageStack.Data;
 using GarageStack.Worker.Services;
 using MQTTnet;
+using MQTTnet.Protocol;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -41,9 +42,15 @@ public class MqttConsumerService(
 
         client.ApplicationMessageReceivedAsync += msg => HandleMessageAsync(msg, stoppingToken);
 
+        // CleanSession(false) + a stable ClientId let the broker retain a persistent
+        // session across reconnects, so it queues messages for us while we're offline.
+        // Actual redelivery still depends on the effective QoS being >=1, i.e. it also
+        // requires the saic-mqtt-gateway publisher to publish at QoS >=1 - the broker
+        // downgrades delivery to the lower of publish/subscribe QoS.
         var mqttOptionsBuilder = new MqttClientOptionsBuilder()
             .WithTcpServer(_options.Host, _options.Port)
-            .WithCleanSession();
+            .WithClientId(_options.ClientId)
+            .WithCleanSession(false);
 
         if (!string.IsNullOrWhiteSpace(_options.Username))
             mqttOptionsBuilder.WithCredentials(_options.Username, _options.Password);
@@ -67,8 +74,8 @@ public class MqttConsumerService(
                 logger.LogInformation("Connected to MQTT broker at {Host}:{Port}", _options.Host, _options.Port);
 
                 await client.SubscribeAsync(new MqttClientSubscribeOptionsBuilder()
-                    .WithTopicFilter("saic/#")
-                    .WithTopicFilter("homeassistant/#")
+                    .WithTopicFilter("saic/#", MqttQualityOfServiceLevel.AtLeastOnce)
+                    .WithTopicFilter("homeassistant/#", MqttQualityOfServiceLevel.AtLeastOnce)
                     .Build(), stoppingToken);
                 logger.LogInformation("Subscribed to saic/# and homeassistant/#");
 

--- a/src/GarageStack.Worker/Mqtt/MqttOptions.cs
+++ b/src/GarageStack.Worker/Mqtt/MqttOptions.cs
@@ -6,4 +6,8 @@ public class MqttOptions
     public int Port { get; set; } = 1883;
     public string? Username { get; set; }
     public string? Password { get; set; }
+
+    // Stable across reconnects so the broker can recognize this as the same
+    // persistent session (see WithCleanSession(false) in MqttConsumerService).
+    public string ClientId { get; set; } = "garagestack-worker";
 }

--- a/src/GarageStack.Worker/Program.cs
+++ b/src/GarageStack.Worker/Program.cs
@@ -51,6 +51,7 @@ try
 catch (Exception ex) when (ex is not HostAbortedException)
 {
     Log.Fatal(ex, "Worker terminated unexpectedly");
+    Environment.ExitCode = 1;
 }
 finally
 {


### PR DESCRIPTION
## Summary
- Worker now exits with a non-zero code after an unhandled fatal exception, instead of exiting 0, so restart-on-failure orchestration (Docker/systemd) actually restarts it instead of leaving ingestion silently dead.
- MQTT client now uses a stable `ClientId` with `CleanSession(false)` and QoS 1 subscriptions (previously clean session + implicit QoS 0), so the broker can queue and redeliver telemetry published while the worker is reconnecting instead of dropping it.
- Note: redelivery also depends on the upstream `saic-mqtt-gateway` publishing at QoS >= 1; documented that caveat in a comment since it's outside this repo's control.

## Test plan
- [x] `dotnet build src/GarageStack.Worker/GarageStack.Worker.csproj` succeeds
- [x] `dotnet test src/GarageStack.Tests/GarageStack.Tests.csproj` passes (247/247)
- [ ] Manual verification against a live broker recommended before release (reconnect + offline message queuing behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)