### PR TITLE
fix(security): log failed logins and rate-limit before CSRF checks

### DIFF
--- a/src/GarageStack.Api/Endpoints/AuthEndpoints.cs
+++ b/src/GarageStack.Api/Endpoints/AuthEndpoints.cs
@@ -69,7 +69,12 @@ public static class AuthEndpoints
             var validPassword = FixedTimeEquals(providedPassword, configuredPassword);
 
             if (!validUser || !validPassword)
+            {
+                logger.LogWarning(
+                    "Failed login attempt for username={Username} from IP={RemoteIp}",
+                    providedUsername, httpContext.Connection.RemoteIpAddress);
                 return Results.Unauthorized();
+            }
 
             var jwtSecret = config["Jwt:Secret"];
             if (string.IsNullOrWhiteSpace(jwtSecret))
@@ -119,6 +124,7 @@ public static class AuthEndpoints
 
             return Results.Ok(new LoginResponse(providedUsername, expires));
         })
+        .RequireRateLimiting("login")
         .WithSummary("Authenticate user and issue JWT token");
 
         return app;

--- a/src/GarageStack.Api/Program.cs
+++ b/src/GarageStack.Api/Program.cs
@@ -160,6 +160,22 @@ try
                     AutoReplenishment = true,
                 });
         });
+
+        // Tighter, endpoint-specific limit on login to slow down credential-stuffing attempts.
+        // Composes with (i.e. is enforced in addition to) the global limiter above.
+        opts.AddPolicy("login", httpContext =>
+        {
+            var ip = httpContext.Connection.RemoteIpAddress?.ToString() ?? "unknown";
+            return RateLimitPartition.GetFixedWindowLimiter(
+                partitionKey: ip,
+                factory: _ => new FixedWindowRateLimiterOptions
+                {
+                    Window = TimeSpan.FromMinutes(5),
+                    PermitLimit = 10,
+                    QueueLimit = 0,
+                    AutoReplenishment = true,
+                });
+        });
     });
 
     builder.Services.AddCors(opts =>
@@ -230,6 +246,11 @@ try
     app.UseSerilogRequestLogging();
     app.UseCors();
 
+    // Rate limiting runs before the CSRF origin check so that a flood of requests with a
+    // spoofed/mismatched Origin gets throttled instead of generating unbounded warning-log
+    // volume below.
+    app.UseRateLimiter();
+
     // Defense-in-depth: when an Origin header is present on a state-changing request,
     // verify it matches a configured allowed origin. SameSite=Strict is the primary CSRF
     // protection; this adds an explicit server-side check for deployments where that alone
@@ -280,7 +301,6 @@ try
         SupportedCultures = [new CultureInfo("en"), new CultureInfo("nl")],
         SupportedUICultures = [new CultureInfo("en"), new CultureInfo("nl")],
     });
-    app.UseRateLimiter();
     app.UseAuthentication();
     app.UseAuthorization();
 


### PR DESCRIPTION
## Summary
The two HIGH-priority items from an earlier full-project security review.

- **No audit trail for failed logins.** `AuthEndpoints.cs` returned `Unauthorized` on bad credentials with zero logging, and the only throttle was the global 120 req/min-per-IP limiter (not endpoint-specific). Now logs a warning with the attempted username and remote IP on every failed login, and login has its own tighter rate-limit policy (10 attempts / 5 min per IP) layered on top of the existing global limiter via `RequireRateLimiting("login")`.
- **Rate limiter ran after the CSRF Origin-check middleware.** `Program.cs` had `UseRateLimiter()` positioned after the Origin-check block (which logs a warning on every rejected request). An attacker could send unlimited requests with a spoofed/mismatched `Origin` header and generate unbounded warning-log volume before rate limiting ever applied. Moved `UseRateLimiter()` to run immediately after `UseCors()`, before the CSRF check.

## Test plan
- [x] `dotnet build` succeeds
- [x] `dotnet test` passes (251/251, unmodified - existing `CsrfMiddlewareTests` still pass with the reordered pipeline)
- [ ] No new test added for the login-specific rate limit policy or the audit-log line - both are thin, declarative/one-line changes; didn't feel like they warranted standing up new integration-test infra for this PR. Flagging in case you want it covered later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)