### PR TITLE
fix(frontend): reset scroll position when navigating between pages

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -114,6 +114,7 @@ const lastRecorded = computed(() => {
 
 const menuOpen = ref(false)
 const isLoginRoute = computed(() => route.name === 'login')
+const mainContent = ref<HTMLElement | null>(null)
 
 function toggleMenu() {
   menuOpen.value = !menuOpen.value
@@ -133,6 +134,7 @@ watch(
   () => route.path,
   () => {
     menuOpen.value = false
+    mainContent.value?.scrollTo({ top: 0 })
   },
 )
 watch(
@@ -281,7 +283,7 @@ watch(
         </div>
       </nav>
 
-      <main class="main-content">
+      <main ref="mainContent" class="main-content">
         <RouterView />
       </main>
     </div>

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -26,6 +26,12 @@ const router = createRouter({
       component: () => import('@/views/MapView.vue'),
     },
   ],
+  scrollBehavior(to, from, savedPosition) {
+    if (savedPosition) {
+      return savedPosition
+    }
+    return { top: 0 }
+  },
 })
 
 router.beforeEach(async (to) => {


### PR DESCRIPTION
## Summary
- The page's `.main-content` element is a custom scrollable container (not the window), so scroll position was being retained across route changes, most noticeable on mobile where scrolling happens faster.
- Reset `.main-content` scroll to top on every route change in App.vue.
- Added a router-level `scrollBehavior` (resets to top, preserves position on back/forward) as a fallback for any window-scrolled views (e.g. login).

## Test plan
- [x] `pnpm run test:unit` (140 tests passing)
- [ ] Manually verify: navigate between Dashboard/Statistics/Map on a scrolled page and confirm it snaps to top, especially on mobile viewport