### PR TITLE
test: cover HA discovery parsing and PushSenderService VAPID fallback

### DIFF
--- a/src/GarageStack.Tests/MqttConsumerServiceTests.cs
+++ b/src/GarageStack.Tests/MqttConsumerServiceTests.cs
@@ -92,6 +92,20 @@ file sealed class FakeMqttClient : IMqttClient
     public Task WaitForConnectAsync(TimeSpan? timeout = null) =>
         _connectCalled.WaitAsync(timeout ?? TimeSpan.FromSeconds(5));
 
+    // Call from a test to simulate an incoming message on the subscribed topics.
+    public Task TriggerMessageAsync(string topic, string payload)
+    {
+        if (_msgHandler is null) return Task.CompletedTask;
+
+        var message = new MqttApplicationMessageBuilder()
+            .WithTopic(topic)
+            .WithPayload(payload)
+            .Build();
+        var args = new MqttApplicationMessageReceivedEventArgs(
+            "test-client", message, new MqttPublishPacket(), (_, _) => Task.CompletedTask);
+        return _msgHandler(args);
+    }
+
     public Task PingAsync(CancellationToken ct) => Task.CompletedTask;
     public Task<MqttClientPublishResult> PublishAsync(MqttApplicationMessage msg, CancellationToken ct) =>
         throw new NotImplementedException();
@@ -320,5 +334,56 @@ public class MqttConsumerServiceReconnectTests
         try { await serviceTask; } catch (OperationCanceledException) { }
 
         Assert.True(client.ConnectCount >= 3, $"Expected >= 3 connects, got {client.ConnectCount}");
+    }
+}
+
+// ---------------------------------------------------------------------------
+// HA discovery payload parsing -- these all resolve before (or independently of)
+// the DI scope, so they're reachable with the null-service FakeServiceScopeFactory.
+// The assertion is that malformed/incomplete payloads never crash the message
+// pipeline, matching HandleHaDiscoveryAsync's early-return / catch-and-log design.
+// ---------------------------------------------------------------------------
+
+public class MqttConsumerServiceHaDiscoveryTests
+{
+    [Theory]
+    [InlineData("""{"device":{"identifiers":["FAKEVN00000000001"]}}""")] // missing hw_version
+    [InlineData("""{"device":{"hw_version":"MG_BEV_1.0"}}""")] // missing identifiers
+    [InlineData("not json but mentions hw_version and identifiers")] // not valid JSON at all
+    [InlineData("""{"foo":{"hw_version":"x","identifiers":["VIN"]}}""")] // missing "device" property
+    [InlineData("""{"device":{"identifiers":["VIN"],"other":"hw_version"}}""")] // device has no hw_version property
+    [InlineData("""{"device":{"hw_version":"MG_BEV_1.0","identifiers":[]}}""")] // empty identifiers array
+    [InlineData("""{"device":{"hw_version":"MG_BEV_1.0","identifiers":[123,456]}}""")] // non-string identifiers
+    public async Task HandleHaDiscovery_IncompleteOrMalformedPayload_DoesNotThrow(string payload)
+    {
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        var client = new FakeMqttClient();
+        var svc = new TestableMqttConsumerService(new FakePushSender(), client);
+        var serviceTask = svc.RunAsync(cts.Token);
+        await client.WaitForConnectAsync();
+
+        // Should return quietly (or be caught internally) rather than propagate.
+        await client.TriggerMessageAsync("homeassistant/sensor/garagestack/config", payload);
+
+        await cts.CancelAsync();
+        try { await serviceTask; } catch (OperationCanceledException) { }
+    }
+
+    [Fact]
+    public async Task HandleHaDiscovery_ValidPayload_DoesNotThrowEvenWhenScopeResolutionFails()
+    {
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        var client = new FakeMqttClient();
+        var svc = new TestableMqttConsumerService(new FakePushSender(), client);
+        var serviceTask = svc.RunAsync(cts.Token);
+        await client.WaitForConnectAsync();
+        const string payload = """{"device":{"hw_version":"MG_BEV_1.0","identifiers":["FAKEVN00000000001"],"model":"MG4"}}""";
+
+        // FakeServiceScopeFactory resolves no real services, so the DB write inside
+        // HandleHaDiscoveryAsync will fail - but it's caught and logged, not thrown.
+        await client.TriggerMessageAsync("homeassistant/sensor/garagestack/config", payload);
+
+        await cts.CancelAsync();
+        try { await serviceTask; } catch (OperationCanceledException) { }
     }
 }

--- a/src/GarageStack.Tests/PushSenderServiceTests.cs
+++ b/src/GarageStack.Tests/PushSenderServiceTests.cs
@@ -1,0 +1,90 @@
+using System.Security.Cryptography;
+using GarageStack.Worker.Services;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace GarageStack.Tests;
+
+// FakeServiceScopeFactory / FakePushSender live in WorkerTestFakes.cs.
+//
+// Full delivery (dead-subscription pruning, pg_notify payload) needs a working
+// AppDbContext + PushSubscriptions from the DI scope, which FakeServiceScopeFactory
+// deliberately doesn't provide. These tests cover what's reachable without that: the
+// VAPID-not-configured fallback path, which is the only path that completes without
+// ever needing a real scope.
+
+file sealed class NoopHttpClientFactory : IHttpClientFactory
+{
+    public HttpClient CreateClient(string name) => new();
+}
+
+public class PushSenderServiceTests
+{
+    private static IConfiguration BuildConfig(string? publicKey = null, string? privateKey = null)
+    {
+        var dict = new Dictionary<string, string?>();
+        if (publicKey is not null) dict["Vapid:PublicKey"] = publicKey;
+        if (privateKey is not null) dict["Vapid:PrivateKey"] = privateKey;
+        return new ConfigurationBuilder().AddInMemoryCollection(dict).Build();
+    }
+
+    private static PushSenderService BuildService(string? publicKey = null, string? privateKey = null) =>
+        new(
+            NullLogger<PushSenderService>.Instance,
+            new FakeServiceScopeFactory(),
+            BuildConfig(publicKey, privateKey),
+            new NoopHttpClientFactory());
+
+    // VapidAuthentication validates key shape eagerly (65-byte uncompressed P-256 public
+    // key, 32-byte private scalar), so "both keys set" needs a real - if freshly generated
+    // and otherwise meaningless - key pair rather than placeholder strings.
+    private static (string PublicKey, string PrivateKey) GenerateFakeVapidKeyPair()
+    {
+        using var ecdsa = ECDsa.Create(ECCurve.NamedCurves.nistP256);
+        var p = ecdsa.ExportParameters(true);
+        var publicKeyBytes = new byte[65];
+        publicKeyBytes[0] = 0x04;
+        Buffer.BlockCopy(p.Q.X!, 0, publicKeyBytes, 1, 32);
+        Buffer.BlockCopy(p.Q.Y!, 0, publicKeyBytes, 33, 32);
+        return (Base64UrlEncode(publicKeyBytes), Base64UrlEncode(p.D!));
+    }
+
+    private static string Base64UrlEncode(byte[] data) =>
+        Convert.ToBase64String(data).TrimEnd('=').Replace('+', '-').Replace('/', '_');
+
+    [Fact]
+    public void IsConfigured_NoVapidKeys_ReturnsFalse()
+    {
+        using var svc = BuildService();
+
+        Assert.False(svc.IsConfigured);
+    }
+
+    [Fact]
+    public void IsConfigured_OnlyPublicKeySet_ReturnsFalse()
+    {
+        using var svc = BuildService(publicKey: "some-public-key");
+
+        Assert.False(svc.IsConfigured);
+    }
+
+    [Fact]
+    public void IsConfigured_BothKeysSet_ReturnsTrue()
+    {
+        var (publicKey, privateKey) = GenerateFakeVapidKeyPair();
+        using var svc = BuildService(publicKey, privateKey);
+
+        Assert.True(svc.IsConfigured);
+    }
+
+    [Fact]
+    public async Task SendToAllAsync_NoVapidKeys_CompletesWithoutThrowing()
+    {
+        using var svc = BuildService();
+
+        // The record-persist step also fails silently (FakeServiceScopeFactory resolves no
+        // real AppDbContext), and push delivery is skipped entirely since IsConfigured is
+        // false - neither failure should propagate out of SendToAllAsync.
+        await svc.SendToAllAsync("Test", "Body", CancellationToken.None);
+    }
+}


### PR DESCRIPTION
## Summary
Two of the three zero-coverage areas from an earlier full-project review (`PoiPreCachingService`, `PushSenderService`, and `MqttConsumerService`'s merge/persist + HA discovery flow all had zero tests).

Went with the lighter-touch option here rather than building a full DI test harness (real in-memory-DB-backed `IServiceScopeFactory` + fake HTTP clients) - see "Not included" below for what that would unlock.

- **`MqttConsumerService.HandleHaDiscoveryAsync`** - added a `TriggerMessageAsync` helper to the existing `FakeMqttClient` test double and 8 tests covering the early-return guards (missing `hw_version`, missing `identifiers`, missing `device` property, empty/non-string `identifiers` array) plus invalid JSON and a fully-valid payload. All of this logic resolves before (or independently of) the DI scope, so it's reachable with the existing null-service `FakeServiceScopeFactory`. Assertion is that malformed/incomplete payloads never crash the message pipeline, matching the method's early-return / catch-and-log design.
- **`PushSenderService`** - had zero tests at all. `FakeServiceScopeFactory` deliberately resolves no real services, so the only path reachable without new infrastructure is VAPID-not-configured. Added tests for `IsConfigured` under various key configurations (including a real freshly-generated EC P-256 key pair, since `VapidAuthentication` validates key shape eagerly and rejects placeholder strings) and confirmed `SendToAllAsync` completes without throwing when push isn't configured.

## Not included
**`PoiPreCachingService`** has no reachable-without-infrastructure path at all - unlike the other two, every branch immediately needs a working `AppDbContext` + `IPoiRepository` + `OverpassApiClient`/`OcmApiClient` from the DI scope, so there's no early-return logic to test in isolation. Covering it (tile-refresh gating, vehicle-type -> POI-type routing, per-tile error-swallow path) needs the shared DI harness this PR intentionally skips.

Also not covered: `PushSenderService`'s actual delivery logic (dead-subscription pruning, concurrent delivery, `pg_notify` payload shape) and `MqttConsumerService`'s telemetry merge-window row-collapsing - both require the same real-scope infrastructure.

## Test plan
- [x] `dotnet build` succeeds
- [x] `dotnet test` passes (263/263 - 12 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)