### PR TITLE
fix: handle concurrent vehicle creation and make VinStateTracker thread-safe

### DIFF
--- a/src/GarageStack.Core/Helpers/VinStateTracker.cs
+++ b/src/GarageStack.Core/Helpers/VinStateTracker.cs
@@ -8,6 +8,11 @@ public sealed class VinStateTracker<T>
 {
     private readonly Dictionary<string, T> _state = new();
 
+    // Callers hold this as a singleton and invoke TryUpdate from MQTT message handlers; the current
+    // handler dispatch happens to be sequential, but that's an MQTTnet implementation detail this
+    // class can't rely on, so guard the dictionary explicitly instead of assuming single-threaded access.
+    private readonly object _lock = new();
+
     /// <summary>
     /// Records <paramref name="current"/> as the new value for <paramref name="vin"/> and returns the
     /// value seen before this call via <paramref name="previous"/>. Returns false on the first observation
@@ -15,8 +20,11 @@ public sealed class VinStateTracker<T>
     /// </summary>
     public bool TryUpdate(string vin, T current, out T previous)
     {
-        var hadPrevious = _state.TryGetValue(vin, out previous!);
-        _state[vin] = current;
-        return hadPrevious;
+        lock (_lock)
+        {
+            var hadPrevious = _state.TryGetValue(vin, out previous!);
+            _state[vin] = current;
+            return hadPrevious;
+        }
     }
 }

--- a/src/GarageStack.Data/Repositories/VehicleRepository.cs
+++ b/src/GarageStack.Data/Repositories/VehicleRepository.cs
@@ -2,6 +2,7 @@ using System.Text.Json;
 using GarageStack.Core.Interfaces;
 using GarageStack.Core.Models;
 using Microsoft.EntityFrameworkCore;
+using Npgsql;
 
 namespace GarageStack.Data.Repositories;
 
@@ -25,7 +26,19 @@ public class VehicleRepository(AppDbContext db) : IVehicleRepository
 
         vehicle = new Vehicle { Vin = vin, SaicUser = saicUser };
         db.Vehicles.Add(vehicle);
-        await db.SaveChangesAsync(ct);
+        try
+        {
+            await db.SaveChangesAsync(ct);
+        }
+        catch (DbUpdateException ex) when (ex.InnerException is PostgresException { SqlState: "23505" })
+        {
+            // The API and Worker can both call GetOrCreateByVinAsync for a brand-new VIN at
+            // nearly the same time (e.g. on startup); the loser of that race hits the unique
+            // constraint on Vin here. Forget our failed insert and read back the winner's row.
+            db.ChangeTracker.Clear();
+            vehicle = await db.Vehicles.FirstOrDefaultAsync(v => v.Vin == vin, ct)
+                ?? throw new InvalidOperationException($"Unique-constraint violation on VIN {vin} but no row found on retry.");
+        }
         return vehicle;
     }
 

--- a/src/GarageStack.Worker/Mqtt/MqttConsumerService.cs
+++ b/src/GarageStack.Worker/Mqtt/MqttConsumerService.cs
@@ -30,6 +30,12 @@ public class MqttConsumerService(
     // Messages arriving within this window are merged into the same DB row so that
     // each row represents a complete poll rather than a single field, reducing row
     // count by ~9x and ensuring all chart fields land in the same sample.
+    //
+    // Unlike _engineRunningTracker, this dictionary is read, awaited on, then written back
+    // (see HandleMessageAsync), so a simple lock can't cover the whole critical section without
+    // blocking across an await. That's safe only because MQTTnet invokes
+    // ApplicationMessageReceivedAsync for one message at a time on this client; if that dispatch
+    // model ever changes, this needs an async-safe lock (e.g. SemaphoreSlim) around the read/await/write.
     private static readonly TimeSpan MergeWindow = TimeSpan.FromSeconds(15);
     internal readonly Dictionary<int, (long RowId, DateTime RecordedAt)> _mergeState = new();
 


### PR DESCRIPTION
## Summary
- `VehicleRepository.GetOrCreateByVinAsync` had a read-then-insert race: the API and Worker both call this for a brand-new VIN around the same time on startup, and the loser previously got an unhandled `DbUpdateException` from the unique constraint on `Vin` instead of returning the winner's row. Now catches the same `PostgresException { SqlState: "23505" }` and retries once, mirroring the existing pattern in `PoiRepository.UpsertTileAsync`.
- `VinStateTracker<T>` is held as a singleton per background service and mutated from MQTT message handlers, but its internal `Dictionary` had no synchronization - it only worked because MQTTnet happens to dispatch messages sequentially today. Added a lock so it's correct regardless of that assumption.
- `MqttConsumerService._mergeState` has the identical exposure, but a real fix needs an async-safe lock (it's read, awaited on, then written back - a plain `lock` can't span an `await`). Left a comment documenting the assumption and what would be needed if it's ever revisited, rather than restructuring that flow as a drive-by.

## Not included
Investigated the "unbounded `GetHistoryAsync`/`GetTripsAsync` queries" finding from the earlier review and found it's already mitigated: `VehicleEndpoints.cs` clamps every date-range query to a 90-day max via `ClampRangeStart` before it reaches the repository. No change needed there.

The new race-condition retry path can't be meaningfully unit-tested against the in-memory EF provider (it doesn't throw real `PostgresException`s), and there's no existing precedent for it either - `PoiRepository.UpsertTileAsync`'s identical retry pattern has the same gap.

## Test plan
- [x] `dotnet build` succeeds
- [x] `dotnet test` passes (251/251, no new tests - see note above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)