### PR TITLE
chore(deps): bump MQTTnet/Scalar.AspNetCore, fix Microsoft.OpenApi 3.x break

### DIFF
--- a/src/GarageStack.Api/GarageStack.Api.csproj
+++ b/src/GarageStack.Api/GarageStack.Api.csproj
@@ -13,15 +13,18 @@
     <PackageReference Include="MinVer" Version="7.0.0" PrivateAssets="all" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.9" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.9" />
-    <!-- Pinned above the transitive 2.0.0 pulled in by Microsoft.AspNetCore.OpenApi 10.0.9 to avoid CVE-2026-49451 (stack overflow on circular schema refs). -->
-    <PackageReference Include="Microsoft.OpenApi" Version="2.7.6" />
+    <!-- Pinned above the transitive 2.0.0 pulled in by Microsoft.AspNetCore.OpenApi 10.0.9 to avoid CVE-2026-49451 (stack overflow on circular schema refs).
+         Stay on the 2.x line - Microsoft.OpenApi 3.x breaks Microsoft.AspNetCore.OpenApi 10.0.9 at
+         both compile time (XmlCommentGenerator) and runtime (OpenApiResponse.Content no longer
+         exists in the same form), and no compatible Microsoft.AspNetCore.OpenApi release exists yet. -->
+    <PackageReference Include="Microsoft.OpenApi" Version="2.9.0" />
     <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="8.19.1" />
-    <PackageReference Include="MQTTnet" Version="5.1.0.1559" />
+    <PackageReference Include="MQTTnet" Version="5.2.0.1603" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.9">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Scalar.AspNetCore" Version="2.16.6" />
+    <PackageReference Include="Scalar.AspNetCore" Version="2.16.9" />
     <PackageReference Include="Serilog.AspNetCore" Version="10.0.0" />
     <PackageReference Include="Serilog.Extensions.Hosting" Version="10.0.0" />
     <PackageReference Include="Serilog.Settings.Configuration" Version="10.0.1" />

--- a/src/GarageStack.Worker/GarageStack.Worker.csproj
+++ b/src/GarageStack.Worker/GarageStack.Worker.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="MinVer" Version="7.0.0" PrivateAssets="all" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.9" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.9" />
-    <PackageReference Include="MQTTnet" Version="5.1.0.1559" />
+    <PackageReference Include="MQTTnet" Version="5.2.0.1603" />
     <PackageReference Include="Lib.Net.Http.WebPush" Version="3.3.1" />
     <PackageReference Include="Serilog.Extensions.Hosting" Version="10.0.0" />
     <PackageReference Include="Serilog.Settings.Configuration" Version="10.0.1" />


### PR DESCRIPTION
## Summary
Found while working on an unrelated task: the working tree had uncommitted package bumps (`MQTTnet` 5.1.0->5.2.0.1603, `Scalar.AspNetCore` 2.16.6->2.16.9, `Microsoft.OpenApi` 2.7.6->3.7.0) that broke the build.

- `MQTTnet` and `Scalar.AspNetCore` bumps are fine, kept as-is.
- `Microsoft.OpenApi` 3.7.0 is **not compatible** with `Microsoft.AspNetCore.OpenApi` 10.0.9 (the current stable release for .NET 10):
  - **Compile time**: the bundled `XmlCommentGenerator` source generator hard-codes a call to `IOpenApiMediaType.Example`'s setter, which v3 made read-only.
  - **Runtime**: `OpenApiResponse.Content` no longer exists in the same form, so `GET /openapi/v1.json` and the Scalar UI threw `MissingMethodException` -> 500 on every single request. This isn't a cosmetic issue - the API's own docs endpoint was completely broken.
  - No stable `Microsoft.AspNetCore.OpenApi` release supports `Microsoft.OpenApi` 3.x yet (checked NuGet - latest stable is still 10.0.9; only a `11.0.0-preview` series exists targeting the next .NET major version).
- Pinned `Microsoft.OpenApi` to **2.9.0** instead - the latest 2.x release, still well above the `2.0.0` version the existing pin comment warns is vulnerable to CVE-2026-49451.

## Test plan
- [x] Clean rebuild of the whole solution succeeds
- [x] `dotnet test` passes (268/268)
- [x] Started the API and confirmed `GET /openapi/v1.json` returns 200 with a valid OpenAPI document (was 500 with `Microsoft.OpenApi` 3.7.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)