### PR TITLE
Show in-progress trip on the dashboard location preview

### DIFF
--- a/frontend/src/assets/main.css
+++ b/frontend/src/assets/main.css
@@ -933,6 +933,23 @@ body,
   fill: #2d2d2d;
 }
 
+/* Live car marker (buildCarMarkerIcon in utils/mapCarIcon.ts) - used on both MapView and the
+   dashboard's location preview, so it lives here rather than in either view's own <style>
+   block to guarantee it's loaded regardless of which route the user opens first. */
+.trip-marker--active {
+  width: 24px;
+  height: 46px;
+  pointer-events: none;
+  transform-origin: center;
+  filter: drop-shadow(0 1px 3px rgba(0, 0, 0, 0.5));
+}
+
+.trip-marker-car-svg {
+  width: 100%;
+  height: 100%;
+  display: block;
+}
+
 /* ── Tyre pressure indicator lines ───────────────────────── */
 
 .tyre-indicator-line {

--- a/frontend/src/components/LocationMapWidget.vue
+++ b/frontend/src/components/LocationMapWidget.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, nextTick, onUnmounted, ref, watch } from 'vue'
+import { computed, nextTick, onUnmounted, ref, shallowRef, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useRouter } from 'vue-router'
 import { LMap, LTileLayer, LMarker } from '@vue-leaflet/vue-leaflet'
@@ -47,7 +47,7 @@ const mapOptions = {
 }
 
 const mapWrapperRef = ref<HTMLElement | null>(null)
-const mapInstance = ref<LeafletMap | null>(null)
+const mapInstance = shallowRef<LeafletMap | null>(null)
 let resizeObserver: ResizeObserver | null = null
 let routeLine: L.Polyline | null = null
 let carMarker: L.Marker | null = null

--- a/frontend/src/components/LocationMapWidget.vue
+++ b/frontend/src/components/LocationMapWidget.vue
@@ -3,9 +3,16 @@ import { computed, nextTick, onUnmounted, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useRouter } from 'vue-router'
 import { LMap, LTileLayer, LMarker } from '@vue-leaflet/vue-leaflet'
+import * as LModule from 'leaflet'
 import type { Map as LeafletMap } from 'leaflet'
 import { useVehicleStore } from '@/stores/vehicle'
 import CardInfoWrap from './CardInfoWrap.vue'
+import { buildCarMarkerIcon } from '@/utils/mapCarIcon'
+
+// Vite wraps CJS modules in a frozen ESM namespace - `import * as LModule` gives that frozen
+// namespace, which already exposes the plain (unpatched) Leaflet API this file needs.
+const L = ((LModule as unknown as { default?: typeof LModule }).default ??
+  LModule) as typeof LModule
 
 const { t } = useI18n()
 const router = useRouter()
@@ -20,6 +27,15 @@ const center = computed<[number, number]>(() => [
   status.value?.longitude ?? 0,
 ])
 
+// Same logic as MapView: the backend always appends the still-open segment as the last trip
+// while the car hasn't parked for 5+ minutes, so a positive currentJourneyDistance means that
+// last trip is the one currently being driven.
+const activeTrip = computed(() => {
+  const dist = status.value?.currentJourneyDistance
+  if (dist == null || dist <= 0 || store.trips.length === 0) return null
+  return store.trips[store.trips.length - 1] ?? null
+})
+
 const mapOptions = {
   zoomControl: false,
   dragging: false,
@@ -33,6 +49,32 @@ const mapOptions = {
 const mapWrapperRef = ref<HTMLElement | null>(null)
 const mapInstance = ref<LeafletMap | null>(null)
 let resizeObserver: ResizeObserver | null = null
+let routeLine: L.Polyline | null = null
+let carMarker: L.Marker | null = null
+
+function clearActiveTripLayers() {
+  routeLine?.remove()
+  routeLine = null
+  carMarker?.remove()
+  carMarker = null
+}
+
+// Draws the in-progress trip's route (as recorded so far) plus a live car marker at the
+// current position/heading, in place of the plain pin shown while parked.
+function buildActiveTripLayers() {
+  const map = mapInstance.value
+  const trip = activeTrip.value
+  clearActiveTripLayers()
+  if (!map || !trip || !hasLocation.value) return
+
+  if (trip.points.length >= 2) {
+    const coords = trip.points.map((p) => [p.latitude, p.longitude] as [number, number])
+    routeLine = L.polyline(coords, { color: '#3b82f6', weight: 4, opacity: 0.8 }).addTo(map)
+  }
+  carMarker = L.marker(center.value, {
+    icon: buildCarMarkerIcon(status.value?.heading ?? 0),
+  }).addTo(map)
+}
 
 function onMapReady(map: LeafletMap) {
   mapInstance.value = map
@@ -44,21 +86,39 @@ function onMapReady(map: LeafletMap) {
     requestAnimationFrame(() => {
       map.invalidateSize()
       if (hasLocation.value) map.setView(center.value, 14, { animate: false })
+      buildActiveTripLayers()
     })
   })
 }
 
-// Keep the preview centred on the car as new status updates arrive.
+// Keep the preview centred on the car as new status updates arrive, and keep the live car
+// marker (if the active trip is currently shown) following position/heading without a full
+// layer rebuild.
 watch(status, (s) => {
-  if (mapInstance.value && s?.latitude != null && s?.longitude != null) {
-    mapInstance.value.setView([s.latitude, s.longitude], 14, { animate: false })
+  if (!mapInstance.value || s?.latitude == null || s?.longitude == null) return
+  mapInstance.value.setView([s.latitude, s.longitude], 14, { animate: false })
+  if (carMarker) {
+    carMarker.setLatLng([s.latitude, s.longitude])
+    carMarker.setIcon(buildCarMarkerIcon(s.heading ?? 0))
   }
 })
 
-onUnmounted(() => resizeObserver?.disconnect())
+// Trip start/end, or a refreshed trips fetch: rebuild the route line and car marker.
+watch(activeTrip, () => buildActiveTripLayers())
+
+onUnmounted(() => {
+  resizeObserver?.disconnect()
+  clearActiveTripLayers()
+})
 
 function openFullMap() {
-  router.push({ name: 'map' })
+  // Same deep-link MapView already supports for the "active trip" dashboard card - it
+  // auto-selects the last trip in the list, which is the in-progress one when there is one.
+  if (activeTrip.value) {
+    router.push({ name: 'map', query: { selectLatest: '1' } })
+  } else {
+    router.push({ name: 'map' })
+  }
 }
 </script>
 
@@ -83,7 +143,7 @@ function openFullMap() {
             url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
             attribution="© OpenStreetMap contributors"
           />
-          <LMarker :lat-lng="center" />
+          <LMarker v-if="!activeTrip" :lat-lng="center" />
         </LMap>
         <div v-else class="location-map-card__empty">
           <font-awesome-icon icon="location-dot" />

--- a/frontend/src/utils/mapCarIcon.ts
+++ b/frontend/src/utils/mapCarIcon.ts
@@ -1,0 +1,28 @@
+import * as LModule from 'leaflet'
+import { CAR_SILHOUETTE_VIEWBOX, CAR_SILHOUETTE_MARKUP } from '@/assets/carSilhouette'
+
+// Vite wraps CJS modules in a frozen ESM namespace - `import * as LModule` gives that frozen
+// namespace, which already exposes the plain (unpatched) Leaflet API this file needs.
+const L = ((LModule as unknown as { default?: typeof LModule }).default ??
+  LModule) as typeof LModule
+
+const CAR_ICON_SIZE: [number, number] = [24, 46]
+const CAR_ICON_ANCHOR: [number, number] = [12, 23]
+
+// Live car icon marking the vehicle's current position while a trip is in progress - used by
+// both MapView (replacing the end-of-trip flag) and the dashboard's location preview. Rotated
+// to the vehicle's current heading (0deg = north, matching the silhouette's forward-facing-up
+// artwork). See .trip-marker--active / .trip-marker-car-svg in main.css for styling - kept
+// there (not view-scoped CSS) so it renders correctly even when MapView's own chunk hasn't
+// loaded yet.
+export function buildCarMarkerIcon(headingDeg: number) {
+  const heading = Number.isFinite(headingDeg) ? headingDeg : 0
+  return L.divIcon({
+    className: '',
+    html: `<div class="trip-marker trip-marker--active" style="transform: rotate(${heading}deg)">
+      <svg viewBox="${CAR_SILHOUETTE_VIEWBOX}" class="trip-marker-car-svg">${CAR_SILHOUETTE_MARKUP}</svg>
+    </div>`,
+    iconSize: CAR_ICON_SIZE,
+    iconAnchor: CAR_ICON_ANCHOR,
+  })
+}

--- a/frontend/src/views/MapView.vue
+++ b/frontend/src/views/MapView.vue
@@ -18,7 +18,7 @@ import type { Map as LeafletMap } from 'leaflet'
 import 'leaflet.heat'
 import '@/assets/map.css'
 import type { Trip } from '@/services/vehicleApi'
-import { CAR_SILHOUETTE_VIEWBOX, CAR_SILHOUETTE_MARKUP } from '@/assets/carSilhouette'
+import { buildCarMarkerIcon } from '@/utils/mapCarIcon'
 
 // Vite wraps CJS modules in a frozen ESM namespace - `import * as LModule` gives that frozen
 // namespace. leaflet.heat patches the actual mutable CJS export (LModule.default), so we must
@@ -327,21 +327,6 @@ function buildSelectedLine() {
   }
 
   buildTripMarkers(trip, idx)
-}
-
-// Live car icon used for a trip's endpoint while it is still in progress, in place of the
-// static end flag - rotated to the vehicle's current heading (0deg = north, matching the
-// silhouette's default forward-facing-up orientation).
-function buildCarMarkerIcon(headingDeg: number) {
-  const heading = Number.isFinite(headingDeg) ? headingDeg : 0
-  return L.divIcon({
-    className: '',
-    html: `<div class="trip-marker trip-marker--active" style="transform: rotate(${heading}deg)">
-      <svg viewBox="${CAR_SILHOUETTE_VIEWBOX}" class="trip-marker-car-svg">${CAR_SILHOUETTE_MARKUP}</svg>
-    </div>`,
-    iconSize: [24, 46],
-    iconAnchor: [12, 23],
-  })
 }
 
 function buildTripMarkers(trip: Trip, realIdx: number) {
@@ -949,20 +934,6 @@ onUnmounted(() => {
   70% {
     transform: skewY(3deg) scaleX(0.97);
   }
-}
-
-.trip-marker--active {
-  width: 24px;
-  height: 46px;
-  pointer-events: none;
-  transform-origin: center;
-  filter: drop-shadow(0 1px 3px rgba(0, 0, 0, 0.5));
-}
-
-.trip-marker-car-svg {
-  width: 100%;
-  height: 100%;
-  display: block;
 }
 
 .trip-list__dot--live {


### PR DESCRIPTION
## Summary
- LocationMapWidget (the dashboard's small location preview) now uses the same active-trip detection as MapView (`currentJourneyDistance > 0` on the vehicle's last trip) to draw the route driven so far plus a live car marker rotated to heading, in place of the plain pin, while a trip is in progress.
- Extracted `buildCarMarkerIcon` out of MapView.vue into `frontend/src/utils/mapCarIcon.ts` so both views build the identical marker instead of duplicating it.
- Moved the marker's CSS (`.trip-marker--active` / `.trip-marker-car-svg`) into `main.css`, since MapView's route chunk is lazy-loaded and wouldn't be present yet if the dashboard is the first page opened.
- Clicking the location widget while a trip is in progress now opens the full map with that trip pre-selected (reusing MapView's existing `selectLatest` deep-link); otherwise it opens the map with no selection, as before.

## Test plan
- [x] `pnpm test:unit` — 144 frontend tests pass
- [x] `vue-tsc --noEmit` — no type errors
- [x] Manually verified in the demo instance via a headless browser: dashboard preview shows the route + live car icon, and clicking it while a trip is in progress lands on `/map?selectLatest=1` with that trip selected and highlighted

🤖 Generated with [Claude Code](https://claude.com/claude-code)