### PR TITLE
fix: validate map coordinates and surface telemetry notify failures

### DIFF
--- a/src/GarageStack.Api/Endpoints/MapEndpoints.cs
+++ b/src/GarageStack.Api/Endpoints/MapEndpoints.cs
@@ -19,6 +19,9 @@ public static class MapEndpoints
             ChargingStationService svc,
             CancellationToken ct) =>
         {
+            if (lat is < -90 or > 90 || lng is < -180 or > 180)
+                return Results.BadRequest(new { error = "lat must be between -90 and 90, lng between -180 and 180" });
+
             if (distanceKm is < 1 or > 200)
                 return Results.BadRequest(new { error = "distanceKm must be between 1 and 200" });
 
@@ -53,6 +56,9 @@ public static class MapEndpoints
             PoiService svc,
             CancellationToken ct) =>
         {
+            if (lat is < -90 or > 90 || lng is < -180 or > 180)
+                return Results.BadRequest(new { error = "lat must be between -90 and 90, lng between -180 and 180" });
+
             if (radiusKm is < 1 or > 200)
                 return Results.BadRequest(new { error = "radiusKm must be between 1 and 200" });
 

--- a/src/GarageStack.Core/Helpers/TileHelper.cs
+++ b/src/GarageStack.Core/Helpers/TileHelper.cs
@@ -5,14 +5,19 @@ public static class TileHelper
     // Grid resolution: each cell covers 0.5 degrees of lat/lng (~55km at the equator).
     private const double CellsPerDegree = 2.0;
 
+    // Below this, cos(lat) is close enough to zero near the poles that radiusKm / lngFactor
+    // would blow up into an enormous longitude range (and a huge tile count); fall back to a
+    // fixed +/-1 degree box instead.
+    private const double MinLngFactor = 1.0;
+
     public static (double MinLat, double MaxLat, double MinLng, double MaxLng) ComputeBounds(
         double lat, double lng, double radiusKm)
     {
         var minLat = lat - radiusKm / 111.0;
         var maxLat = lat + radiusKm / 111.0;
         var lngFactor = 111.0 * Math.Cos(lat * Math.PI / 180.0);
-        var minLng = lngFactor > 0 ? lng - radiusKm / lngFactor : lng - 1.0;
-        var maxLng = lngFactor > 0 ? lng + radiusKm / lngFactor : lng + 1.0;
+        var minLng = lngFactor > MinLngFactor ? lng - radiusKm / lngFactor : lng - 1.0;
+        var maxLng = lngFactor > MinLngFactor ? lng + radiusKm / lngFactor : lng + 1.0;
         return (minLat, maxLat, minLng, maxLng);
     }
 

--- a/src/GarageStack.Data/Repositories/TelemetryRepository.cs
+++ b/src/GarageStack.Data/Repositories/TelemetryRepository.cs
@@ -4,10 +4,13 @@ using GarageStack.Core.Helpers;
 using GarageStack.Core.Interfaces;
 using GarageStack.Core.Models;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
 
 namespace GarageStack.Data.Repositories;
 
-public class TelemetryRepository(AppDbContext db) : ITelemetryRepository
+// logger is optional (DI always supplies one) so existing tests can keep constructing
+// this directly with just a DbContext.
+public class TelemetryRepository(AppDbContext db, ILogger<TelemetryRepository>? logger = null) : ITelemetryRepository
 {
     // All TelemetrySnapshot properties except identity/bookkeeping fields (Id, VehicleId, Vehicle,
     // RecordedAt, RawTopic) participate in field-by-field merging. Computed once and reused by both
@@ -136,7 +139,12 @@ public class TelemetryRepository(AppDbContext db) : ITelemetryRepository
         {
             await db.Database.ExecuteSqlAsync($"SELECT pg_notify('telemetry_updated', {vehicleId.ToString()})", ct);
         }
-        catch { }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            // The telemetry row itself is already saved at this point, so this only means
+            // live SignalR/dashboard updates are delayed until the next poll, not data loss.
+            logger?.LogWarning(ex, "Failed to notify telemetry_updated for vehicleId={VehicleId}", vehicleId);
+        }
     }
 
     public Task<TelemetrySnapshot?> GetLatestAsync(int vehicleId, CancellationToken ct = default) =>

--- a/src/GarageStack.Tests/TileHelperTests.cs
+++ b/src/GarageStack.Tests/TileHelperTests.cs
@@ -1,0 +1,28 @@
+using GarageStack.Core.Helpers;
+
+namespace GarageStack.Tests;
+
+public class TileHelperTests
+{
+    [Theory]
+    [InlineData(89.999)]
+    [InlineData(90.0)]
+    [InlineData(-90.0)]
+    public void ComputeTiles_NearPole_DoesNotExplode(double lat)
+    {
+        var tiles = TileHelper.ComputeTiles(lat, 0.0, 100);
+
+        // Without the cos(lat)-near-zero guard, this would blow up into tens of
+        // thousands of tiles instead of a small box around the pole.
+        Assert.True(tiles.Count < 50, $"expected a small tile set near the pole, got {tiles.Count}");
+    }
+
+    [Fact]
+    public void ComputeTiles_NormalLatitude_ReturnsReasonableTileCount()
+    {
+        var tiles = TileHelper.ComputeTiles(52.0, 5.0, 100);
+
+        Assert.NotEmpty(tiles);
+        Assert.True(tiles.Count < 50);
+    }
+}


### PR DESCRIPTION
## Summary
- `/api/map/charging-stations` and `/api/map/poi` never validated `lat`/`lng`. A latitude near +/-90 drives `cos(lat)` toward zero in `TileHelper.ComputeBounds`, which blows up `radiusKm / lngFactor` into an enormous longitude range and a correspondingly huge tile count fed into a SQL `IN` query - a cheap DoS vector against the API/DB. Both endpoints now reject out-of-range coordinates with a 400, and `TileHelper` itself now falls back to a fixed +/-1 degree box when `cos(lat)` gets too small instead of dividing by a near-zero factor, so the helper is safe even for its other (non-endpoint) callers.
- `TelemetryRepository.NotifyUpdatedAsync` caught and discarded `pg_notify` failures with no `ILogger` injected into the class at all, meaning a broken live-update notification (SignalR/dashboard staying stale) had zero trace anywhere in the logs. It now logs a warning with the vehicle id; the logger is optional so existing tests that construct the repository directly are unaffected.
- Added `TileHelperTests.cs` covering the pole-proximity fix.

## Test plan
- [x] `dotnet build` succeeds
- [x] `dotnet test` passes (251/251, 4 new)
- [ ] Manual sanity check of `/api/map/poi` and `/api/map/charging-stations` with out-of-range lat/lng recommended before release

🤖 Generated with [Claude Code](https://claude.com/claude-code)