### PR TITLE
chore(deps): stop Dependabot from proposing the Microsoft.OpenApi 3.x…

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -84,6 +84,13 @@ updates:
       time: "07:00"
       timezone: "Europe/Amsterdam"
     open-pull-requests-limit: 6
+    ignore:
+      # Microsoft.OpenApi 3.x breaks Microsoft.AspNetCore.OpenApi 10.0.9 at both compile
+      # time and runtime (see the pin comment on the Microsoft.OpenApi PackageReference
+      # in GarageStack.Api.csproj) - no compatible Microsoft.AspNetCore.OpenApi release
+      # exists yet. Only block the major bump; keep getting 2.x patch/minor updates.
+      - dependency-name: "Microsoft.OpenApi"
+        update-types: ["version-update:semver-major"]
     groups:
       # The whole Microsoft .NET / ASP.NET / Extensions family ships on the same
       # cadence (patch Tuesday), so one PR covers all of them.


### PR DESCRIPTION
… major bump

PR #217 re-proposed the exact 2.9.0 -> 3.7.0 upgrade that was already tried and reverted in 2b857a3: Microsoft.OpenApi 3.x breaks Microsoft.AspNetCore.OpenApi 10.0.9 at compile time (XmlCommentGenerator) and runtime (OpenApiResponse.Content), and no compatible Microsoft.AspNetCore.OpenApi release exists yet. Ignoring only semver-major updates for this dependency, so 2.x patch/minor releases (e.g. security fixes) still come through automatically until the ecosystem catches up and the pin can be lifted.

# Pull Request

## Summary

Describe what this PR does and why.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] Dependency update
- [ ] Other

## Related Issues

Closes #

## Checklist

- [ ] Tests added or updated
- [ ] Linting passes (`pnpm lint` / `dotnet build`)
- [ ] No secrets or personal data committed
- [ ] Responsive on mobile
- [ ] i18n keys added for any new UI strings
