### PR TITLE
fix: log-forging security fix, command validation, and query optimization

### DIFF
--- a/src/GarageStack.Api/Endpoints/AuthEndpoints.cs
+++ b/src/GarageStack.Api/Endpoints/AuthEndpoints.cs
@@ -72,7 +72,7 @@ public static class AuthEndpoints
             {
                 logger.LogWarning(
                     "Failed login attempt for username={Username} from IP={RemoteIp}",
-                    providedUsername, httpContext.Connection.RemoteIpAddress);
+                    SanitizeForLog(providedUsername), httpContext.Connection.RemoteIpAddress);
                 return Results.Unauthorized();
             }
 
@@ -140,6 +140,9 @@ public static class AuthEndpoints
 
         return null;
     }
+
+    private static string SanitizeForLog(string value) =>
+        value.Replace("\r", string.Empty).Replace("\n", string.Empty);
 
     private static bool FixedTimeEquals(string left, string right)
     {

--- a/src/GarageStack.Api/Endpoints/AuthEndpoints.cs
+++ b/src/GarageStack.Api/Endpoints/AuthEndpoints.cs
@@ -144,7 +144,7 @@ public static class AuthEndpoints
     private static string SanitizeForLog(string value) =>
         value.Replace("\r", string.Empty).Replace("\n", string.Empty);
 
-    private static bool FixedTimeEquals(string left, string right)
+    internal static bool FixedTimeEquals(string left, string right)
     {
         // Hash both values first so the compared buffers always have identical length.
         var leftBytes = SHA256.HashData(Encoding.UTF8.GetBytes(left));

--- a/src/GarageStack.Api/Endpoints/VehicleEndpoints.cs
+++ b/src/GarageStack.Api/Endpoints/VehicleEndpoints.cs
@@ -291,7 +291,9 @@ public static class VehicleEndpoints
             value is "True" or "False" ? null : "'lock' value must be 'True' or 'False'",
         "refresh" =>
             value == "force" ? null : "'refresh' value must be 'force'",
-        _ => null  // scheduled-charging: accept any non-empty string
+        // scheduled-charging: the SAIC API expects a JSON blob (mode + start/end time), whose
+        // shape isn't validated here; just cap the length forwarded to MQTT.
+        _ => value.Length <= 500 ? null : "value is too long"
     };
 }
 

--- a/src/GarageStack.Data/Repositories/TelemetryRepository.cs
+++ b/src/GarageStack.Data/Repositories/TelemetryRepository.cs
@@ -418,15 +418,16 @@ public class TelemetryRepository(AppDbContext db, ILogger<TelemetryRepository>? 
 
     public async Task<VehicleAggregateStats> GetAggregateStatsAsync(int vehicleId, DateTime from, DateTime to, CancellationToken ct = default)
     {
-        var climateKnown = await db.TelemetrySnapshots
+        // Single grouped query instead of two round-trips: total count and the
+        // ClimateOn == true count are both conditional aggregates over the same filtered set.
+        var agg = await db.TelemetrySnapshots
             .Where(s => s.VehicleId == vehicleId && s.RecordedAt >= from && s.RecordedAt <= to && s.ClimateOn != null)
-            .CountAsync(ct);
+            .GroupBy(s => 1)
+            .Select(g => new { Known = g.Count(), On = g.Count(s => s.ClimateOn == true) })
+            .FirstOrDefaultAsync(ct);
 
-        var climateOn = climateKnown > 0
-            ? await db.TelemetrySnapshots
-                .Where(s => s.VehicleId == vehicleId && s.RecordedAt >= from && s.RecordedAt <= to && s.ClimateOn == true)
-                .CountAsync(ct)
-            : 0;
+        var climateKnown = agg?.Known ?? 0;
+        var climateOn = agg?.On ?? 0;
 
         return new VehicleAggregateStats(
             ClimateUsagePct: climateKnown > 0 ? (int)Math.Round((double)climateOn / climateKnown * 100) : null,

--- a/src/GarageStack.Tests/TelemetryRepositoryTests.cs
+++ b/src/GarageStack.Tests/TelemetryRepositoryTests.cs
@@ -365,6 +365,71 @@ public class TelemetryRepositoryTests
         Assert.Equal("On", result.BatteryHeatingScheduleMode);
         Assert.Equal("06:30", result.BatteryHeatingScheduleStartTime);
     }
+
+    // ── GetAggregateStatsAsync tests ─────────────────────────────────────────
+
+    [Fact]
+    public async Task GetAggregateStats_NoSnapshotsWithClimateData_ReturnsNullPercentAndZeroCounts()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        await using var db = CreateDb();
+        var vehicle = new Vehicle { Vin = "STAT00000000000001" };
+        db.Vehicles.Add(vehicle);
+        await db.SaveChangesAsync(ct);
+
+        var now = DateTime.UtcNow;
+        db.TelemetrySnapshots.Add(new TelemetrySnapshot { VehicleId = vehicle.Id, RecordedAt = now, FuelLevelPercent = 50 });
+        await db.SaveChangesAsync(ct);
+
+        var result = await new TelemetryRepository(db).GetAggregateStatsAsync(vehicle.Id, now.AddDays(-1), now.AddDays(1), ct);
+
+        Assert.Null(result.ClimateUsagePct);
+        Assert.Equal(0, result.ClimateOnSnapshots);
+        Assert.Equal(0, result.TotalClimateSnapshots);
+    }
+
+    [Fact]
+    public async Task GetAggregateStats_MixedClimateSnapshots_ComputesCorrectPercentage()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        await using var db = CreateDb();
+        var vehicle = new Vehicle { Vin = "STAT00000000000002" };
+        db.Vehicles.Add(vehicle);
+        await db.SaveChangesAsync(ct);
+
+        var now = DateTime.UtcNow;
+        db.TelemetrySnapshots.AddRange(
+            new TelemetrySnapshot { VehicleId = vehicle.Id, RecordedAt = now.AddMinutes(-1), ClimateOn = true },
+            new TelemetrySnapshot { VehicleId = vehicle.Id, RecordedAt = now.AddMinutes(-2), ClimateOn = true },
+            new TelemetrySnapshot { VehicleId = vehicle.Id, RecordedAt = now.AddMinutes(-3), ClimateOn = false },
+            new TelemetrySnapshot { VehicleId = vehicle.Id, RecordedAt = now.AddMinutes(-4), ClimateOn = false }
+        );
+        await db.SaveChangesAsync(ct);
+
+        var result = await new TelemetryRepository(db).GetAggregateStatsAsync(vehicle.Id, now.AddDays(-1), now.AddDays(1), ct);
+
+        Assert.Equal(50, result.ClimateUsagePct);
+        Assert.Equal(2, result.ClimateOnSnapshots);
+        Assert.Equal(4, result.TotalClimateSnapshots);
+    }
+
+    [Fact]
+    public async Task GetAggregateStats_OutsideDateRange_IsExcluded()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        await using var db = CreateDb();
+        var vehicle = new Vehicle { Vin = "STAT00000000000003" };
+        db.Vehicles.Add(vehicle);
+        await db.SaveChangesAsync(ct);
+
+        var now = DateTime.UtcNow;
+        db.TelemetrySnapshots.Add(new TelemetrySnapshot { VehicleId = vehicle.Id, RecordedAt = now.AddDays(-30), ClimateOn = true });
+        await db.SaveChangesAsync(ct);
+
+        var result = await new TelemetryRepository(db).GetAggregateStatsAsync(vehicle.Id, now.AddDays(-1), now.AddDays(1), ct);
+
+        Assert.Equal(0, result.TotalClimateSnapshots);
+    }
 }
 
 // ── MergeIntoAsync tests ─────────────────────────────────────────────────────

--- a/src/GarageStack.Tests/VehicleCommandValidationTests.cs
+++ b/src/GarageStack.Tests/VehicleCommandValidationTests.cs
@@ -143,4 +143,18 @@ public class VehicleCommandValidationTests
     {
         Assert.Null(VehicleEndpoints.ValidateCommandValue(command, value));
     }
+
+    [Fact]
+    public void ScheduledCharging_ValueOver500Chars_ReturnsError()
+    {
+        var value = new string('a', 501);
+        Assert.NotNull(VehicleEndpoints.ValidateCommandValue("scheduled-charging", value));
+    }
+
+    [Fact]
+    public void ScheduledCharging_ValueExactly500Chars_ReturnsNull()
+    {
+        var value = new string('a', 500);
+        Assert.Null(VehicleEndpoints.ValidateCommandValue("scheduled-charging", value));
+    }
 }


### PR DESCRIPTION
## Summary
- Fix log forging (CWE-117 / CodeQL alert [#452](https://github.com/joszz/GarageStack/security/code-scanning/452)): sanitize the user-supplied username before writing it into the failed-login warning log, preventing CR/LF injection of forged log entries.
- Cap the `scheduled-charging` command value at 500 characters before it's forwarded to MQTT.
- Combine `GetAggregateStatsAsync`'s two separate COUNT queries into a single grouped query.

## Test plan
- [x] `dotnet test src/GarageStack.Tests` — 265/265 passing
- [x] New tests added for the scheduled-charging length cap and the aggregate-stats query behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)