### PR TITLE
refactor: extract ExpandableStatusCard to dedupe card scaffolding

### DIFF
--- a/frontend/src/components/BatteryHeatingCard.vue
+++ b/frontend/src/components/BatteryHeatingCard.vue
@@ -1,10 +1,8 @@
 <script setup lang="ts">
 import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
-import StatusCard from './StatusCard.vue'
-import DetailModal from './DetailModal.vue'
+import ExpandableStatusCard from './ExpandableStatusCard.vue'
 import DetailListItem from './DetailListItem.vue'
-import { useModal } from '@/composables/useModal'
 
 const { t } = useI18n()
 
@@ -13,8 +11,6 @@ const props = defineProps<{
   scheduleMode: string | null
   scheduleStartTime: string | null
 }>()
-
-const { isOpen: modalOpen, open: openModal, close: closeModal } = useModal()
 
 const summaryValue = computed((): string | null => {
   if (props.batteryHeating === null) return null
@@ -28,21 +24,13 @@ const hasModal = computed(() => props.scheduleMode !== null || props.scheduleSta
 </script>
 
 <template>
-  <StatusCard
+  <ExpandableStatusCard
     v-if="batteryHeating !== null"
     icon="temperature-arrow-up"
-    :label="t('vehicle.batteryHeating.title')"
+    :title="t('vehicle.batteryHeating.title')"
     :value="summaryValue"
     :variant="batteryHeating ? 'info' : undefined"
     :clickable="hasModal"
-    @click="hasModal ? openModal() : undefined"
-  />
-
-  <DetailModal
-    v-if="hasModal"
-    :open="modalOpen"
-    :title="t('vehicle.batteryHeating.title')"
-    @close="closeModal"
   >
     <div class="detail-list">
       <DetailListItem
@@ -74,5 +62,5 @@ const hasModal = computed(() => props.scheduleMode !== null || props.scheduleSta
         :label="t('vehicle.batteryHeating.startTime')"
       />
     </div>
-  </DetailModal>
+  </ExpandableStatusCard>
 </template>

--- a/frontend/src/components/ChargingSessionCard.vue
+++ b/frontend/src/components/ChargingSessionCard.vue
@@ -1,10 +1,8 @@
 <script setup lang="ts">
 import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
-import StatusCard from './StatusCard.vue'
-import DetailModal from './DetailModal.vue'
+import ExpandableStatusCard from './ExpandableStatusCard.vue'
 import DetailListItem from './DetailListItem.vue'
-import { useModal } from '@/composables/useModal'
 
 const { t } = useI18n()
 
@@ -21,8 +19,6 @@ const props = defineProps<{
   chargingScheduleStartTime: string | null
   chargingScheduleEndTime: string | null
 }>()
-
-const { isOpen: modalOpen, open: openModal, close: closeModal } = useModal()
 
 const obcPower = computed(() => props.obcPowerThreePhase ?? props.obcPowerSinglePhase)
 
@@ -60,17 +56,13 @@ const lastEndFormatted = computed((): string | null => {
 </script>
 
 <template>
-  <StatusCard
+  <ExpandableStatusCard
     v-if="hasAnyData"
     icon="plug-circle-bolt"
-    :label="t('vehicle.chargingSession.title')"
+    :title="t('vehicle.chargingSession.title')"
     :value="summaryValue"
     variant="info"
-    clickable
-    @click="openModal"
-  />
-
-  <DetailModal :open="modalOpen" :title="t('vehicle.chargingSession.title')" @close="closeModal">
+  >
     <div class="detail-list">
       <DetailListItem
         v-if="obcPower !== null"
@@ -158,5 +150,5 @@ const lastEndFormatted = computed((): string | null => {
         </template>
       </DetailListItem>
     </div>
-  </DetailModal>
+  </ExpandableStatusCard>
 </template>

--- a/frontend/src/components/ClimateDetailCard.vue
+++ b/frontend/src/components/ClimateDetailCard.vue
@@ -1,10 +1,8 @@
 <script setup lang="ts">
 import { computed, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
-import StatusCard from './StatusCard.vue'
-import DetailModal from './DetailModal.vue'
+import ExpandableStatusCard from './ExpandableStatusCard.vue'
 import DetailListItem from './DetailListItem.vue'
-import { useModal } from '@/composables/useModal'
 import { useVehicleCommand } from '@/composables/useVehicleCommand'
 
 const { t } = useI18n()
@@ -21,7 +19,7 @@ const props = defineProps<{
   steeringWheelHeating: boolean | null
 }>()
 
-const { isOpen: modalOpen, open: openModal, close: closeModal } = useModal()
+const modalOpen = ref(false)
 const { sending, lastResult, isPending, send } = useVehicleCommand()
 
 const TEMP_MIN = 16
@@ -158,17 +156,14 @@ function onSeatRightChange(e: Event) {
 </script>
 
 <template>
-  <StatusCard
+  <ExpandableStatusCard
     v-if="hasAnyData"
     icon="wind"
-    :label="t('control.climate')"
+    :title="t('control.climate')"
     :value="summaryValue"
     :variant="climateOn ? 'info' : undefined"
-    clickable
-    @click="openModal"
-  />
-
-  <DetailModal :open="modalOpen" :title="t('control.climate')" @close="closeModal">
+    v-model:open="modalOpen"
+  >
     <div class="detail-list">
       <!-- AC temperature slider -->
       <div
@@ -314,11 +309,11 @@ function onSeatRightChange(e: Event) {
       </div>
     </div>
 
-    <template #footer>
+    <template #footer="{ close }">
       <span v-if="lastResult && !lastResult.ok && !anyPending" class="text-danger me-auto">
         {{ t('control.error') }}
       </span>
-      <button class="btn btn-outline-secondary" @click="closeModal">
+      <button class="btn btn-outline-secondary" @click="close">
         {{ t('common.cancel') }}
       </button>
       <button
@@ -333,7 +328,7 @@ function onSeatRightChange(e: Event) {
         {{ anyPending ? t('control.pending') : t('common.apply') }}
       </button>
     </template>
-  </DetailModal>
+  </ExpandableStatusCard>
 </template>
 
 <style scoped>

--- a/frontend/src/components/DoorsCard.vue
+++ b/frontend/src/components/DoorsCard.vue
@@ -1,10 +1,8 @@
 <script setup lang="ts">
 import { ref, computed, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
-import StatusCard from './StatusCard.vue'
-import DetailModal from './DetailModal.vue'
+import ExpandableStatusCard from './ExpandableStatusCard.vue'
 import DetailListItem from './DetailListItem.vue'
-import { useModal } from '@/composables/useModal'
 import { useVehicleCommand } from '@/composables/useVehicleCommand'
 
 const { t } = useI18n()
@@ -20,7 +18,6 @@ const props = defineProps<{
   trunkOpen: boolean | null
 }>()
 
-const { isOpen: modalOpen, open: openModal, close: closeModal } = useModal()
 const { sending, lastResult, isPending, send } = useVehicleCommand()
 
 const localLocked = ref<boolean | null>(null)
@@ -108,17 +105,13 @@ async function handleLockToggle() {
 </script>
 
 <template>
-  <StatusCard
+  <ExpandableStatusCard
     v-if="summary !== null"
     :icon="effectiveLocked === false ? 'lock-open' : 'lock'"
-    :label="t('vehicle.doors')"
+    :title="t('vehicle.doors')"
     :value="summary"
     :variant="variant"
-    clickable
-    @click="openModal"
-  />
-
-  <DetailModal :open="modalOpen" :title="t('vehicle.doors')" @close="closeModal">
+  >
     <div v-if="isLocked !== null" class="detail-list">
       <div class="detail-list__item detail-list__item--control">
         <font-awesome-icon
@@ -168,5 +161,5 @@ async function handleLockToggle() {
         :alert="door.open"
       />
     </div>
-  </DetailModal>
+  </ExpandableStatusCard>
 </template>

--- a/frontend/src/components/ExpandableStatusCard.vue
+++ b/frontend/src/components/ExpandableStatusCard.vue
@@ -1,0 +1,38 @@
+<script setup lang="ts">
+import StatusCard from './StatusCard.vue'
+import DetailModal from './DetailModal.vue'
+
+withDefaults(
+  defineProps<{
+    icon: string
+    title: string
+    value: string | number | null
+    variant?: 'success' | 'warning' | 'danger' | 'info'
+    clickable?: boolean
+  }>(),
+  { clickable: true },
+)
+
+// Most cards don't need to observe the open state themselves, so this works standalone.
+// Cards that do (e.g. resetting local edit state when the modal opens) can bind
+// v-model:open to their own ref and watch it.
+const open = defineModel<boolean>('open', { default: false })
+</script>
+
+<template>
+  <StatusCard
+    :icon="icon"
+    :label="title"
+    :value="value"
+    :variant="variant"
+    :clickable="clickable"
+    @click="open = true"
+  />
+
+  <DetailModal :open="open" :title="title" @close="open = false">
+    <slot :close="() => (open = false)" />
+    <template v-if="$slots.footer" #footer>
+      <slot name="footer" :close="() => (open = false)" />
+    </template>
+  </DetailModal>
+</template>

--- a/frontend/src/components/FindMyCarCard.vue
+++ b/frontend/src/components/FindMyCarCard.vue
@@ -1,10 +1,8 @@
 <script setup lang="ts">
 import { ref } from 'vue'
 import { useI18n } from 'vue-i18n'
-import StatusCard from './StatusCard.vue'
-import DetailModal from './DetailModal.vue'
+import ExpandableStatusCard from './ExpandableStatusCard.vue'
 import { useVehicleCommand } from '@/composables/useVehicleCommand'
-import { useModal } from '@/composables/useModal'
 
 const { t } = useI18n()
 
@@ -14,7 +12,6 @@ const props = defineProps<{
 
 const { sending, isPending, send } = useVehicleCommand()
 const active = ref(false)
-const { isOpen: modalOpen, open: openModal, close: closeModal } = useModal()
 
 async function activate() {
   if (await send(props.vin, 'find-my-car', 'activate')) active.value = true
@@ -26,19 +23,15 @@ async function stop() {
 </script>
 
 <template>
-  <StatusCard
+  <ExpandableStatusCard
     icon="car-burst"
-    :label="t('control.findMyCar')"
+    :title="t('control.findMyCar')"
     :value="active ? t('control.findMyCarActive') : '-'"
     :variant="active ? 'warning' : undefined"
-    clickable
-    @click="openModal"
-  />
-
-  <DetailModal :open="modalOpen" :title="t('control.findMyCar')" @close="closeModal">
+  >
     <p class="card-info-desc">{{ t('control.findMyCarConfirm') }}</p>
-    <template #footer>
-      <button class="btn btn-outline-secondary" @click="closeModal">
+    <template #footer="{ close }">
+      <button class="btn btn-outline-secondary" @click="close">
         {{ t('common.cancel') }}
       </button>
       <button
@@ -66,5 +59,5 @@ async function stop() {
         {{ isPending('find-my-car') ? t('control.pending') : t('control.findMyCarStop') }}
       </button>
     </template>
-  </DetailModal>
+  </ExpandableStatusCard>
 </template>

--- a/frontend/src/components/HvBatteryCard.vue
+++ b/frontend/src/components/HvBatteryCard.vue
@@ -1,10 +1,8 @@
 <script setup lang="ts">
 import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
-import StatusCard from './StatusCard.vue'
-import DetailModal from './DetailModal.vue'
+import ExpandableStatusCard from './ExpandableStatusCard.vue'
 import DetailListItem from './DetailListItem.vue'
-import { useModal } from '@/composables/useModal'
 import { useVehicleCommand } from '@/composables/useVehicleCommand'
 
 const { t } = useI18n()
@@ -22,7 +20,6 @@ const props = defineProps<{
   canSetChargeLimit: boolean
 }>()
 
-const { isOpen: modalOpen, open: openModal, close: closeModal } = useModal()
 const { sending, lastResult, isPending, send } = useVehicleCommand()
 
 const socPercent = computed(() => {
@@ -61,17 +58,13 @@ function setChargeLimit(value: string) {
 </script>
 
 <template>
-  <StatusCard
+  <ExpandableStatusCard
     v-if="hasAnyData"
     icon="bolt"
-    :label="t('vehicle.hvBattery.title')"
+    :title="t('vehicle.hvBattery.title')"
     :value="summaryValue"
     :variant="summaryVariant"
-    clickable
-    @click="openModal"
-  />
-
-  <DetailModal :open="modalOpen" :title="t('vehicle.hvBattery.title')" @close="closeModal">
+  >
     <div class="detail-list">
       <DetailListItem
         v-if="hvSocKwh !== null"
@@ -178,5 +171,5 @@ function setChargeLimit(value: string) {
         {{ t('control.error') }}
       </div>
     </div>
-  </DetailModal>
+  </ExpandableStatusCard>
 </template>

--- a/frontend/src/components/LightsCard.vue
+++ b/frontend/src/components/LightsCard.vue
@@ -1,10 +1,8 @@
 <script setup lang="ts">
 import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
-import StatusCard from './StatusCard.vue'
-import DetailModal from './DetailModal.vue'
+import ExpandableStatusCard from './ExpandableStatusCard.vue'
 import DetailListItem from './DetailListItem.vue'
-import { useModal } from '@/composables/useModal'
 
 const { t } = useI18n()
 
@@ -13,8 +11,6 @@ const props = defineProps<{
   dippedBeam: boolean | null
   side: boolean | null
 }>()
-
-const { isOpen: modalOpen, open: openModal, close: closeModal } = useModal()
 
 type LightItem = { key: string; label: string; on: boolean }
 
@@ -38,17 +34,13 @@ const summary = computed((): string | null => {
 </script>
 
 <template>
-  <StatusCard
+  <ExpandableStatusCard
     v-if="lightList.length > 0"
     icon="lightbulb"
-    :label="t('vehicle.lights.title')"
+    :title="t('vehicle.lights.title')"
     :value="summary"
     :variant="activeLights.length > 0 ? 'success' : 'danger'"
-    clickable
-    @click="openModal"
-  />
-
-  <DetailModal :open="modalOpen" :title="t('vehicle.lights.title')" @close="closeModal">
+  >
     <div class="detail-list">
       <DetailListItem
         v-for="light in lightList"
@@ -64,5 +56,5 @@ const summary = computed((): string | null => {
         </template>
       </DetailListItem>
     </div>
-  </DetailModal>
+  </ExpandableStatusCard>
 </template>

--- a/frontend/src/components/WindowsCard.vue
+++ b/frontend/src/components/WindowsCard.vue
@@ -1,10 +1,8 @@
 <script setup lang="ts">
 import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
-import StatusCard from './StatusCard.vue'
-import DetailModal from './DetailModal.vue'
+import ExpandableStatusCard from './ExpandableStatusCard.vue'
 import DetailListItem from './DetailListItem.vue'
-import { useModal } from '@/composables/useModal'
 
 const { t } = useI18n()
 
@@ -14,8 +12,6 @@ const props = defineProps<{
   rearLeftWindowOpen: boolean | null
   rearRightWindowOpen: boolean | null
 }>()
-
-const { isOpen: modalOpen, open: openModal, close: closeModal } = useModal()
 
 type WinItem = { key: string; label: string; open: boolean }
 
@@ -56,17 +52,13 @@ const variant = computed(() => {
 </script>
 
 <template>
-  <StatusCard
+  <ExpandableStatusCard
     v-if="summary !== null"
     icon="car-side"
-    :label="t('vehicle.windows')"
+    :title="t('vehicle.windows')"
     :value="summary"
     :variant="variant"
-    clickable
-    @click="openModal"
-  />
-
-  <DetailModal :open="modalOpen" :title="t('vehicle.windows')" @close="closeModal">
+  >
     <div class="detail-list">
       <DetailListItem
         v-for="win in windowList"
@@ -77,5 +69,5 @@ const variant = computed(() => {
         :alert="win.open"
       />
     </div>
-  </DetailModal>
+  </ExpandableStatusCard>
 </template>


### PR DESCRIPTION
## Summary
The single largest duplication flagged in an earlier full-project review: 8 dashboard card components (`DoorsCard`, `WindowsCard`, `LightsCard`, `ClimateDetailCard`, `HvBatteryCard`, `ChargingSessionCard`, `BatteryHeatingCard`, `FindMyCarCard`) each hand-rolled the identical `useModal()` + `StatusCard` + `DetailModal` wiring - about 150+ duplicated lines total.

- Extracted `ExpandableStatusCard.vue`, which wraps `StatusCard` + `DetailModal` and owns the open/close state via `defineModel('open')`. Cards that don't need to observe the open state (6 of 8) just use it standalone with no `v-model`.
- `ClimateDetailCard` needs to reset local edit fields when the modal opens (`watch(modalOpen, ...)`), so it binds `v-model:open` to its own local ref - the wrapper supports both modes.
- `FindMyCarCard` and `ClimateDetailCard`'s footer buttons need to close the modal from inside a slot; the wrapper exposes `close` as a scoped-slot prop on both the default and footer slots.
- `BatteryHeatingCard`'s conditional clickable/no-modal case is preserved via the `clickable` prop (defaults to `true`), which `StatusCard` already gates click emission on internally.

## Verification
No behavior changes intended - pure extraction.
- `vue-tsc --build`, `eslint`, `prettier --check` all clean
- All 140 existing frontend unit tests pass unmodified
- Manually clicked through all 8 cards against the demo app (`dotnet run --launch-profile Demo` + `pnpm dev`) in a headless browser: every card's modal opens with correct content, Escape closes it, and the footer Cancel buttons (Climate, Find My Car) close it via the scoped `close` slot prop. Screenshots confirmed visually correct rendering for Doors and Climate (the two most complex cases).

## Test plan
- [x] `pnpm run type-check` passes
- [x] `pnpm run lint` passes
- [x] `pnpm exec prettier --check src/` passes
- [x] `pnpm run test:unit --run` passes (140/140, unmodified)
- [x] Manual click-through of all 8 refactored cards in a running demo instance

🤖 Generated with [Claude Code](https://claude.com/claude-code)