### PR TITLE
fix: widget key timing, notification error handling, SignalR status, concurrent push

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -50,6 +50,7 @@ const {
   unreadCount,
   panelOpen,
   loading,
+  actionError: notificationActionError,
   togglePanel,
   closePanel,
   archiveNotification,
@@ -83,14 +84,25 @@ onBeforeUnmount(() => {
 
 useFavicon()
 
-const { start: startSignalR, stop: stopSignalR } = useSignalR({
+const {
+  connected: signalRConnected,
+  start: startSignalR,
+  stop: stopSignalR,
+} = useSignalR({
   onTelemetryUpdated: (snapshot) => vehicleStore.applyLiveStatus(snapshot),
   onNotificationReceived: (notification) => prependNotification(notification),
   onTripCompleted: () => vehicleStore.notifyTripCompleted(),
 })
 
+// Only show "paused" once we've actually attempted a connection, not during the
+// brief window before startSignalR() is first called.
+const signalRAttempted = ref(false)
+
 watch(vehicleId, (id) => {
-  if (id) startSignalR(id)
+  if (id) {
+    signalRAttempted.value = true
+    startSignalR(id)
+  }
 })
 
 const isInitialLoading = computed(() => vehicleStore.loading && !vehicleStore.currentStatus)
@@ -206,6 +218,13 @@ watch(
             <span>{{ carModel }}</span>
           </div>
           <div
+            v-if="signalRAttempted && !signalRConnected"
+            class="sidebar-online-status sidebar-online-status--offline"
+          >
+            <font-awesome-icon icon="triangle-exclamation" aria-hidden="true" />
+            <span class="sidebar-footer__text">{{ t('common.liveUpdatesPaused') }}</span>
+          </div>
+          <div
             v-if="isInitialLoading || onlineStatusText"
             class="sidebar-online-status"
             :class="
@@ -307,6 +326,7 @@ watch(
       :open="panelOpen"
       :notifications="notifications"
       :loading="loading"
+      :action-error="notificationActionError"
       @close="closePanel"
       @archive="archiveNotification"
       @archive-all="archiveAllNotifications"

--- a/frontend/src/assets/main.css
+++ b/frontend/src/assets/main.css
@@ -2372,6 +2372,16 @@ body,
   color: var(--color-text);
 }
 
+.notif-panel__error {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.625rem 1.25rem;
+  border-bottom: 1px solid var(--color-border);
+  font-size: 0.875rem;
+  flex-shrink: 0;
+}
+
 .notif-panel__tabs {
   display: flex;
   border-bottom: 1px solid var(--color-border);

--- a/frontend/src/components/NotificationPanel.vue
+++ b/frontend/src/components/NotificationPanel.vue
@@ -24,6 +24,7 @@ const props = defineProps<{
   open: boolean
   notifications: AppNotification[]
   loading: boolean
+  actionError?: string | null
 }>()
 
 const emit = defineEmits<{
@@ -128,6 +129,11 @@ onUnmounted(() => document.removeEventListener('keydown', onKey))
             >
               <font-awesome-icon icon="xmark" aria-hidden="true" />
             </button>
+          </div>
+
+          <div v-if="actionError" class="notif-panel__error text-danger">
+            <font-awesome-icon icon="triangle-exclamation" />
+            {{ t('common.error') }}
           </div>
 
           <div v-if="!loading && notifications.length > 0" class="notif-panel__tabs">

--- a/frontend/src/composables/__tests__/useNotifications.spec.ts
+++ b/frontend/src/composables/__tests__/useNotifications.spec.ts
@@ -9,7 +9,9 @@ vi.mock('@/services/notificationsApi', () => ({
   notificationsApi: {
     list: vi.fn<() => Promise<AppNotification[]>>(),
     archive: vi.fn<(id: number) => Promise<void>>(),
+    archiveAll: vi.fn<() => Promise<void>>(),
     delete: vi.fn<(id: number) => Promise<void>>(),
+    deleteAll: vi.fn<() => Promise<void>>(),
   },
 }))
 
@@ -44,7 +46,9 @@ describe('useNotifications', () => {
     setActivePinia(createPinia())
     vi.mocked(notificationsApi.list).mockReset()
     vi.mocked(notificationsApi.archive).mockReset()
+    vi.mocked(notificationsApi.archiveAll).mockReset()
     vi.mocked(notificationsApi.delete).mockReset()
+    vi.mocked(notificationsApi.deleteAll).mockReset()
   })
 
   afterEach(() => {
@@ -210,6 +214,63 @@ describe('useNotifications', () => {
     await deleteNotification(9)
 
     expect(vi.mocked(notificationsApi.delete)).toHaveBeenCalledWith(9)
+  })
+
+  it('archiveNotification() sets actionError and leaves the item unarchived when the API throws', async () => {
+    const item = makeNotification({ id: 5, isArchived: false })
+    vi.mocked(notificationsApi.list).mockResolvedValue([item])
+    vi.mocked(notificationsApi.archive).mockRejectedValue(new Error('Network error'))
+
+    const { useNotifications } = await import('@/composables/useNotifications')
+    const { fetchNotifications, archiveNotification, notifications, actionError } =
+      useNotifications()
+    await fetchNotifications()
+    await archiveNotification(5)
+
+    expect(actionError.value).toBe('Network error')
+    expect(notifications.value.find((n) => n.id === 5)?.isArchived).toBe(false)
+  })
+
+  it('deleteNotification() sets actionError and keeps the item when the API throws', async () => {
+    vi.mocked(notificationsApi.list).mockResolvedValue([makeNotification({ id: 9 })])
+    vi.mocked(notificationsApi.delete).mockRejectedValue(new Error('Network error'))
+
+    const { useNotifications } = await import('@/composables/useNotifications')
+    const { fetchNotifications, deleteNotification, notifications, actionError } =
+      useNotifications()
+    await fetchNotifications()
+    await deleteNotification(9)
+
+    expect(actionError.value).toBe('Network error')
+    expect(notifications.value).toHaveLength(1)
+  })
+
+  it('archiveAllNotifications() sets actionError when the API throws', async () => {
+    vi.mocked(notificationsApi.list).mockResolvedValue([makeNotification({ id: 1 })])
+    vi.mocked(notificationsApi.archiveAll).mockRejectedValue(new Error('Network error'))
+
+    const { useNotifications } = await import('@/composables/useNotifications')
+    const { fetchNotifications, archiveAllNotifications, notifications, actionError } =
+      useNotifications()
+    await fetchNotifications()
+    await archiveAllNotifications()
+
+    expect(actionError.value).toBe('Network error')
+    expect(notifications.value[0]?.isArchived).toBe(false)
+  })
+
+  it('deleteAllNotifications() sets actionError when the API throws', async () => {
+    vi.mocked(notificationsApi.list).mockResolvedValue([makeNotification({ id: 1 })])
+    vi.mocked(notificationsApi.deleteAll).mockRejectedValue(new Error('Network error'))
+
+    const { useNotifications } = await import('@/composables/useNotifications')
+    const { fetchNotifications, deleteAllNotifications, notifications, actionError } =
+      useNotifications()
+    await fetchNotifications()
+    await deleteAllNotifications()
+
+    expect(actionError.value).toBe('Network error')
+    expect(notifications.value).toHaveLength(1)
   })
 
   it('togglePanel() opens a closed panel', async () => {

--- a/frontend/src/composables/useNotifications.ts
+++ b/frontend/src/composables/useNotifications.ts
@@ -24,6 +24,7 @@ export function prependNotification(notification: AppNotification) {
 const panelOpen = ref(false)
 const loading = ref(false)
 const fetchError = ref<string | null>(null)
+const actionError = ref<string | null>(null)
 
 export function useNotifications() {
   const auth = useAuthStore()
@@ -72,27 +73,51 @@ export function useNotifications() {
   }
 
   async function archiveNotification(id: number) {
-    await notificationsApi.archive(id)
-    const n = notifications.value.find((n) => n.id === id)
-    if (n) n.isArchived = true
+    actionError.value = null
+    try {
+      await notificationsApi.archive(id)
+      const n = notifications.value.find((n) => n.id === id)
+      if (n) n.isArchived = true
+    } catch (err) {
+      console.error('Failed to archive notification', err)
+      actionError.value = err instanceof Error ? err.message : 'Failed to archive notification'
+    }
   }
 
   async function archiveAllNotifications() {
-    await notificationsApi.archiveAll()
-    notifications.value.forEach((n) => (n.isArchived = true))
-    syncBadge(0)
+    actionError.value = null
+    try {
+      await notificationsApi.archiveAll()
+      notifications.value.forEach((n) => (n.isArchived = true))
+      syncBadge(0)
+    } catch (err) {
+      console.error('Failed to archive all notifications', err)
+      actionError.value = err instanceof Error ? err.message : 'Failed to archive all notifications'
+    }
   }
 
   async function deleteNotification(id: number) {
-    await notificationsApi.delete(id)
-    notifications.value = notifications.value.filter((n) => n.id !== id)
-    syncBadge(unreadCount.value)
+    actionError.value = null
+    try {
+      await notificationsApi.delete(id)
+      notifications.value = notifications.value.filter((n) => n.id !== id)
+      syncBadge(unreadCount.value)
+    } catch (err) {
+      console.error('Failed to delete notification', err)
+      actionError.value = err instanceof Error ? err.message : 'Failed to delete notification'
+    }
   }
 
   async function deleteAllNotifications() {
-    await notificationsApi.deleteAll()
-    notifications.value = []
-    syncBadge(0)
+    actionError.value = null
+    try {
+      await notificationsApi.deleteAll()
+      notifications.value = []
+      syncBadge(0)
+    } catch (err) {
+      console.error('Failed to delete all notifications', err)
+      actionError.value = err instanceof Error ? err.message : 'Failed to delete all notifications'
+    }
   }
 
   function togglePanel() {
@@ -110,6 +135,7 @@ export function useNotifications() {
     panelOpen,
     loading,
     fetchError,
+    actionError,
     fetchNotifications,
     archiveNotification,
     archiveAllNotifications,

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -366,6 +366,7 @@
     "loading": "Loading...",
     "refreshing": "Refreshing...",
     "error": "Something went wrong",
+    "liveUpdatesPaused": "Live updates paused",
     "open": "Open",
     "closed": "Closed",
     "cancel": "Cancel",

--- a/frontend/src/locales/nl.json
+++ b/frontend/src/locales/nl.json
@@ -366,6 +366,7 @@
     "loading": "Laden...",
     "refreshing": "Vernieuwen...",
     "error": "Er is iets misgegaan",
+    "liveUpdatesPaused": "Live-updates gepauzeerd",
     "open": "Open",
     "closed": "Gesloten",
     "cancel": "Annuleren",

--- a/src/GarageStack.Api/Endpoints/AuthEndpoints.cs
+++ b/src/GarageStack.Api/Endpoints/AuthEndpoints.cs
@@ -141,7 +141,7 @@ public static class AuthEndpoints
         return null;
     }
 
-    private static bool FixedTimeEquals(string left, string right)
+    internal static bool FixedTimeEquals(string left, string right)
     {
         // Hash both values first so the compared buffers always have identical length.
         var leftBytes = SHA256.HashData(Encoding.UTF8.GetBytes(left));

--- a/src/GarageStack.Api/Endpoints/WidgetEndpoints.cs
+++ b/src/GarageStack.Api/Endpoints/WidgetEndpoints.cs
@@ -20,7 +20,7 @@ public static class WidgetEndpoints
                         statusCode: StatusCodes.Status503ServiceUnavailable);
 
                 var providedKey = ctx.HttpContext.Request.Headers["X-Widget-Key"].ToString();
-                if (!string.Equals(providedKey, configuredKey, StringComparison.Ordinal))
+                if (!AuthEndpoints.FixedTimeEquals(providedKey, configuredKey))
                     return Results.Unauthorized();
 
                 return await next(ctx);

--- a/src/GarageStack.Worker/Services/PushSenderService.cs
+++ b/src/GarageStack.Worker/Services/PushSenderService.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.Text.Json;
 using GarageStack.Core.Interfaces;
 using GarageStack.Data;
@@ -13,6 +14,8 @@ namespace GarageStack.Worker.Services;
 
 public sealed class PushSenderService : IPushSender, IDisposable
 {
+    private const int MaxConcurrentDeliveries = 10;
+
     private readonly ILogger<PushSenderService> _logger;
     private readonly IServiceScopeFactory _scopeFactory;
     private readonly HttpClient _httpClient;
@@ -99,30 +102,42 @@ public sealed class PushSenderService : IPushSender, IDisposable
             .CountAsync(n => !n.IsArchived && !n.IsDeleted, ct);
         var payload = System.Text.Json.JsonSerializer.Serialize(new { title, body, icon = "/icons/icon-192.png", category, unreadCount = unreadCountForPayload });
         var message = new PushMessage(payload) { TimeToLive = 3600 };
-        var dead = new List<ModelPushSubscription>();
+        var dead = new ConcurrentBag<ModelPushSubscription>();
 
-        foreach (var sub in subscriptions)
+        // Deliver concurrently (bounded) so one slow/unreachable subscriber can't delay
+        // delivery to everyone else; a single push endpoint request can take several
+        // seconds if that push service is degraded.
+        using var throttle = new SemaphoreSlim(MaxConcurrentDeliveries);
+        await Task.WhenAll(subscriptions.Select(async sub =>
         {
-            var pushSub = new PushSubscription();
-            pushSub.Endpoint = sub.Endpoint;
-            pushSub.SetKey(PushEncryptionKeyName.P256DH, sub.P256DhKey);
-            pushSub.SetKey(PushEncryptionKeyName.Auth, sub.AuthKey);
-
+            await throttle.WaitAsync(ct);
             try
             {
-                await _pushClient.RequestPushMessageDeliveryAsync(pushSub, message, ct);
+                var pushSub = new PushSubscription();
+                pushSub.Endpoint = sub.Endpoint;
+                pushSub.SetKey(PushEncryptionKeyName.P256DH, sub.P256DhKey);
+                pushSub.SetKey(PushEncryptionKeyName.Auth, sub.AuthKey);
+
+                try
+                {
+                    await _pushClient.RequestPushMessageDeliveryAsync(pushSub, message, ct);
+                }
+                catch (PushServiceClientException ex) when (
+                    ex.StatusCode == System.Net.HttpStatusCode.Gone ||
+                    ex.StatusCode == System.Net.HttpStatusCode.NotFound)
+                {
+                    dead.Add(sub);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(ex, "Failed to send push to {Endpoint}", sub.Endpoint);
+                }
             }
-            catch (PushServiceClientException ex) when (
-                ex.StatusCode == System.Net.HttpStatusCode.Gone ||
-                ex.StatusCode == System.Net.HttpStatusCode.NotFound)
+            finally
             {
-                dead.Add(sub);
+                throttle.Release();
             }
-            catch (Exception ex)
-            {
-                _logger.LogWarning(ex, "Failed to send push to {Endpoint}", sub.Endpoint);
-            }
-        }
+        }));
 
         if (dead.Count > 0)
         {


### PR DESCRIPTION
## Summary
Four of the six MEDIUM-priority items from an earlier full-project review (the other two, test coverage for `PoiPreCachingService`/`PushSenderService`/`MqttConsumerService`'s merge flow, are being handled as a separate follow-up since they're a different kind of work).

- **Widget API key timing side-channel.** `WidgetEndpoints.cs` compared the `X-Widget-Key` header with plain `string.Equals` instead of the constant-time comparison `AuthEndpoints` already has for the same purpose. Promoted `FixedTimeEquals` to `internal` and reused it.
- **Silent notification action failures.** `useNotifications.ts`'s archive/delete/archiveAll/deleteAll had no error handling; a failed request became an unhandled promise rejection with zero user feedback. They now catch, log to console, and set an `actionError` ref that `NotificationPanel.vue` surfaces as an inline error banner.
- **SignalR connection state never surfaced.** `App.vue` destructured `start`/`stop` from `useSignalR()` but discarded the `connected` ref. A dropped connection left telemetry silently stale with no visible indicator. Now shows a "Live updates paused" indicator in the sidebar once a connection has been attempted and isn't currently up (new `common.liveUpdatesPaused` i18n key, en + nl).
- **Sequential push delivery.** `PushSenderService.SendToAllAsync` delivered to subscribers one at a time; a single slow/unreachable push endpoint could delay delivery to everyone else. Now delivers with bounded concurrency (10 at a time) via `Task.WhenAll` + `SemaphoreSlim`, collecting dead subscriptions in a `ConcurrentBag` instead of a plain `List`.

## Test plan
- [x] `dotnet build` succeeds, `dotnet test` passes (251/251)
- [x] `pnpm run type-check`, `pnpm run lint`, `pnpm exec prettier --check src/` all pass
- [x] `pnpm run test:unit --run` passes (144/144 - 4 new tests added for the notification action error paths)

🤖 Generated with [Claude Code](https://claude.com/claude-code)