### PR TITLE
Deduplicate repeated logic across backend and frontend

### DIFF
--- a/frontend/src/components/CarDiagram.vue
+++ b/frontend/src/components/CarDiagram.vue
@@ -46,6 +46,74 @@ function fmt(bar: number | null): string {
   return bar !== null ? bar.toFixed(2) : '-'
 }
 
+// Tyre indicator line/dot endpoints - see the ViewBox comment above the template for how
+// these coordinates were derived from the car body bounds.
+const tyreIndicators = computed(() => [
+  { key: 'frontLeft', value: props.frontLeft, x1: 110, y1: 145, x2: 72, y2: 131, cx: 110, cy: 145 },
+  {
+    key: 'frontRight',
+    value: props.frontRight,
+    x1: 230,
+    y1: 145,
+    x2: 268,
+    y2: 131,
+    cx: 230,
+    cy: 145,
+  },
+  { key: 'rearLeft', value: props.rearLeft, x1: 110, y1: 327, x2: 72, y2: 341, cx: 110, cy: 327 },
+  {
+    key: 'rearRight',
+    value: props.rearRight,
+    x1: 230,
+    y1: 327,
+    x2: 268,
+    y2: 341,
+    cx: 230,
+    cy: 327,
+  },
+])
+
+const tyreLabels = computed(() => [
+  { key: 'frontLeft', suffix: 'fl', value: props.frontLeft },
+  { key: 'frontRight', suffix: 'fr', value: props.frontRight },
+  { key: 'rearLeft', suffix: 'rl', value: props.rearLeft },
+  { key: 'rearRight', suffix: 'rr', value: props.rearRight },
+])
+
+const doorBadges = computed(() => [
+  {
+    key: 'bonnet',
+    open: props.bonnetOpen,
+    suffix: 'bonnet',
+    titleKey: 'vehicle.doors_detail.bonnet',
+  },
+  {
+    key: 'driver',
+    open: props.driverDoorOpen,
+    suffix: 'door-fl',
+    titleKey: 'vehicle.doors_detail.driver',
+  },
+  {
+    key: 'passenger',
+    open: props.passengerDoorOpen,
+    suffix: 'door-fr',
+    titleKey: 'vehicle.doors_detail.passenger',
+  },
+  {
+    key: 'rearLeft',
+    open: props.rearLeftDoorOpen,
+    suffix: 'door-rl',
+    titleKey: 'vehicle.doors_detail.rearLeft',
+  },
+  {
+    key: 'rearRight',
+    open: props.rearRightDoorOpen,
+    suffix: 'door-rr',
+    titleKey: 'vehicle.doors_detail.rearRight',
+  },
+  { key: 'trunk', open: props.trunkOpen, suffix: 'trunk', titleKey: 'vehicle.doors_detail.boot' },
+])
+
 const hasLights = computed(() => props.lightsMainBeam || props.lightsDippedBeam || props.lightsSide)
 
 const showBattery = computed(() => props.evSocPercent != null)
@@ -356,88 +424,25 @@ const activeLightKey = computed(() => {
             </g>
 
             <!-- Tyre pressure indicator lines -->
-            <g>
+            <g v-for="tyre in tyreIndicators" :key="tyre.key">
               <title>
-                {{ t('vehicle.diagram.tyrePosition.frontLeft') }}: {{ fmt(frontLeft) }}
+                {{ t(`vehicle.diagram.tyrePosition.${tyre.key}`) }}: {{ fmt(tyre.value) }}
                 {{ t('common.bar') }}
               </title>
               <line
-                x1="110"
-                y1="145"
-                x2="72"
-                y2="131"
+                :x1="tyre.x1"
+                :y1="tyre.y1"
+                :x2="tyre.x2"
+                :y2="tyre.y2"
                 class="tyre-indicator-line"
-                :stroke="pressureColor(frontLeft)"
+                :stroke="pressureColor(tyre.value)"
               />
               <circle
-                cx="110"
-                cy="145"
+                :cx="tyre.cx"
+                :cy="tyre.cy"
                 r="5"
                 class="tyre-indicator-dot"
-                :fill="pressureColor(frontLeft)"
-              />
-            </g>
-            <g>
-              <title>
-                {{ t('vehicle.diagram.tyrePosition.frontRight') }}: {{ fmt(frontRight) }}
-                {{ t('common.bar') }}
-              </title>
-              <line
-                x1="230"
-                y1="145"
-                x2="268"
-                y2="131"
-                class="tyre-indicator-line"
-                :stroke="pressureColor(frontRight)"
-              />
-              <circle
-                cx="230"
-                cy="145"
-                r="5"
-                class="tyre-indicator-dot"
-                :fill="pressureColor(frontRight)"
-              />
-            </g>
-            <g>
-              <title>
-                {{ t('vehicle.diagram.tyrePosition.rearLeft') }}: {{ fmt(rearLeft) }}
-                {{ t('common.bar') }}
-              </title>
-              <line
-                x1="110"
-                y1="327"
-                x2="72"
-                y2="341"
-                class="tyre-indicator-line"
-                :stroke="pressureColor(rearLeft)"
-              />
-              <circle
-                cx="110"
-                cy="327"
-                r="5"
-                class="tyre-indicator-dot"
-                :fill="pressureColor(rearLeft)"
-              />
-            </g>
-            <g>
-              <title>
-                {{ t('vehicle.diagram.tyrePosition.rearRight') }}: {{ fmt(rearRight) }}
-                {{ t('common.bar') }}
-              </title>
-              <line
-                x1="230"
-                y1="327"
-                x2="268"
-                y2="341"
-                class="tyre-indicator-line"
-                :stroke="pressureColor(rearRight)"
-              />
-              <circle
-                cx="230"
-                cy="327"
-                r="5"
-                class="tyre-indicator-dot"
-                :fill="pressureColor(rearRight)"
+                :fill="pressureColor(tyre.value)"
               />
             </g>
           </svg>
@@ -445,78 +450,30 @@ const activeLightKey = computed(() => {
           <!-- Tyre pressure labels -->
           <div class="tyre-labels">
             <div
-              class="tyre-label tyre-label--fl"
-              :class="`tyre-label--${pressureVariant(frontLeft)}`"
-              :title="t('vehicle.diagram.tyrePosition.frontLeft')"
+              v-for="label in tyreLabels"
+              :key="label.key"
+              :class="[
+                'tyre-label',
+                `tyre-label--${label.suffix}`,
+                `tyre-label--${pressureVariant(label.value)}`,
+              ]"
+              :title="t(`vehicle.diagram.tyrePosition.${label.key}`)"
             >
-              {{ fmt(frontLeft) }} {{ t('common.bar') }}
-            </div>
-            <div
-              class="tyre-label tyre-label--fr"
-              :class="`tyre-label--${pressureVariant(frontRight)}`"
-              :title="t('vehicle.diagram.tyrePosition.frontRight')"
-            >
-              {{ fmt(frontRight) }} {{ t('common.bar') }}
-            </div>
-            <div
-              class="tyre-label tyre-label--rl"
-              :class="`tyre-label--${pressureVariant(rearLeft)}`"
-              :title="t('vehicle.diagram.tyrePosition.rearLeft')"
-            >
-              {{ fmt(rearLeft) }} {{ t('common.bar') }}
-            </div>
-            <div
-              class="tyre-label tyre-label--rr"
-              :class="`tyre-label--${pressureVariant(rearRight)}`"
-              :title="t('vehicle.diagram.tyrePosition.rearRight')"
-            >
-              {{ fmt(rearRight) }} {{ t('common.bar') }}
+              {{ fmt(label.value) }} {{ t('common.bar') }}
             </div>
           </div>
 
           <!-- Open panel icon badges – positioned over SVG at each panel location -->
-          <div
-            v-if="bonnetOpen"
-            class="car-badge car-badge--bonnet"
-            :title="t('vehicle.doors_detail.bonnet')"
-          >
-            <font-awesome-icon icon="lock-open" />
-          </div>
-          <div
-            v-if="driverDoorOpen"
-            class="car-badge car-badge--door-fl"
-            :title="t('vehicle.doors_detail.driver')"
-          >
-            <font-awesome-icon icon="lock-open" />
-          </div>
-          <div
-            v-if="passengerDoorOpen"
-            class="car-badge car-badge--door-fr"
-            :title="t('vehicle.doors_detail.passenger')"
-          >
-            <font-awesome-icon icon="lock-open" />
-          </div>
-          <div
-            v-if="rearLeftDoorOpen"
-            class="car-badge car-badge--door-rl"
-            :title="t('vehicle.doors_detail.rearLeft')"
-          >
-            <font-awesome-icon icon="lock-open" />
-          </div>
-          <div
-            v-if="rearRightDoorOpen"
-            class="car-badge car-badge--door-rr"
-            :title="t('vehicle.doors_detail.rearRight')"
-          >
-            <font-awesome-icon icon="lock-open" />
-          </div>
-          <div
-            v-if="trunkOpen"
-            class="car-badge car-badge--trunk"
-            :title="t('vehicle.doors_detail.boot')"
-          >
-            <font-awesome-icon icon="lock-open" />
-          </div>
+          <template v-for="badge in doorBadges" :key="badge.key">
+            <div
+              v-if="badge.open"
+              class="car-badge"
+              :class="`car-badge--${badge.suffix}`"
+              :title="t(badge.titleKey)"
+            >
+              <font-awesome-icon icon="lock-open" />
+            </div>
+          </template>
 
           <!-- Fuel level (front) -->
           <div

--- a/frontend/src/components/ClimateDetailCard.vue
+++ b/frontend/src/components/ClimateDetailCard.vue
@@ -3,6 +3,7 @@ import { computed, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import ExpandableStatusCard from './ExpandableStatusCard.vue'
 import DetailListItem from './DetailListItem.vue'
+import CommandButton from './CommandButton.vue'
 import { useVehicleCommand } from '@/composables/useVehicleCommand'
 
 const { t } = useI18n()
@@ -316,17 +317,15 @@ function onSeatRightChange(e: Event) {
       <button class="btn btn-outline-secondary" @click="close">
         {{ t('common.cancel') }}
       </button>
-      <button
-        class="btn btn-primary"
-        :class="anyPending ? 'btn--pending' : ''"
-        :disabled="sending !== null || !vin || !hasPendingChanges"
+      <CommandButton
+        class="btn-primary"
+        :pending="anyPending"
+        :sending="isApplying"
+        :disabled="!vin || !hasPendingChanges"
+        icon="check"
+        :label="t('common.apply')"
         @click="applyAll"
-      >
-        <font-awesome-icon v-if="isApplying" icon="spinner" spin />
-        <font-awesome-icon v-else-if="anyPending" icon="clock" />
-        <font-awesome-icon v-else icon="check" />
-        {{ anyPending ? t('control.pending') : t('common.apply') }}
-      </button>
+      />
     </template>
   </ExpandableStatusCard>
 </template>

--- a/frontend/src/components/CommandButton.vue
+++ b/frontend/src/components/CommandButton.vue
@@ -1,0 +1,40 @@
+<script setup lang="ts">
+import { useI18n } from 'vue-i18n'
+
+const { t } = useI18n()
+
+withDefaults(
+  defineProps<{
+    /** Whether a prior send for this command is still awaiting vehicle confirmation. */
+    pending: boolean
+    /** Whether the send request itself is currently in flight. */
+    sending: boolean
+    /** Extra condition to disable the button beyond sending/pending (e.g. no VIN yet). */
+    disabled?: boolean
+    /** Idle-state icon. Omit to render no icon at all, in any state (matches icon-less buttons). */
+    icon?: string
+    label: string
+    /** Set false when several buttons share one command key, so pending doesn't blank every label. */
+    showPendingLabel?: boolean
+  }>(),
+  { disabled: false, showPendingLabel: true },
+)
+
+defineEmits<{ click: [] }>()
+</script>
+
+<template>
+  <button
+    class="btn"
+    :class="{ 'btn--pending': pending }"
+    :disabled="sending || pending || disabled"
+    @click="$emit('click')"
+  >
+    <template v-if="icon">
+      <font-awesome-icon v-if="sending" icon="spinner" spin />
+      <font-awesome-icon v-else-if="pending" icon="clock" />
+      <font-awesome-icon v-else :icon="icon" />
+    </template>
+    {{ pending && showPendingLabel ? t('control.pending') : label }}
+  </button>
+</template>

--- a/frontend/src/components/DoorsCard.vue
+++ b/frontend/src/components/DoorsCard.vue
@@ -3,6 +3,7 @@ import { ref, computed, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import ExpandableStatusCard from './ExpandableStatusCard.vue'
 import DetailListItem from './DetailListItem.vue'
+import CommandButton from './CommandButton.vue'
 import { useVehicleCommand } from '@/composables/useVehicleCommand'
 
 const { t } = useI18n()
@@ -119,29 +120,22 @@ async function handleLockToggle() {
           class="detail-list__item-icon"
         />
         <span class="detail-list__item-label">{{ t('control.lockDoors') }}</span>
-        <button
-          class="btn btn-sm"
+        <CommandButton
+          class="btn-sm"
           :class="
             isPending('lock')
-              ? 'btn--pending btn-outline-secondary'
+              ? 'btn-outline-secondary'
               : effectiveLocked
                 ? 'btn-outline-warning'
                 : 'btn-success'
           "
-          :disabled="sending === 'lock' || isPending('lock') || !vin"
+          :pending="isPending('lock')"
+          :sending="sending === 'lock'"
+          :disabled="!vin"
+          :icon="effectiveLocked ? 'lock-open' : 'lock'"
+          :label="effectiveLocked ? t('control.unlock') : t('control.lock')"
           @click="handleLockToggle"
-        >
-          <font-awesome-icon v-if="sending === 'lock'" icon="spinner" spin />
-          <font-awesome-icon v-else-if="isPending('lock')" icon="clock" />
-          <font-awesome-icon v-else :icon="effectiveLocked ? 'lock-open' : 'lock'" />
-          {{
-            isPending('lock')
-              ? t('control.pending')
-              : effectiveLocked
-                ? t('control.unlock')
-                : t('control.lock')
-          }}
-        </button>
+        />
       </div>
       <div
         v-if="lastResult?.key === 'lock' && !lastResult.ok && !isPending('lock')"

--- a/frontend/src/components/EditableCardSlot.vue
+++ b/frontend/src/components/EditableCardSlot.vue
@@ -1,0 +1,35 @@
+<script setup lang="ts">
+import { useI18n } from 'vue-i18n'
+
+const { t } = useI18n()
+
+withDefaults(
+  defineProps<{
+    visible: boolean
+    /** False for the two fixed-position dashboard slots (tyre diagram, location map) that aren't part of the draggable list. */
+    draggable?: boolean
+  }>(),
+  { draggable: true },
+)
+
+defineEmits<{ 'toggle-visible': [] }>()
+</script>
+
+<template>
+  <div class="card-slot" :class="{ 'card-slot--hidden': !visible }">
+    <div v-if="draggable" class="card-slot__handle">
+      <font-awesome-icon icon="grip-lines" />
+    </div>
+    <div class="card-slot__content">
+      <slot />
+    </div>
+    <button
+      class="card-slot__badge"
+      :class="visible ? 'card-slot__badge--hide' : 'card-slot__badge--show'"
+      :aria-label="visible ? t('dashboard.hideCard') : t('dashboard.showCard')"
+      @click.stop="$emit('toggle-visible')"
+    >
+      <font-awesome-icon :icon="visible ? 'xmark' : 'plus'" />
+    </button>
+  </div>
+</template>

--- a/frontend/src/components/FindMyCarCard.vue
+++ b/frontend/src/components/FindMyCarCard.vue
@@ -2,6 +2,7 @@
 import { ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 import ExpandableStatusCard from './ExpandableStatusCard.vue'
+import CommandButton from './CommandButton.vue'
 import { useVehicleCommand } from '@/composables/useVehicleCommand'
 
 const { t } = useI18n()
@@ -34,30 +35,25 @@ async function stop() {
       <button class="btn btn-outline-secondary" @click="close">
         {{ t('common.cancel') }}
       </button>
-      <button
+      <CommandButton
         v-if="!active"
-        class="btn btn-warning"
-        :class="isPending('find-my-car') ? 'btn--pending' : ''"
-        :disabled="sending === 'find-my-car' || isPending('find-my-car') || !vin"
+        class="btn-warning"
+        :pending="isPending('find-my-car')"
+        :sending="sending === 'find-my-car'"
+        :disabled="!vin"
+        icon="bullhorn"
+        :label="t('control.findMyCarActivate')"
         @click="activate"
-      >
-        <font-awesome-icon v-if="sending === 'find-my-car'" icon="spinner" spin />
-        <font-awesome-icon v-else-if="isPending('find-my-car')" icon="clock" />
-        <font-awesome-icon v-else icon="bullhorn" />
-        {{ isPending('find-my-car') ? t('control.pending') : t('control.findMyCarActivate') }}
-      </button>
-      <button
+      />
+      <CommandButton
         v-else
-        class="btn btn-danger"
-        :class="isPending('find-my-car') ? 'btn--pending' : ''"
-        :disabled="sending === 'find-my-car' || isPending('find-my-car')"
+        class="btn-danger"
+        :pending="isPending('find-my-car')"
+        :sending="sending === 'find-my-car'"
+        icon="xmark"
+        :label="t('control.findMyCarStop')"
         @click="stop"
-      >
-        <font-awesome-icon v-if="sending === 'find-my-car'" icon="spinner" spin />
-        <font-awesome-icon v-else-if="isPending('find-my-car')" icon="clock" />
-        <font-awesome-icon v-else icon="xmark" />
-        {{ isPending('find-my-car') ? t('control.pending') : t('control.findMyCarStop') }}
-      </button>
+      />
     </template>
   </ExpandableStatusCard>
 </template>

--- a/frontend/src/components/HvBatteryCard.vue
+++ b/frontend/src/components/HvBatteryCard.vue
@@ -3,6 +3,7 @@ import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import ExpandableStatusCard from './ExpandableStatusCard.vue'
 import DetailListItem from './DetailListItem.vue'
+import CommandButton from './CommandButton.vue'
 import { useVehicleCommand } from '@/composables/useVehicleCommand'
 
 const { t } = useI18n()
@@ -127,38 +128,38 @@ function setChargeLimit(value: string) {
     <div v-if="canSetChargeLimit" class="detail-modal__section">
       <div class="detail-modal__section-title">{{ t('control.chargeLimit') }}</div>
       <div class="modal-btn-group">
-        <button
-          class="btn btn-outline-secondary"
-          :class="isPending('charge-limit') ? 'btn--pending' : ''"
-          :disabled="sending === 'charge-limit' || isPending('charge-limit')"
+        <CommandButton
+          class="btn-outline-secondary"
+          :pending="isPending('charge-limit')"
+          :sending="sending === 'charge-limit'"
+          :show-pending-label="false"
+          label="6 A"
           @click="setChargeLimit('6A')"
-        >
-          6 A
-        </button>
-        <button
-          class="btn btn-outline-secondary"
-          :class="isPending('charge-limit') ? 'btn--pending' : ''"
-          :disabled="sending === 'charge-limit' || isPending('charge-limit')"
+        />
+        <CommandButton
+          class="btn-outline-secondary"
+          :pending="isPending('charge-limit')"
+          :sending="sending === 'charge-limit'"
+          :show-pending-label="false"
+          label="8 A"
           @click="setChargeLimit('8A')"
-        >
-          8 A
-        </button>
-        <button
-          class="btn btn-outline-secondary"
-          :class="isPending('charge-limit') ? 'btn--pending' : ''"
-          :disabled="sending === 'charge-limit' || isPending('charge-limit')"
+        />
+        <CommandButton
+          class="btn-outline-secondary"
+          :pending="isPending('charge-limit')"
+          :sending="sending === 'charge-limit'"
+          :show-pending-label="false"
+          label="16 A"
           @click="setChargeLimit('16A')"
-        >
-          16 A
-        </button>
-        <button
-          class="btn btn-success"
-          :class="isPending('charge-limit') ? 'btn--pending' : ''"
-          :disabled="sending === 'charge-limit' || isPending('charge-limit')"
+        />
+        <CommandButton
+          class="btn-success"
+          :pending="isPending('charge-limit')"
+          :sending="sending === 'charge-limit'"
+          :show-pending-label="false"
+          label="Max"
           @click="setChargeLimit('Max')"
-        >
-          Max
-        </button>
+        />
       </div>
       <div v-if="isPending('charge-limit')" class="detail-list__feedback text-info">
         <font-awesome-icon icon="clock" />

--- a/frontend/src/components/LocationMapWidget.vue
+++ b/frontend/src/components/LocationMapWidget.vue
@@ -1,18 +1,13 @@
 <script setup lang="ts">
-import { computed, nextTick, onUnmounted, ref, shallowRef, watch } from 'vue'
+import { computed, onUnmounted, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useRouter } from 'vue-router'
 import { LMap, LTileLayer, LMarker } from '@vue-leaflet/vue-leaflet'
-import * as LModule from 'leaflet'
-import type { Map as LeafletMap } from 'leaflet'
+import { L, type LeafletMap } from '@/utils/leaflet'
+import { useLeafletMap } from '@/composables/useLeafletMap'
 import { useVehicleStore } from '@/stores/vehicle'
 import CardInfoWrap from './CardInfoWrap.vue'
 import { buildCarMarkerIcon } from '@/utils/mapCarIcon'
-
-// Vite wraps CJS modules in a frozen ESM namespace - `import * as LModule` gives that frozen
-// namespace, which already exposes the plain (unpatched) Leaflet API this file needs.
-const L = ((LModule as unknown as { default?: typeof LModule }).default ??
-  LModule) as typeof LModule
 
 const { t } = useI18n()
 const router = useRouter()
@@ -47,8 +42,7 @@ const mapOptions = {
 }
 
 const mapWrapperRef = ref<HTMLElement | null>(null)
-const mapInstance = shallowRef<LeafletMap | null>(null)
-let resizeObserver: ResizeObserver | null = null
+const { mapInstance, bindMapReady } = useLeafletMap(mapWrapperRef)
 let routeLine: L.Polyline | null = null
 let carMarker: L.Marker | null = null
 
@@ -77,17 +71,9 @@ function buildActiveTripLayers() {
 }
 
 function onMapReady(map: LeafletMap) {
-  mapInstance.value = map
-  if (mapWrapperRef.value) {
-    resizeObserver = new ResizeObserver(() => map.invalidateSize())
-    resizeObserver.observe(mapWrapperRef.value)
-  }
-  nextTick(() => {
-    requestAnimationFrame(() => {
-      map.invalidateSize()
-      if (hasLocation.value) map.setView(center.value, 14, { animate: false })
-      buildActiveTripLayers()
-    })
+  bindMapReady(map, () => {
+    if (hasLocation.value) map.setView(center.value, 14, { animate: false })
+    buildActiveTripLayers()
   })
 }
 
@@ -107,7 +93,6 @@ watch(status, (s) => {
 watch(activeTrip, () => buildActiveTripLayers())
 
 onUnmounted(() => {
-  resizeObserver?.disconnect()
   clearActiveTripLayers()
 })
 

--- a/frontend/src/composables/useLeafletMap.ts
+++ b/frontend/src/composables/useLeafletMap.ts
@@ -1,0 +1,34 @@
+import { nextTick, onUnmounted, shallowRef, type Ref } from 'vue'
+import type { LeafletMap } from '@/utils/leaflet'
+
+/**
+ * Shared @ready wiring for Leaflet map views: stores the map instance, keeps it in sync with
+ * its wrapper's size via ResizeObserver (when a wrapper ref is given), and defers afterReady
+ * until the browser has actually laid out the container. Without the requestAnimationFrame,
+ * clientHeight is still 0 on mobile right after nextTick because the flex/grid layout pass
+ * hasn't run yet.
+ */
+export function useLeafletMap(wrapperRef?: Ref<HTMLElement | null>) {
+  const mapInstance = shallowRef<LeafletMap | null>(null)
+  let resizeObserver: ResizeObserver | null = null
+
+  function bindMapReady(map: LeafletMap, afterReady?: (map: LeafletMap) => void) {
+    mapInstance.value = map
+
+    if (wrapperRef?.value) {
+      resizeObserver = new ResizeObserver(() => map.invalidateSize())
+      resizeObserver.observe(wrapperRef.value)
+    }
+
+    nextTick(() => {
+      requestAnimationFrame(() => {
+        map.invalidateSize()
+        afterReady?.(map)
+      })
+    })
+  }
+
+  onUnmounted(() => resizeObserver?.disconnect())
+
+  return { mapInstance, bindMapReady }
+}

--- a/frontend/src/composables/usePoiLayers.ts
+++ b/frontend/src/composables/usePoiLayers.ts
@@ -1,21 +1,12 @@
 import { computed, ref, watch, onUnmounted, type ComputedRef, type Ref } from 'vue'
 import { useI18n } from 'vue-i18n'
-import * as LModule from 'leaflet'
-import type { Map as LeafletMap } from 'leaflet'
+import { L, type LeafletMap } from '@/utils/leaflet'
 import 'leaflet.markercluster'
 import 'leaflet.markercluster/dist/MarkerCluster.css'
 import type { VehicleType } from '@/stores/vehicle'
 import { useMapSettingsStore } from '@/stores/settingsMap'
 import { mapApi } from '@/services/mapApi'
 import type { ChargingStation, PoiItem } from '@/services/mapApi'
-
-// Vite wraps CJS modules in a frozen ESM namespace - `import * as LModule` gives that frozen
-// namespace. leaflet.markercluster patches the actual mutable CJS export (LModule.default), so
-// we must use that reference to reach markerClusterGroup at runtime. Both this module and
-// MapView.vue import 'leaflet' as the same cached ES module instance, so the plugin patch here
-// is visible from either file regardless of which one imported the plugin side-effect first.
-const L = ((LModule as unknown as { default?: typeof LModule }).default ??
-  LModule) as typeof LModule
 
 type ClusterFactory = {
   markerClusterGroup: (options?: {

--- a/frontend/src/utils/leaflet.ts
+++ b/frontend/src/utils/leaflet.ts
@@ -1,0 +1,10 @@
+import * as LModule from 'leaflet'
+
+// Vite wraps CJS modules in a frozen ESM namespace - `import * as LModule` gives that frozen
+// namespace. Plugins like leaflet.heat and leaflet.markercluster patch the actual mutable CJS
+// export (LModule.default), so every consumer must resolve through this same shared instance
+// rather than re-importing 'leaflet' directly, or plugin-added methods won't be visible on it.
+export const L = ((LModule as unknown as { default?: typeof LModule }).default ??
+  LModule) as typeof LModule
+
+export type { Map as LeafletMap } from 'leaflet'

--- a/frontend/src/utils/mapCarIcon.ts
+++ b/frontend/src/utils/mapCarIcon.ts
@@ -1,10 +1,5 @@
-import * as LModule from 'leaflet'
+import { L } from '@/utils/leaflet'
 import { CAR_SILHOUETTE_VIEWBOX, CAR_SILHOUETTE_MARKUP } from '@/assets/carSilhouette'
-
-// Vite wraps CJS modules in a frozen ESM namespace - `import * as LModule` gives that frozen
-// namespace, which already exposes the plain (unpatched) Leaflet API this file needs.
-const L = ((LModule as unknown as { default?: typeof LModule }).default ??
-  LModule) as typeof LModule
 
 const CAR_ICON_SIZE: [number, number] = [24, 46]
 const CAR_ICON_ANCHOR: [number, number] = [12, 23]

--- a/frontend/src/views/DashboardView.vue
+++ b/frontend/src/views/DashboardView.vue
@@ -12,6 +12,7 @@ import DashboardCardContent from '@/components/DashboardCardContent.vue'
 import CardInfoWrap from '@/components/CardInfoWrap.vue'
 import CarDiagram from '@/components/CarDiagram.vue'
 import LocationMapWidget from '@/components/LocationMapWidget.vue'
+import EditableCardSlot from '@/components/EditableCardSlot.vue'
 import SkeletonCard from '@/components/SkeletonCard.vue'
 import SkeletonCarDiagram from '@/components/SkeletonCarDiagram.vue'
 import SkeletonLocationMap from '@/components/SkeletonLocationMap.vue'
@@ -293,51 +294,31 @@ onUnmounted(() => {
     <template v-if="editMode">
       <!-- Tyre diagram + location map toggles -->
       <div class="overview-row overview-row--edit mt-4 mb-4">
-        <div
-          class="card-slot card-slot--static overview-row__car"
-          :class="{ 'card-slot--hidden': !settings.showTyreDiagram }"
+        <EditableCardSlot
+          class="card-slot--static overview-row__car"
+          :visible="settings.showTyreDiagram"
+          :draggable="false"
+          @toggle-visible="settings.showTyreDiagram = !settings.showTyreDiagram"
         >
-          <div class="card-slot__content">
-            <CarDiagram v-if="settings.showTyreDiagram && status" v-bind="carDiagramProps" />
-            <div v-else class="card-slot__placeholder card-slot__placeholder--chart">
-              <font-awesome-icon icon="car-side" />
-              <span>{{ t('vehicle.overview') }}</span>
-            </div>
+          <CarDiagram v-if="settings.showTyreDiagram && status" v-bind="carDiagramProps" />
+          <div v-else class="card-slot__placeholder card-slot__placeholder--chart">
+            <font-awesome-icon icon="car-side" />
+            <span>{{ t('vehicle.overview') }}</span>
           </div>
-          <button
-            class="card-slot__badge"
-            :class="settings.showTyreDiagram ? 'card-slot__badge--hide' : 'card-slot__badge--show'"
-            :aria-label="
-              settings.showTyreDiagram ? t('dashboard.hideCard') : t('dashboard.showCard')
-            "
-            @click.stop="settings.showTyreDiagram = !settings.showTyreDiagram"
-          >
-            <font-awesome-icon :icon="settings.showTyreDiagram ? 'xmark' : 'plus'" />
-          </button>
-        </div>
+        </EditableCardSlot>
 
-        <div
-          class="card-slot card-slot--static overview-row__map"
-          :class="{ 'card-slot--hidden': !settings.showLocationMap }"
+        <EditableCardSlot
+          class="card-slot--static overview-row__map"
+          :visible="settings.showLocationMap"
+          :draggable="false"
+          @toggle-visible="settings.showLocationMap = !settings.showLocationMap"
         >
-          <div class="card-slot__content">
-            <LocationMapWidget v-if="settings.showLocationMap" />
-            <div v-else class="card-slot__placeholder card-slot__placeholder--chart">
-              <font-awesome-icon icon="location-dot" />
-              <span>{{ t('vehicle.location') }}</span>
-            </div>
+          <LocationMapWidget v-if="settings.showLocationMap" />
+          <div v-else class="card-slot__placeholder card-slot__placeholder--chart">
+            <font-awesome-icon icon="location-dot" />
+            <span>{{ t('vehicle.location') }}</span>
           </div>
-          <button
-            class="card-slot__badge"
-            :class="settings.showLocationMap ? 'card-slot__badge--hide' : 'card-slot__badge--show'"
-            :aria-label="
-              settings.showLocationMap ? t('dashboard.hideCard') : t('dashboard.showCard')
-            "
-            @click.stop="settings.showLocationMap = !settings.showLocationMap"
-          >
-            <font-awesome-icon :icon="settings.showLocationMap ? 'xmark' : 'plus'" />
-          </button>
-        </div>
+        </EditableCardSlot>
       </div>
 
       <VueDraggable
@@ -348,34 +329,21 @@ onUnmounted(() => {
         chosen-class="card-slot--chosen"
         handle=".card-slot__handle"
       >
-        <div
+        <EditableCardSlot
           v-for="card in editableCards"
           :key="card.id"
-          class="card-slot"
-          :class="{ 'card-slot--hidden': !card.visible }"
+          :visible="card.visible"
+          @toggle-visible="toggleCardVisibility(card)"
         >
-          <div class="card-slot__handle">
-            <font-awesome-icon icon="grip-lines" />
+          <DashboardCardContent
+            v-if="card.visible && status && cardHasData(card.id)"
+            :card-id="card.id"
+          />
+          <div v-else class="card-slot__placeholder">
+            <font-awesome-icon :icon="CARD_ICONS[card.id]" />
+            <span>{{ t(`settings.cards.${card.id}`) }}</span>
           </div>
-          <div class="card-slot__content">
-            <DashboardCardContent
-              v-if="card.visible && status && cardHasData(card.id)"
-              :card-id="card.id"
-            />
-            <div v-else class="card-slot__placeholder">
-              <font-awesome-icon :icon="CARD_ICONS[card.id]" />
-              <span>{{ t(`settings.cards.${card.id}`) }}</span>
-            </div>
-          </div>
-          <button
-            class="card-slot__badge"
-            :class="card.visible ? 'card-slot__badge--hide' : 'card-slot__badge--show'"
-            :aria-label="card.visible ? t('dashboard.hideCard') : t('dashboard.showCard')"
-            @click.stop="toggleCardVisibility(card)"
-          >
-            <font-awesome-icon :icon="card.visible ? 'xmark' : 'plus'" />
-          </button>
-        </div>
+        </EditableCardSlot>
       </VueDraggable>
 
       <button class="btn btn-outline-secondary mt-3" @click="resetLayout">

--- a/frontend/src/views/MapView.vue
+++ b/frontend/src/views/MapView.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { onMounted, onUnmounted, computed, ref, shallowRef, watch, nextTick } from 'vue'
+import { onMounted, onUnmounted, computed, ref, watch, nextTick } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useRoute, useRouter } from 'vue-router'
 import { useVehicleStore } from '@/stores/vehicle'
@@ -11,20 +11,14 @@ import FiltersPanel from '@/components/FiltersPanel.vue'
 import SettingsToggle from '@/components/SettingsToggle.vue'
 import { useInfiniteScroll } from '@/composables/useInfiniteScroll'
 import { usePoiLayers } from '@/composables/usePoiLayers'
+import { useLeafletMap } from '@/composables/useLeafletMap'
 import Slider from '@vueform/slider'
 import Multiselect from '@vueform/multiselect'
-import * as LModule from 'leaflet'
-import type { Map as LeafletMap } from 'leaflet'
+import { L, type LeafletMap } from '@/utils/leaflet'
 import 'leaflet.heat'
 import '@/assets/map.css'
 import type { Trip } from '@/services/vehicleApi'
 import { buildCarMarkerIcon } from '@/utils/mapCarIcon'
-
-// Vite wraps CJS modules in a frozen ESM namespace - `import * as LModule` gives that frozen
-// namespace. leaflet.heat patches the actual mutable CJS export (LModule.default), so we must
-// use that reference to reach heatLayer at runtime.
-const L = ((LModule as unknown as { default?: typeof LModule }).default ??
-  LModule) as typeof LModule
 
 const { t } = useI18n()
 const route = useRoute()
@@ -80,7 +74,7 @@ const LOAD_MORE_SIZE = 10
 
 const mapWrapperRef = ref<HTMLElement | null>(null)
 const tripSidebarRef = ref<HTMLElement | null>(null)
-const mapInstance = shallowRef<LeafletMap | null>(null)
+const { mapInstance, bindMapReady } = useLeafletMap(mapWrapperRef)
 
 // Charging-station / fuel-station / service-area layers: settings bindings, on-demand tile
 // fetching/caching, marker clustering, and popups all live in this composable so this view only
@@ -105,7 +99,6 @@ let heatLayer: L.Layer | null = null
 let routeLines: L.Polyline[] = []
 let startMarker: L.Marker | null = null
 let endMarker: L.Marker | null = null
-let resizeObserver: ResizeObserver | null = null
 let mapUpdateRaf: number | null = null
 let hasCenteredOnStatus = false
 
@@ -405,34 +398,19 @@ function flyToStatus() {
 }
 
 function onMapReady(map: LeafletMap) {
-  mapInstance.value = map
-
-  // Keep map in sync when the flex container resizes (orientation change, sidebar toggle, etc.)
-  if (mapWrapperRef.value) {
-    resizeObserver = new ResizeObserver(() => map.invalidateSize())
-    resizeObserver.observe(mapWrapperRef.value)
-  }
-
   // POI layer reload on pan/zoom is handled internally by usePoiLayers (it watches mapInstance).
-
-  // nextTick: wait for Vue DOM → requestAnimationFrame: wait for browser layout pass.
-  // Without rAF, clientHeight is still 0 on mobile because the flex heights haven't been
-  // computed by the browser yet even though the DOM is ready.
-  nextTick(() => {
-    requestAnimationFrame(() => {
-      map.invalidateSize()
-      if (allPoints.value.length > 0) {
-        buildHeatLayer()
-        buildRouteLines()
-        fitAll()
-      } else if (status.value?.latitude != null && status.value?.longitude != null) {
-        hasCenteredOnStatus = true
-        map.setView([status.value.latitude, status.value.longitude], 14, { animate: false })
-      }
-      if (chargingStationsEnabled.value) loadChargingStations(100)
-      if (fuelStationsEnabled.value) loadPoiLayer('fuel', 100)
-      if (serviceAreasEnabled.value) loadPoiLayer('service_area', 100)
-    })
+  bindMapReady(map, () => {
+    if (allPoints.value.length > 0) {
+      buildHeatLayer()
+      buildRouteLines()
+      fitAll()
+    } else if (status.value?.latitude != null && status.value?.longitude != null) {
+      hasCenteredOnStatus = true
+      map.setView([status.value.latitude, status.value.longitude], 14, { animate: false })
+    }
+    if (chargingStationsEnabled.value) loadChargingStations(100)
+    if (fuelStationsEnabled.value) loadPoiLayer('fuel', 100)
+    if (serviceAreasEnabled.value) loadPoiLayer('service_area', 100)
   })
 }
 
@@ -589,7 +567,6 @@ onMounted(async () => {
 onUnmounted(() => {
   if (mapUpdateRaf !== null) cancelAnimationFrame(mapUpdateRaf)
   removeHeatLayer()
-  resizeObserver?.disconnect()
   // POI layer cleanup (debouncers, marker clearing) is handled internally by usePoiLayers.
 })
 </script>

--- a/frontend/src/views/StatisticsView.vue
+++ b/frontend/src/views/StatisticsView.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import '@/assets/statistics.css'
-import { onMounted, computed, ref, watch, shallowRef, nextTick } from 'vue'
+import { onMounted, computed, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useVehicleStore } from '@/stores/vehicle'
 import { useDashboardSettingsStore } from '@/stores/settingsDashboard'
@@ -12,14 +12,15 @@ import type { TelemetrySnapshot, VehicleAggregateStats } from '@/services/vehicl
 import { Line, Bar } from 'vue-chartjs'
 import { VueDraggable } from 'vue-draggable-plus'
 import { LMap, LTileLayer, LMarker } from '@vue-leaflet/vue-leaflet'
-import * as LModule from 'leaflet'
-import type { Map as LeafletMap } from 'leaflet'
+import { L, type LeafletMap } from '@/utils/leaflet'
+import { useLeafletMap } from '@/composables/useLeafletMap'
 import CardInfoWrap from '@/components/CardInfoWrap.vue'
 import DetailModal from '@/components/DetailModal.vue'
 import FiltersPanel from '@/components/FiltersPanel.vue'
 import SkeletonCard from '@/components/SkeletonCard.vue'
 import SkeletonChart from '@/components/SkeletonChart.vue'
 import StatusCard from '@/components/StatusCard.vue'
+import EditableCardSlot from '@/components/EditableCardSlot.vue'
 import {
   Chart as ChartJS,
   CategoryScale,
@@ -46,9 +47,6 @@ ChartJS.register(
   Legend,
   Filler,
 )
-
-const L = ((LModule as unknown as { default?: typeof LModule }).default ??
-  LModule) as typeof LModule
 
 const { t } = useI18n()
 const store = useVehicleStore()
@@ -281,7 +279,7 @@ const electricShareToday = computed(() => {
 const activeChartInfo = ref<StatsChartId | null>(null)
 
 const parkingModalOpen = ref(false)
-const parkingMapInstance = shallowRef<LeafletMap | null>(null)
+const { bindMapReady: bindParkingMapReady } = useLeafletMap()
 
 const parkingMapCenter = computed<[number, number]>(() =>
   parkingCoordinates.value.length
@@ -290,19 +288,15 @@ const parkingMapCenter = computed<[number, number]>(() =>
 )
 
 function onParkingMapReady(map: LeafletMap) {
-  parkingMapInstance.value = map
-  nextTick(() => {
-    requestAnimationFrame(() => {
-      map.invalidateSize()
-      const pts = parkingCoordinates.value
-      if (!pts.length) return
-      const bounds = L.latLngBounds(pts.map((c) => [c.lat, c.lng] as [number, number]))
-      if (bounds.getNorthEast().equals(bounds.getSouthWest())) {
-        map.setView(bounds.getCenter(), 15, { animate: false })
-      } else {
-        map.fitBounds(bounds, { padding: [24, 24], animate: false })
-      }
-    })
+  bindParkingMapReady(map, () => {
+    const pts = parkingCoordinates.value
+    if (!pts.length) return
+    const bounds = L.latLngBounds(pts.map((c) => [c.lat, c.lng] as [number, number]))
+    if (bounds.getNorthEast().equals(bounds.getSouthWest())) {
+      map.setView(bounds.getCenter(), 15, { animate: false })
+    } else {
+      map.fitBounds(bounds, { padding: [24, 24], animate: false })
+    }
   })
 }
 
@@ -715,44 +709,31 @@ const skeletonChartCount = computed(
             chosen-class="card-slot--chosen"
             handle=".card-slot__handle"
           >
-            <div
+            <EditableCardSlot
               v-for="item in settings.statsInsights"
               v-show="insightDefMap.get(item.id)?.vehicleApplicable !== false"
               :key="item.id"
-              class="card-slot"
-              :class="{ 'card-slot--hidden': !item.visible }"
+              :visible="item.visible"
+              @toggle-visible="item.visible = !item.visible"
             >
-              <div class="card-slot__handle">
-                <font-awesome-icon icon="grip-lines" />
-              </div>
-              <div class="card-slot__content">
-                <template
-                  v-if="
-                    insightDefMap.get(item.id)?.applicable &&
-                    insightDefMap.get(item.id)?.value !== null
-                  "
-                >
-                  <StatusCard
-                    :icon="insightDefMap.get(item.id)!.icon"
-                    :label="insightDefMap.get(item.id)!.title"
-                    :value="insightDefMap.get(item.id)!.value"
-                    :unit="insightDefMap.get(item.id)!.unit"
-                  />
-                </template>
-                <div v-else class="card-slot__placeholder">
-                  <font-awesome-icon :icon="insightDefMap.get(item.id)?.icon ?? 'circle-info'" />
-                  <span>{{ insightDefMap.get(item.id)?.title }}</span>
-                </div>
-              </div>
-              <button
-                class="card-slot__badge"
-                :class="item.visible ? 'card-slot__badge--hide' : 'card-slot__badge--show'"
-                :aria-label="item.visible ? t('dashboard.hideCard') : t('dashboard.showCard')"
-                @click.stop="item.visible = !item.visible"
+              <template
+                v-if="
+                  insightDefMap.get(item.id)?.applicable &&
+                  insightDefMap.get(item.id)?.value !== null
+                "
               >
-                <font-awesome-icon :icon="item.visible ? 'xmark' : 'plus'" />
-              </button>
-            </div>
+                <StatusCard
+                  :icon="insightDefMap.get(item.id)!.icon"
+                  :label="insightDefMap.get(item.id)!.title"
+                  :value="insightDefMap.get(item.id)!.value"
+                  :unit="insightDefMap.get(item.id)!.unit"
+                />
+              </template>
+              <div v-else class="card-slot__placeholder">
+                <font-awesome-icon :icon="insightDefMap.get(item.id)?.icon ?? 'circle-info'" />
+                <span>{{ insightDefMap.get(item.id)?.title }}</span>
+              </div>
+            </EditableCardSlot>
           </VueDraggable>
 
           <!-- Normal mode: visible + applicable insights -->
@@ -807,55 +788,43 @@ const skeletonChartCount = computed(
             chosen-class="card-slot--chosen"
             handle=".card-slot__handle"
           >
-            <div
+            <EditableCardSlot
               v-for="item in settings.statsCharts"
               v-show="chartDefMap.get(item.id)?.vehicleApplicable !== false"
               :key="item.id"
-              class="card-slot card-slot--chart"
-              :class="{ 'card-slot--hidden': !item.visible }"
+              class="card-slot--chart"
+              :visible="item.visible"
+              @toggle-visible="item.visible = !item.visible"
             >
-              <div class="card-slot__handle">
-                <font-awesome-icon icon="grip-lines" />
-              </div>
-              <div class="card-slot__content">
-                <div
-                  v-if="chartDefMap.get(item.id)?.applicable && store.history.length"
-                  class="chart-container"
-                >
-                  <button
-                    v-if="uiSettings.showCardInfoIcons"
-                    class="card-info-btn"
-                    :aria-label="t('dashboard.cardInfoBtn')"
-                    @click.stop="activeChartInfo = item.id"
-                  >
-                    <font-awesome-icon icon="circle-info" />
-                  </button>
-                  <h2>{{ chartDefMap.get(item.id)!.title }}</h2>
-                  <Bar
-                    v-if="chartDefMap.get(item.id)!.isBar"
-                    :data="chartDefMap.get(item.id)!.data"
-                    :options="chartDefMap.get(item.id)!.options"
-                  />
-                  <Line
-                    v-else
-                    :data="chartDefMap.get(item.id)!.data"
-                    :options="chartDefMap.get(item.id)!.options"
-                  />
-                </div>
-                <div v-else class="card-slot__placeholder card-slot__placeholder--chart">
-                  <font-awesome-icon :icon="chartDefMap.get(item.id)?.icon ?? 'chart-line'" />
-                  <span>{{ chartDefMap.get(item.id)?.title }}</span>
-                </div>
-              </div>
-              <button
-                class="card-slot__badge"
-                :class="item.visible ? 'card-slot__badge--hide' : 'card-slot__badge--show'"
-                :aria-label="item.visible ? t('dashboard.hideCard') : t('dashboard.showCard')"
-                @click.stop="item.visible = !item.visible"
+              <div
+                v-if="chartDefMap.get(item.id)?.applicable && store.history.length"
+                class="chart-container"
               >
-                <font-awesome-icon :icon="item.visible ? 'xmark' : 'plus'" />
-              </button>
-            </div>
+                <button
+                  v-if="uiSettings.showCardInfoIcons"
+                  class="card-info-btn"
+                  :aria-label="t('dashboard.cardInfoBtn')"
+                  @click.stop="activeChartInfo = item.id"
+                >
+                  <font-awesome-icon icon="circle-info" />
+                </button>
+                <h2>{{ chartDefMap.get(item.id)!.title }}</h2>
+                <Bar
+                  v-if="chartDefMap.get(item.id)!.isBar"
+                  :data="chartDefMap.get(item.id)!.data"
+                  :options="chartDefMap.get(item.id)!.options"
+                />
+                <Line
+                  v-else
+                  :data="chartDefMap.get(item.id)!.data"
+                  :options="chartDefMap.get(item.id)!.options"
+                />
+              </div>
+              <div v-else class="card-slot__placeholder card-slot__placeholder--chart">
+                <font-awesome-icon :icon="chartDefMap.get(item.id)?.icon ?? 'chart-line'" />
+                <span>{{ chartDefMap.get(item.id)?.title }}</span>
+              </div>
+            </EditableCardSlot>
           </VueDraggable>
 
           <!-- Normal mode: visible + applicable charts -->

--- a/src/GarageStack.Api/Endpoints/DemoEndpoints.cs
+++ b/src/GarageStack.Api/Endpoints/DemoEndpoints.cs
@@ -18,18 +18,14 @@ public static class DemoEndpoints
             .WithTags("Demo")
             .RequireAuthorization();
 
-        group.MapPost("/status/{vin}", async (
-            string vin,
-            DemoStatusOverrideDto dto,
-            IVehicleRepository vehicles,
-            CancellationToken ct) =>
-        {
-            var resolved = await VehicleEndpoints.ResolveVehicleAsync(vin, vehicles, ct);
-            if (resolved.NotFound is not null) return resolved.NotFound;
-            demoRepo.ApplyOverride(dto);
-            return Results.NoContent();
-        })
-        .WithSummary("Override demo vehicle status fields");
+        group.MapGroup("/status/{vin}")
+            .AddEndpointFilter<VehicleEndpoints.ResolveVehicleFilter>()
+            .MapPost("/", (DemoStatusOverrideDto dto) =>
+            {
+                demoRepo.ApplyOverride(dto);
+                return Results.NoContent();
+            })
+            .WithSummary("Override demo vehicle status fields");
 
         return app;
     }

--- a/src/GarageStack.Api/Endpoints/MapEndpoints.cs
+++ b/src/GarageStack.Api/Endpoints/MapEndpoints.cs
@@ -4,6 +4,21 @@ namespace GarageStack.Api.Endpoints;
 
 public static class MapEndpoints
 {
+    private static IResult? ValidateLatLng(double lat, double lng) =>
+        lat is < -90 or > 90 || lng is < -180 or > 180
+            ? Results.BadRequest(new { error = "lat must be between -90 and 90, lng between -180 and 180" })
+            : null;
+
+    private static IResult? ValidateRadiusKm(double radiusKm, string paramName) =>
+        radiusKm is < 1 or > 200
+            ? Results.BadRequest(new { error = $"{paramName} must be between 1 and 200" })
+            : null;
+
+    private static IResult? ValidatePoiType(string type) =>
+        type is not ("fuel" or "service_area")
+            ? Results.BadRequest(new { error = "type must be 'fuel' or 'service_area'" })
+            : null;
+
     public static IEndpointRouteBuilder MapMapEndpoints(this IEndpointRouteBuilder app)
     {
         var group = app.MapGroup("/api/map")
@@ -19,11 +34,8 @@ public static class MapEndpoints
             ChargingStationService svc,
             CancellationToken ct) =>
         {
-            if (lat is < -90 or > 90 || lng is < -180 or > 180)
-                return Results.BadRequest(new { error = "lat must be between -90 and 90, lng between -180 and 180" });
-
-            if (distanceKm is < 1 or > 200)
-                return Results.BadRequest(new { error = "distanceKm must be between 1 and 200" });
+            var error = ValidateLatLng(lat, lng) ?? ValidateRadiusKm(distanceKm, "distanceKm");
+            if (error is not null) return error;
 
             var stations = await svc.GetStationsAsync(lat, lng, distanceKm, minPowerKw, maxPowerKw, ct);
             return Results.Ok(stations);
@@ -36,8 +48,8 @@ public static class MapEndpoints
             PoiService svc,
             CancellationToken ct) =>
         {
-            if (type is not ("fuel" or "service_area"))
-                return Results.BadRequest(new { error = "type must be 'fuel' or 'service_area'" });
+            var error = ValidatePoiType(type);
+            if (error is not null) return error;
 
             if (!PoiService.IsPoiTypeAllowed(type, vehicleType))
                 return Results.Ok(Array.Empty<string>());
@@ -56,14 +68,8 @@ public static class MapEndpoints
             PoiService svc,
             CancellationToken ct) =>
         {
-            if (lat is < -90 or > 90 || lng is < -180 or > 180)
-                return Results.BadRequest(new { error = "lat must be between -90 and 90, lng between -180 and 180" });
-
-            if (radiusKm is < 1 or > 200)
-                return Results.BadRequest(new { error = "radiusKm must be between 1 and 200" });
-
-            if (type is not ("fuel" or "service_area"))
-                return Results.BadRequest(new { error = "type must be 'fuel' or 'service_area'" });
+            var error = ValidateLatLng(lat, lng) ?? ValidateRadiusKm(radiusKm, "radiusKm") ?? ValidatePoiType(type);
+            if (error is not null) return error;
 
             if (!PoiService.IsPoiTypeAllowed(type, vehicleType))
                 return Results.Ok(new PoiResult([], false));

--- a/src/GarageStack.Api/Endpoints/VehicleEndpoints.cs
+++ b/src/GarageStack.Api/Endpoints/VehicleEndpoints.cs
@@ -9,21 +9,56 @@ namespace GarageStack.Api.Endpoints;
 
 public static class VehicleEndpoints
 {
-    /// <summary>Looks up a vehicle by VIN, shared by every endpoint that takes a {vin} route parameter.</summary>
-    public static async Task<(Vehicle? Vehicle, IResult? NotFound)> ResolveVehicleAsync(
-        string vin,
-        IVehicleRepository vehicles,
-        CancellationToken ct)
+    /// <summary>
+    /// Resolves the {vin} route value to a Vehicle before the handler runs, short-circuiting
+    /// with 404 if no such vehicle exists. Shared by every endpoint group that takes a {vin}
+    /// route parameter (vehicles, widget, demo). Handlers retrieve the result via
+    /// <see cref="GetResolvedVehicle"/>.
+    /// </summary>
+    public sealed class ResolveVehicleFilter : IEndpointFilter
     {
-        var vehicle = await vehicles.GetByVinAsync(vin, ct);
-        return vehicle is null ? (null, Results.NotFound()) : (vehicle, null);
+        private const string VehicleItemKey = "GarageStack.ResolvedVehicle";
+
+        public async ValueTask<object?> InvokeAsync(EndpointFilterInvocationContext context, EndpointFilterDelegate next)
+        {
+            var vin = context.HttpContext.Request.RouteValues["vin"] as string
+                ?? throw new InvalidOperationException($"{nameof(ResolveVehicleFilter)} requires a {{vin}} route parameter.");
+
+            var vehicles = context.HttpContext.RequestServices.GetRequiredService<IVehicleRepository>();
+            var vehicle = await vehicles.GetByVinAsync(vin, context.HttpContext.RequestAborted);
+            if (vehicle is null) return Results.NotFound();
+
+            context.HttpContext.Items[VehicleItemKey] = vehicle;
+            return await next(context);
+        }
+
+        public static Vehicle GetResolvedVehicle(HttpContext httpContext) =>
+            (Vehicle)httpContext.Items[VehicleItemKey]!;
+    }
+
+    /// <summary>
+    /// Resolves the [start, end) UTC range for a from/to query: defaults the missing bound
+    /// (end to now, start to end - defaultSpan) and clamps the span to maxSpan. Returns a 400
+    /// IResult if the resulting range is inverted.
+    /// </summary>
+    private static IResult? TryResolveDateRange(
+        DateTimeOffset? from, DateTimeOffset? to, TimeSpan defaultSpan, TimeSpan maxSpan,
+        out DateTime start, out DateTime end)
+    {
+        end = to?.UtcDateTime ?? DateTime.UtcNow;
+        start = from?.UtcDateTime ?? end - defaultSpan;
+
+        if (start >= end)
+            return Results.BadRequest(new { error = "from must be before to" });
+
+        if (end - start > maxSpan)
+            start = end - maxSpan;
+
+        return null;
     }
 
     public static IEndpointRouteBuilder MapVehicleEndpoints(this IEndpointRouteBuilder app)
     {
-        static DateTime ClampRangeStart(DateTime start, DateTime end, TimeSpan maxRange) =>
-            end - start > maxRange ? end - maxRange : start;
-
         var group = app.MapGroup("/api/vehicles")
             .WithTags("Vehicles")
             .RequireAuthorization();
@@ -38,11 +73,11 @@ public static class VehicleEndpoints
         })
         .WithSummary("List all vehicles");
 
-        group.MapGet("/{vin}/config", async (string vin, IVehicleRepository vehicles, CancellationToken ct) =>
+        var vehicleGroup = group.MapGroup("/{vin}").AddEndpointFilter<ResolveVehicleFilter>();
+
+        vehicleGroup.MapGet("/config", (HttpContext httpContext) =>
         {
-            var resolved = await ResolveVehicleAsync(vin, vehicles, ct);
-            if (resolved.NotFound is not null) return resolved.NotFound;
-            var vehicle = resolved.Vehicle!;
+            var vehicle = ResolveVehicleFilter.GetResolvedVehicle(httpContext);
             if (vehicle.ConfigJson is null) return Results.Ok(new Dictionary<string, string>());
             var config = SafeJson.TryDeserialize<Dictionary<string, string>>(vehicle.ConfigJson)
                 ?? new Dictionary<string, string>();
@@ -50,43 +85,34 @@ public static class VehicleEndpoints
         })
         .WithSummary("Get vehicle capability config");
 
-        group.MapGet("/{vin}/status", async (string vin, ITelemetryRepository telemetry, IVehicleRepository vehicles, CancellationToken ct) =>
+        vehicleGroup.MapGet("/status", async (HttpContext httpContext, ITelemetryRepository telemetry, CancellationToken ct) =>
         {
-            var resolved = await ResolveVehicleAsync(vin, vehicles, ct);
-            if (resolved.NotFound is not null) return resolved.NotFound;
-            var vehicle = resolved.Vehicle!;
+            var vehicle = ResolveVehicleFilter.GetResolvedVehicle(httpContext);
             var snapshot = await telemetry.GetMergedLatestAsync(vehicle.Id, ct);
             return snapshot is null ? Results.NoContent() : Results.Ok(snapshot);
         })
         .WithSummary("Get latest telemetry for a vehicle");
 
-        group.MapGet("/{vin}/history", async (
-            string vin,
+        vehicleGroup.MapGet("/history", async (
+            HttpContext httpContext,
             ITelemetryRepository telemetry,
-            IVehicleRepository vehicles,
             DateTimeOffset? from,
             DateTimeOffset? to,
             CancellationToken ct) =>
         {
-            var resolved = await ResolveVehicleAsync(vin, vehicles, ct);
-            if (resolved.NotFound is not null) return resolved.NotFound;
-            var vehicle = resolved.Vehicle!;
+            var vehicle = ResolveVehicleFilter.GetResolvedVehicle(httpContext);
 
-            var start = from?.UtcDateTime ?? DateTime.UtcNow.AddDays(-7);
-            var end = to?.UtcDateTime ?? DateTime.UtcNow;
-            if (start >= end)
-                return Results.BadRequest(new { error = "from must be before to" });
-            start = ClampRangeStart(start, end, TimeSpan.FromDays(90));
+            var rangeError = TryResolveDateRange(from, to, TimeSpan.FromDays(7), TimeSpan.FromDays(90), out var start, out var end);
+            if (rangeError is not null) return rangeError;
+
             var history = await telemetry.GetHistoryAsync(vehicle.Id, start, end, ct);
             return Results.Ok(history);
         })
         .WithSummary("Get telemetry history for a vehicle");
 
-        group.MapGet("/{vin}/trips/last", async (string vin, IVehicleRepository vehicles, AppDbContext db, CancellationToken ct) =>
+        vehicleGroup.MapGet("/trips/last", async (HttpContext httpContext, AppDbContext db, CancellationToken ct) =>
         {
-            var resolved = await ResolveVehicleAsync(vin, vehicles, ct);
-            if (resolved.NotFound is not null) return resolved.NotFound;
-            var vehicle = resolved.Vehicle!;
+            var vehicle = ResolveVehicleFilter.GetResolvedVehicle(httpContext);
 
             var row = await db.TelemetrySnapshots
                 .Where(s => s.VehicleId == vehicle.Id && s.CurrentJourneyDistance > 0)
@@ -98,44 +124,40 @@ public static class VehicleEndpoints
         })
         .WithSummary("Get last trip summary (distance and timestamp of most recent journey)");
 
-        group.MapGet("/{vin}/trips", async (
-            string vin,
+        vehicleGroup.MapGet("/trips", async (
+            HttpContext httpContext,
             ITelemetryRepository telemetry,
-            IVehicleRepository vehicles,
             DateTimeOffset? from,
             DateTimeOffset? to,
             CancellationToken ct) =>
         {
-            var resolved = await ResolveVehicleAsync(vin, vehicles, ct);
-            if (resolved.NotFound is not null) return resolved.NotFound;
-            var vehicle = resolved.Vehicle!;
+            var vehicle = ResolveVehicleFilter.GetResolvedVehicle(httpContext);
 
-            var start = from?.UtcDateTime ?? DateTime.UtcNow.AddDays(-30);
-            var end = to?.UtcDateTime ?? DateTime.UtcNow;
-            if (start >= end)
-                return Results.BadRequest(new { error = "from must be before to" });
-            start = ClampRangeStart(start, end, TimeSpan.FromDays(90));
+            var rangeError = TryResolveDateRange(from, to, TimeSpan.FromDays(30), TimeSpan.FromDays(90), out var start, out var end);
+            if (rangeError is not null) return rangeError;
+
             var trips = await telemetry.GetTripsAsync(vehicle.Id, start, end, ct);
             return Results.Ok(trips);
         })
         .WithSummary("Get trip history");
 
-        group.MapPost("/{vin}/commands/{command}", async (
+        vehicleGroup.MapPost("/commands/{command}", async (
+            HttpContext httpContext,
             string vin,
             string command,
             JsonElement body,
             IMqttPublisher mqtt,
-            IVehicleRepository vehicles,
             CancellationToken ct) =>
         {
-            var resolved = await ResolveVehicleAsync(vin, vehicles, ct);
-            if (resolved.NotFound is not null) return resolved.NotFound;
-            var vehicle = resolved.Vehicle!;
+            var vehicle = ResolveVehicleFilter.GetResolvedVehicle(httpContext);
             if (vehicle.SaicUser is null)
                 return Results.Problem("SAIC username not yet known for this vehicle");
 
             if (!body.TryGetProperty("value", out var valueEl))
                 return Results.BadRequest(new { error = "Missing 'value' in request body" });
+
+            if (valueEl.ValueKind != JsonValueKind.String)
+                return Results.BadRequest(new { error = "'value' must be a string" });
 
             var value = valueEl.GetString();
             if (string.IsNullOrWhiteSpace(value))
@@ -172,32 +194,26 @@ public static class VehicleEndpoints
         })
         .WithSummary("Send a command to the vehicle via MQTT");
 
-        group.MapGet("/{vin}/stats", async (
-            string vin,
+        vehicleGroup.MapGet("/stats", async (
+            HttpContext httpContext,
             DateTimeOffset? from,
             DateTimeOffset? to,
             ITelemetryRepository telemetry,
-            IVehicleRepository vehicles,
             CancellationToken ct) =>
         {
-            var resolved = await ResolveVehicleAsync(vin, vehicles, ct);
-            if (resolved.NotFound is not null) return resolved.NotFound;
-            var vehicle = resolved.Vehicle!;
+            var vehicle = ResolveVehicleFilter.GetResolvedVehicle(httpContext);
 
-            var end = to?.UtcDateTime ?? DateTime.UtcNow;
-            var start = from?.UtcDateTime ?? end.AddDays(-30);
-            start = ClampRangeStart(start, end, TimeSpan.FromDays(90));
+            var rangeError = TryResolveDateRange(from, to, TimeSpan.FromDays(30), TimeSpan.FromDays(90), out var start, out var end);
+            if (rangeError is not null) return rangeError;
 
             var stats = await telemetry.GetAggregateStatsAsync(vehicle.Id, start, end, ct);
             return Results.Ok(stats);
         })
         .WithSummary("Get aggregate statistics for a vehicle over a date range");
 
-        group.MapGet("/{vin}/topics", async (string vin, IVehicleRepository vehicles, AppDbContext db, CancellationToken ct) =>
+        vehicleGroup.MapGet("/topics", async (HttpContext httpContext, AppDbContext db, CancellationToken ct) =>
         {
-            var resolved = await ResolveVehicleAsync(vin, vehicles, ct);
-            if (resolved.NotFound is not null) return resolved.NotFound;
-            var vehicle = resolved.Vehicle!;
+            var vehicle = ResolveVehicleFilter.GetResolvedVehicle(httpContext);
 
             var topics = await db.TelemetrySnapshots
                 .Where(s => s.VehicleId == vehicle.Id && s.RawTopic != null)

--- a/src/GarageStack.Api/Endpoints/WidgetEndpoints.cs
+++ b/src/GarageStack.Api/Endpoints/WidgetEndpoints.cs
@@ -26,21 +26,19 @@ public static class WidgetEndpoints
                 return await next(ctx);
             });
 
-        group.MapGet("/{vin}/status", async (
-            string vin,
-            IVehicleRepository vehicles,
-            ITelemetryRepository telemetry,
-            IStringLocalizer<WidgetStrings> localizer,
-            CancellationToken ct) =>
-        {
-            var resolved = await VehicleEndpoints.ResolveVehicleAsync(vin, vehicles, ct);
-            if (resolved.NotFound is not null) return resolved.NotFound;
-            var vehicle = resolved.Vehicle!;
-
-            var snapshot = await telemetry.GetMergedLatestAsync(vehicle.Id, ct);
-            return snapshot is null ? Results.NoContent() : Results.Ok(WidgetStatusDto.FromSnapshot(snapshot, localizer));
-        })
-        .WithSummary("Get latest vehicle status for Homepage widget (requires X-Widget-Key header)");
+        group.MapGroup("/{vin}")
+            .AddEndpointFilter<VehicleEndpoints.ResolveVehicleFilter>()
+            .MapGet("/status", async (
+                HttpContext httpContext,
+                ITelemetryRepository telemetry,
+                IStringLocalizer<WidgetStrings> localizer,
+                CancellationToken ct) =>
+            {
+                var vehicle = VehicleEndpoints.ResolveVehicleFilter.GetResolvedVehicle(httpContext);
+                var snapshot = await telemetry.GetMergedLatestAsync(vehicle.Id, ct);
+                return snapshot is null ? Results.NoContent() : Results.Ok(WidgetStatusDto.FromSnapshot(snapshot, localizer));
+            })
+            .WithSummary("Get latest vehicle status for Homepage widget (requires X-Widget-Key header)");
 
         return app;
     }

--- a/src/GarageStack.Api/Program.cs
+++ b/src/GarageStack.Api/Program.cs
@@ -96,15 +96,6 @@ try
         throw new InvalidOperationException("Jwt:Secret must be at least 32 bytes.");
 
     builder.Services.AddMemoryCache();
-    builder.Services.AddHttpClient("ocm", client =>
-    {
-        client.DefaultRequestHeaders.UserAgent.ParseAdd("GarageStack/1.0");
-    });
-    builder.Services.AddHttpClient("overpass", client =>
-    {
-        client.DefaultRequestHeaders.UserAgent.ParseAdd("GarageStack/1.0");
-        client.Timeout = TimeSpan.FromSeconds(45);
-    });
     builder.Services.AddScoped<ChargingStationService>();
     builder.Services.AddScoped<PoiService>();
 

--- a/src/GarageStack.Api/Services/PoiService.cs
+++ b/src/GarageStack.Api/Services/PoiService.cs
@@ -20,14 +20,11 @@ public sealed class PoiService(
         _ => false,
     };
 
-    public static IReadOnlyList<(int CellLat, int CellLng)> ComputeTiles(double lat, double lng, double radiusKm)
-        => TileHelper.ComputeTiles(lat, lng, radiusKm);
-
     public async Task<PoiResult> GetPoisAsync(
         string poiType, double lat, double lng, double radiusKm,
         CancellationToken ct = default)
     {
-        var tiles = ComputeTiles(lat, lng, radiusKm);
+        var tiles = TileHelper.ComputeTiles(lat, lng, radiusKm);
         var uncached = await repository.GetExpiredOrMissingTilesAsync("overpass", poiType, tiles, ct);
 
         // Cap on-demand fetches to the tile closest to the viewport centre. The remaining

--- a/src/GarageStack.Core/Helpers/BoolTransitionDetector.cs
+++ b/src/GarageStack.Core/Helpers/BoolTransitionDetector.cs
@@ -1,0 +1,26 @@
+namespace GarageStack.Core.Helpers;
+
+public enum StateTransition
+{
+    /// <summary>No prior value for this VIN to compare against; treat as a no-op.</summary>
+    FirstObservation,
+    Unchanged,
+    TurnedOn,
+    TurnedOff,
+}
+
+/// <summary>
+/// Interprets a <see cref="VinStateTracker{T}.TryUpdate"/> result (hadPrevious/previous/current)
+/// as an on/off transition. Shared by every checker built on top of a boolean VinStateTracker
+/// (engine running, charging) so the on/off/first-seen branching isn't reimplemented per caller.
+/// </summary>
+public static class BoolTransitionDetector
+{
+    public static StateTransition Detect(bool hadPrevious, bool? previous, bool current)
+    {
+        if (!hadPrevious || previous is null) return StateTransition.FirstObservation;
+        if (current && previous == false) return StateTransition.TurnedOn;
+        if (!current && previous == true) return StateTransition.TurnedOff;
+        return StateTransition.Unchanged;
+    }
+}

--- a/src/GarageStack.Data/Extensions/ServiceCollectionExtensions.cs
+++ b/src/GarageStack.Data/Extensions/ServiceCollectionExtensions.cs
@@ -20,8 +20,7 @@ public static class ServiceCollectionExtensions
         services.AddScoped<IVehicleRepository, VehicleRepository>();
         services.AddScoped<ITelemetryRepository, TelemetryRepository>();
         services.AddScoped<IPoiRepository, PoiRepository>();
-        services.AddSingleton<OverpassApiClient>();
-        services.AddSingleton<OcmApiClient>();
+        services.AddGarageStackPoiClients();
 
         return services;
     }
@@ -36,6 +35,24 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<ITelemetryRepository, DemoTelemetryRepository>();
         services.AddSingleton<IPushSender, DemoPushSender>();
         services.AddScoped<IPoiRepository, PoiRepository>();
+        services.AddGarageStackPoiClients();
+
+        return services;
+    }
+
+    // Shared by both GarageStack.Api and GarageStack.Worker (each calls AddGarageStackData
+    // or AddDemoServices) so the "ocm"/"overpass" HttpClient config can't drift between processes.
+    private static IServiceCollection AddGarageStackPoiClients(this IServiceCollection services)
+    {
+        services.AddHttpClient("ocm", client =>
+        {
+            client.DefaultRequestHeaders.UserAgent.ParseAdd("GarageStack/1.0");
+        });
+        services.AddHttpClient("overpass", client =>
+        {
+            client.DefaultRequestHeaders.UserAgent.ParseAdd("GarageStack/1.0");
+            client.Timeout = TimeSpan.FromSeconds(45);
+        });
         services.AddSingleton<OverpassApiClient>();
         services.AddSingleton<OcmApiClient>();
 

--- a/src/GarageStack.Data/Repositories/VehicleRepository.cs
+++ b/src/GarageStack.Data/Repositories/VehicleRepository.cs
@@ -8,12 +8,20 @@ namespace GarageStack.Data.Repositories;
 
 public class VehicleRepository(AppDbContext db) : IVehicleRepository
 {
+    // track: false for read-only lookups so EF doesn't snapshot the entity for change detection;
+    // track: true when the caller may mutate and save the returned entity.
+    private Task<Vehicle?> FindByVinAsync(string vin, bool track, CancellationToken ct)
+    {
+        var query = track ? db.Vehicles : db.Vehicles.AsNoTracking();
+        return query.FirstOrDefaultAsync(v => v.Vin == vin, ct);
+    }
+
     public Task<Vehicle?> GetByVinAsync(string vin, CancellationToken ct = default) =>
-        db.Vehicles.FirstOrDefaultAsync(v => v.Vin == vin, ct);
+        FindByVinAsync(vin, track: false, ct);
 
     public async Task<Vehicle> GetOrCreateByVinAsync(string vin, string? saicUser = null, CancellationToken ct = default)
     {
-        var vehicle = await db.Vehicles.FirstOrDefaultAsync(v => v.Vin == vin, ct);
+        var vehicle = await FindByVinAsync(vin, track: true, ct);
         if (vehicle is not null)
         {
             if (saicUser is not null && vehicle.SaicUser != saicUser)
@@ -36,7 +44,7 @@ public class VehicleRepository(AppDbContext db) : IVehicleRepository
             // nearly the same time (e.g. on startup); the loser of that race hits the unique
             // constraint on Vin here. Forget our failed insert and read back the winner's row.
             db.ChangeTracker.Clear();
-            vehicle = await db.Vehicles.FirstOrDefaultAsync(v => v.Vin == vin, ct)
+            vehicle = await FindByVinAsync(vin, track: true, ct)
                 ?? throw new InvalidOperationException($"Unique-constraint violation on VIN {vin} but no row found on retry.");
         }
         return vehicle;

--- a/src/GarageStack.Data/Services/OcmApiClient.cs
+++ b/src/GarageStack.Data/Services/OcmApiClient.cs
@@ -1,6 +1,7 @@
 using System.Globalization;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using GarageStack.Core.Helpers;
 using GarageStack.Core.Models;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
@@ -95,6 +96,7 @@ public sealed class OcmApiClient(
     {
         var lat = p.AddressInfo?.Latitude ?? 0;
         var lng = p.AddressInfo?.Longitude ?? 0;
+        var (cellLat, cellLng) = TileHelper.CellOf(lat, lng);
 
         // Only store DC connectors (CurrentTypeID == 30); AC already excluded at API level
         // but guard here too in case OCM returns mixed results.
@@ -123,8 +125,8 @@ public sealed class OcmApiClient(
             MetaJson = JsonSerializer.Serialize(meta),
             // Tile from element's own position (same pattern as Overpass) so that a station
             // returned by an adjacent tile's radius query doesn't collide on the unique index.
-            CellLat = (int)Math.Floor(lat * 2),
-            CellLng = (int)Math.Floor(lng * 2),
+            CellLat = cellLat,
+            CellLng = cellLng,
         };
     }
 

--- a/src/GarageStack.Data/Services/OverpassApiClient.cs
+++ b/src/GarageStack.Data/Services/OverpassApiClient.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using GarageStack.Core.Helpers;
 using GarageStack.Core.Models;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
@@ -184,6 +185,7 @@ public sealed class OverpassApiClient(
         var lat = e.Type == "node" ? e.Lat : e.Center?.Lat ?? 0;
         var lng = e.Type == "node" ? e.Lon : e.Center?.Lon ?? 0;
         var meta = e.Tags is { Count: > 0 } ? JsonSerializer.Serialize(e.Tags) : null;
+        var (cellLat, cellLng) = TileHelper.CellOf(lat, lng);
         return new PoiItem
         {
             Source = source,
@@ -196,8 +198,8 @@ public sealed class OverpassApiClient(
             // Tile coords derived from the element's own position, not the queried tile.
             // This prevents duplicate-key violations when the same border element appears
             // in two adjacent tile queries.
-            CellLat = (int)Math.Floor(lat * 2),
-            CellLng = (int)Math.Floor(lng * 2),
+            CellLat = cellLat,
+            CellLng = cellLng,
         };
     }
 

--- a/src/GarageStack.Tests/PoiServiceTests.cs
+++ b/src/GarageStack.Tests/PoiServiceTests.cs
@@ -1,6 +1,7 @@
 using System.Net;
 using System.Text;
 using GarageStack.Api.Services;
+using GarageStack.Core.Helpers;
 using GarageStack.Core.Interfaces;
 using GarageStack.Core.Models;
 using GarageStack.Data.Services;
@@ -141,7 +142,7 @@ public class PoiServiceTests
         var svc = BuildPoiService(repo, BuildOverpassClient(handler));
 
         // Pre-seed every tile that ComputeTiles would return for this request
-        var tiles = PoiService.ComputeTiles(52.0, 5.0, 10.0);
+        var tiles = TileHelper.ComputeTiles(52.0, 5.0, 10.0);
         foreach (var (clat, clng) in tiles)
             repo.SeedTile("overpass", "fuel", clat, clng);
 
@@ -169,7 +170,7 @@ public class PoiServiceTests
     public async Task GetPoisAsync_OverpassFailure_ContinuesAndReturnsSeededItems()
     {
         var repo = new PoiFakeRepository();
-        var tiles = PoiService.ComputeTiles(52.3, 4.9, 5.0).ToList();
+        var tiles = TileHelper.ComputeTiles(52.3, 4.9, 5.0).ToList();
         var firstTile = tiles[0];
 
         // Seed one tile + one item to verify partial return still works
@@ -202,23 +203,5 @@ public class PoiServiceTests
     public void IsPoiTypeAllowed_ReturnsExpectedResult(string poiType, string vehicleType, bool expected)
     {
         Assert.Equal(expected, PoiService.IsPoiTypeAllowed(poiType, vehicleType));
-    }
-
-    [Fact]
-    public void ComputeTiles_KnownPoint_ReturnsContainingCell()
-    {
-        // lat=52.3, lng=4.9 → cellLat=floor(52.3*2)=104, cellLng=floor(4.9*2)=9
-        var tiles = PoiService.ComputeTiles(52.3, 4.9, 0.1);
-
-        Assert.Contains((104, 9), tiles);
-    }
-
-    [Fact]
-    public void ComputeTiles_LargeRadius_ReturnsMultipleCells()
-    {
-        // 100km radius should span several 0.5° cells
-        var tiles = PoiService.ComputeTiles(52.3, 4.9, 100.0);
-
-        Assert.True(tiles.Count > 4);
     }
 }

--- a/src/GarageStack.Tests/TileHelperTests.cs
+++ b/src/GarageStack.Tests/TileHelperTests.cs
@@ -25,4 +25,22 @@ public class TileHelperTests
         Assert.NotEmpty(tiles);
         Assert.True(tiles.Count < 50);
     }
+
+    [Fact]
+    public void ComputeTiles_KnownPoint_ReturnsContainingCell()
+    {
+        // lat=52.3, lng=4.9 → cellLat=floor(52.3*2)=104, cellLng=floor(4.9*2)=9
+        var tiles = TileHelper.ComputeTiles(52.3, 4.9, 0.1);
+
+        Assert.Contains((104, 9), tiles);
+    }
+
+    [Fact]
+    public void ComputeTiles_LargeRadius_ReturnsMultipleCells()
+    {
+        // 100km radius should span several 0.5° cells
+        var tiles = TileHelper.ComputeTiles(52.3, 4.9, 100.0);
+
+        Assert.True(tiles.Count > 4);
+    }
 }

--- a/src/GarageStack.Worker/Mqtt/MqttConsumerService.cs
+++ b/src/GarageStack.Worker/Mqtt/MqttConsumerService.cs
@@ -224,26 +224,25 @@ public class MqttConsumerService(
     {
         if (snapshot.EngineRunning is null) return false;
 
-        var hadPrevious = _engineRunningTracker.TryUpdate(vin, snapshot.EngineRunning.Value, out var wasRunning);
-        if (!hadPrevious)
+        var current = snapshot.EngineRunning.Value;
+        var hadPrevious = _engineRunningTracker.TryUpdate(vin, current, out var wasRunning);
+
+        // First observation after startup is treated as a no-op to avoid false "engine started"
+        // alerts when the worker restarts while driving.
+        switch (BoolTransitionDetector.Detect(hadPrevious, wasRunning, current))
         {
-            // First observation after startup: seed state without firing to avoid
-            // false "engine started" alerts when the worker restarts while driving.
-            return false;
+            case StateTransition.TurnedOn:
+                logger.LogInformation("Engine started for VIN={Vin} - sending push notification", vin);
+                await pushSender.SendToAllAsync("Engine started", "Your car has been started.", ct, "engine-start", snapshot.VehicleId);
+                return false;
+
+            case StateTransition.TurnedOff:
+                // A trip just completed
+                return true;
+
+            default:
+                return false;
         }
-
-        if (snapshot.EngineRunning.Value && !wasRunning)
-        {
-            logger.LogInformation("Engine started for VIN={Vin} - sending push notification", vin);
-            await pushSender.SendToAllAsync("Engine started", "Your car has been started.", ct, "engine-start", snapshot.VehicleId);
-            return false;
-        }
-
-        // Engine stopped: a trip just completed
-        if (!snapshot.EngineRunning.Value && wasRunning)
-            return true;
-
-        return false;
     }
 
     private async Task HandleHaDiscoveryAsync(string payload, CancellationToken ct)

--- a/src/GarageStack.Worker/Mqtt/TelemetryMapper.cs
+++ b/src/GarageStack.Worker/Mqtt/TelemetryMapper.cs
@@ -37,6 +37,23 @@ public static class TelemetryMapper
 
     private static double? N(double v) => double.IsFinite(v) ? v : null;
 
+    // Applies a compound-JSON payload (e.g. location/position, chargingSchedule) via the given
+    // callback. Returns false, rather than throwing, when the payload isn't valid JSON so callers
+    // can treat a malformed message the same way as any other recognised-but-bad subtopic.
+    private static bool TryApplyJson(string payload, Action<JsonElement> apply)
+    {
+        try
+        {
+            using var doc = JsonDocument.Parse(payload);
+            apply(doc.RootElement);
+            return true;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
     private static bool? ApplyDrivetrainBasics(TelemetrySnapshot s, string subtopic, double numeric, bool? asBool)
     {
         switch (subtopic)
@@ -151,20 +168,13 @@ public static class TelemetryMapper
         {
             // Gateway publishes a compound JSON object, not separate topics
             case "location/position":
-                try
+                return TryApplyJson(payload, root =>
                 {
-                    using var doc = JsonDocument.Parse(payload);
-                    var root = doc.RootElement;
                     if (root.TryGetProperty("latitude", out var lat) && lat.TryGetDouble(out var latVal))
                         s.Latitude = N(latVal);
                     if (root.TryGetProperty("longitude", out var lon) && lon.TryGetDouble(out var lonVal))
                         s.Longitude = N(lonVal);
-                }
-                catch
-                {
-                    return false;
-                }
-                return true;
+                });
 
             case "location/latitude":
                 s.Latitude = N(numeric);
@@ -338,17 +348,11 @@ public static class TelemetryMapper
                 return true;
 
             case "drivetrain/currentJourney":
-                try
+                return TryApplyJson(payload, root =>
                 {
-                    using var cjDoc = JsonDocument.Parse(payload);
-                    if (cjDoc.RootElement.TryGetProperty("distance", out var dist) && dist.TryGetDouble(out var dv))
+                    if (root.TryGetProperty("distance", out var dist) && dist.TryGetDouble(out var dv))
                         s.CurrentJourneyDistance = N(dv);
-                }
-                catch
-                {
-                    return false;
-                }
-                return true;
+                });
 
             default:
                 return null;
@@ -382,18 +386,12 @@ public static class TelemetryMapper
                 return true;
 
             case "drivetrain/chargingSchedule":
-                try
+                return TryApplyJson(payload, root =>
                 {
-                    using var csDoc = JsonDocument.Parse(payload);
-                    if (csDoc.RootElement.TryGetProperty("mode", out var csm)) s.ChargingScheduleMode = csm.GetString();
-                    if (csDoc.RootElement.TryGetProperty("startTime", out var css)) s.ChargingScheduleStartTime = css.GetString();
-                    if (csDoc.RootElement.TryGetProperty("endTime", out var cse)) s.ChargingScheduleEndTime = cse.GetString();
-                }
-                catch
-                {
-                    return false;
-                }
-                return true;
+                    if (root.TryGetProperty("mode", out var csm)) s.ChargingScheduleMode = csm.GetString();
+                    if (root.TryGetProperty("startTime", out var css)) s.ChargingScheduleStartTime = css.GetString();
+                    if (root.TryGetProperty("endTime", out var cse)) s.ChargingScheduleEndTime = cse.GetString();
+                });
 
             case "bms/chargeStatus":
                 s.BmsChargeStatus = payload;
@@ -444,19 +442,13 @@ public static class TelemetryMapper
                 return true;
 
             case "drivetrain/batteryHeatingSchedule":
-                try
+                return TryApplyJson(payload, root =>
                 {
-                    using var bhDoc = JsonDocument.Parse(payload);
-                    if (bhDoc.RootElement.TryGetProperty("mode", out var m))
+                    if (root.TryGetProperty("mode", out var m))
                         s.BatteryHeatingScheduleMode = m.GetString();
-                    if (bhDoc.RootElement.TryGetProperty("startTime", out var st))
+                    if (root.TryGetProperty("startTime", out var st))
                         s.BatteryHeatingScheduleStartTime = st.GetString();
-                }
-                catch
-                {
-                    return false;
-                }
-                return true;
+                });
 
             default:
                 return null;

--- a/src/GarageStack.Worker/Program.cs
+++ b/src/GarageStack.Worker/Program.cs
@@ -34,11 +34,6 @@ try
 
     builder.Services.AddGarageStackData(connectionString);
     builder.Services.Configure<MqttOptions>(builder.Configuration.GetSection("Mqtt"));
-    builder.Services.AddHttpClient("overpass", client =>
-    {
-        client.DefaultRequestHeaders.UserAgent.ParseAdd("GarageStack/1.0");
-        client.Timeout = TimeSpan.FromSeconds(45);
-    });
     builder.Services.AddSingleton<GarageStack.Core.Interfaces.IPushSender, GarageStack.Worker.Services.PushSenderService>();
     builder.Services.AddHostedService<MqttConsumerService>();
     builder.Services.AddHostedService<PushNotificationCheckService>();

--- a/src/GarageStack.Worker/Services/PushNotificationCheckService.cs
+++ b/src/GarageStack.Worker/Services/PushNotificationCheckService.cs
@@ -122,12 +122,13 @@ public class PushNotificationCheckService(
         if (s.IsCharging is null) return;
 
         var current = s.IsCharging.Value;
-        var hasPrevious = _isChargingTracker.TryUpdate(vin, current, out var previous);
+        var hadPrevious = _isChargingTracker.TryUpdate(vin, current, out var previous);
 
-        if (!hasPrevious || previous is null) return;
+        if (BoolTransitionDetector.Detect(hadPrevious, previous, current) != StateTransition.TurnedOff)
+            return;
 
         // Charging finished while cable is still connected (session complete, not unplugged mid-charge)
-        if (!current && previous == true && s.ChargerConnected == true)
+        if (s.ChargerConnected == true)
         {
             var soc = s.EvSocPercent is not null ? $" (SOC: {s.EvSocPercent:F0}%)" : string.Empty;
             alerts.Add(("charging-complete", "Charging Complete", $"Your car has finished charging{soc}"));
@@ -143,20 +144,22 @@ public class PushNotificationCheckService(
         if (s.EngineRunning is null) return false;
 
         var current = s.EngineRunning.Value;
-        var hasPrevious = _engineRunningTracker.TryUpdate(vin, current, out var previous);
+        var hadPrevious = _engineRunningTracker.TryUpdate(vin, current, out var previous);
 
-        // Skip the first check after startup — no baseline to compare against
-        if (!hasPrevious || previous is null) return false;
-
-        if (current && previous == false)
-            alerts.Add(("engine-start", "Car Started", "Your car engine has started"));
-        else if (!current && previous == true)
+        // First observation after startup is skipped: no baseline to compare against.
+        switch (BoolTransitionDetector.Detect(hadPrevious, previous, current))
         {
-            _lastParkedAt[vin] = DateTime.UtcNow;
-            return true;
-        }
+            case StateTransition.TurnedOn:
+                alerts.Add(("engine-start", "Car Started", "Your car engine has started"));
+                return false;
 
-        return false;
+            case StateTransition.TurnedOff:
+                _lastParkedAt[vin] = DateTime.UtcNow;
+                return true;
+
+            default:
+                return false;
+        }
     }
 
     private static bool IsParked(Core.Models.TelemetrySnapshot s)

--- a/src/GarageStack.Worker/Services/PushSenderService.cs
+++ b/src/GarageStack.Worker/Services/PushSenderService.cs
@@ -52,6 +52,8 @@ public sealed class PushSenderService : IPushSender, IDisposable
 
     public async Task SendToAllAsync(string title, string body, CancellationToken ct = default, string? category = null, int? vehicleId = null)
     {
+        int? unreadCount = null;
+
         // Always persist so the in-app bell works regardless of push configuration
         try
         {
@@ -68,7 +70,7 @@ public sealed class PushSenderService : IPushSender, IDisposable
             recordDb.AppNotifications.Add(record);
             await recordDb.SaveChangesAsync(ct);
 
-            var unreadCount = await recordDb.AppNotifications
+            unreadCount = await recordDb.AppNotifications
                 .CountAsync(n => !n.IsArchived && !n.IsDeleted, ct);
 
             // Signal the API process via PostgreSQL so connected browser clients get
@@ -88,7 +90,7 @@ public sealed class PushSenderService : IPushSender, IDisposable
         }
         catch (Exception ex)
         {
-            _logger.LogWarning(ex, "Failed to persist notification record — push delivery will still proceed");
+            _logger.LogWarning(ex, "Failed to persist notification record, push delivery will still proceed");
         }
 
         if (_pushClient is null) return;
@@ -98,9 +100,10 @@ public sealed class PushSenderService : IPushSender, IDisposable
         var subscriptions = await db.PushSubscriptions.AsNoTracking().ToListAsync(ct);
         if (subscriptions.Count == 0) return;
 
-        var unreadCountForPayload = await db.AppNotifications
+        // Only re-queried if persistence above failed before it could compute this itself.
+        unreadCount ??= await db.AppNotifications
             .CountAsync(n => !n.IsArchived && !n.IsDeleted, ct);
-        var payload = System.Text.Json.JsonSerializer.Serialize(new { title, body, icon = "/icons/icon-192.png", category, unreadCount = unreadCountForPayload });
+        var payload = System.Text.Json.JsonSerializer.Serialize(new { title, body, icon = "/icons/icon-192.png", category, unreadCount });
         var message = new PushMessage(payload) { TimeToLive = 3600 };
         var dead = new ConcurrentBag<ModelPushSubscription>();
 


### PR DESCRIPTION
## Summary

Follow-up to a full project review, focused purely on deduplication (no new features, no unrelated cleanup).

**Backend**
- Reuse `TileHelper.CellOf` in `OcmApiClient`/`OverpassApiClient` instead of hand-inlined tile math
- Dedupe the `VehicleRepository` VIN lookup (and add `.AsNoTracking()` on the read-only path)
- Remove the redundant `PoiService.ComputeTiles` wrapper
- Centralize the `ocm`/`overpass` HttpClient + singleton registration into one extension shared by Api and Worker
- Extract a `TryApplyJson` helper in `TelemetryMapper` (was copy-pasted 4x)
- Stop computing the unread-notification count twice per call in `PushSenderService`
- Extract a shared date-range parsing helper in `VehicleEndpoints` — also fixes `/stats` silently accepting an inverted date range, a bug the duplication had let drift from `/history` and `/trips`
- Replace the repeated "resolve vehicle or 404" boilerplate (10+ call sites across 3 endpoint files) with a `ResolveVehicleFilter` endpoint filter
- Dedupe lat/lng/radius/type validation across the 3 `MapEndpoints` routes
- Unify engine-start/stop and charging-complete transition detection behind a shared `BoolTransitionDetector`

**Frontend**
- `utils/leaflet.ts` — one shared CJS/ESM unwrap instead of 5 copies
- `useLeafletMap` composable — one shared `@ready` wiring instead of 3 copies
- `CommandButton.vue` — one shared component replacing the spinner/clock/label markup duplicated across Doors, Find My Car, HV Battery, and Climate cards
- `EditableCardSlot.vue` — one shared drag-handle/placeholder/hide-badge wrapper replacing 4 copies in Dashboard and Statistics edit mode
- `CarDiagram.vue` — tyre indicators/labels and door badges now driven from config arrays instead of hand-repeated blocks

## Test plan

- [x] `dotnet test` — 268 passed
- [x] `pnpm run type-check`, `pnpm run lint`, `pnpm run test:unit` (144 passed)
- [x] Manual Playwright pass against the app in Demo mode: dashboard normal/edit mode, card hide/show toggling, car diagram, statistics edit mode, map, and the Doors/Climate/HV Battery/Find My Car command modals (including a live sending → pending state transition)

🤖 Generated with [Claude Code](https://claude.com/claude-code)