### PR TITLE
Widen dashboard map on large screens; fit active trip in view

### DIFF
--- a/frontend/src/assets/main.css
+++ b/frontend/src/assets/main.css
@@ -2111,6 +2111,11 @@ body,
   .status-grid {
     grid-template-columns: repeat(6, 1fr);
   }
+
+  .overview-row__map {
+    flex: 1.4 1 420px;
+    max-width: 560px;
+  }
 }
 
 /* ── Full-HD and above (1920px+) ──────────────────────────── */
@@ -2118,6 +2123,10 @@ body,
 @media (min-width: 1920px) {
   .status-grid {
     grid-template-columns: repeat(8, 1fr);
+  }
+
+  .overview-row__map {
+    max-width: 680px;
   }
 }
 

--- a/frontend/src/components/LocationMapWidget.vue
+++ b/frontend/src/components/LocationMapWidget.vue
@@ -70,27 +70,52 @@ function buildActiveTripLayers() {
   }).addTo(map)
 }
 
+// While a trip is in progress, fit the view to the entire route travelled so far (start to
+// current position) instead of just centering on the car, so the whole trip stays visible as
+// it grows. Falls back to centering on the car when parked (no active trip).
+function updateMapView() {
+  const map = mapInstance.value
+  if (!map) return
+  const trip = activeTrip.value
+  if (trip) {
+    const coords = trip.points.map((p) => [p.latitude, p.longitude] as [number, number])
+    if (hasLocation.value) coords.push(center.value)
+    if (coords.length === 0) return
+    const bounds = L.latLngBounds(coords)
+    if (bounds.getNorthEast().equals(bounds.getSouthWest())) {
+      map.setView(bounds.getCenter(), 15, { animate: false })
+    } else {
+      map.fitBounds(bounds, { padding: [24, 24], animate: false })
+    }
+  } else if (hasLocation.value) {
+    map.setView(center.value, 14, { animate: false })
+  }
+}
+
 function onMapReady(map: LeafletMap) {
   bindMapReady(map, () => {
-    if (hasLocation.value) map.setView(center.value, 14, { animate: false })
     buildActiveTripLayers()
+    updateMapView()
   })
 }
 
-// Keep the preview centred on the car as new status updates arrive, and keep the live car
-// marker (if the active trip is currently shown) following position/heading without a full
-// layer rebuild.
+// Keep the preview following the car (or the whole in-progress trip) as new status updates
+// arrive, and keep the live car marker following position/heading without a full layer rebuild.
 watch(status, (s) => {
   if (!mapInstance.value || s?.latitude == null || s?.longitude == null) return
-  mapInstance.value.setView([s.latitude, s.longitude], 14, { animate: false })
   if (carMarker) {
     carMarker.setLatLng([s.latitude, s.longitude])
     carMarker.setIcon(buildCarMarkerIcon(s.heading ?? 0))
   }
+  updateMapView()
 })
 
-// Trip start/end, or a refreshed trips fetch: rebuild the route line and car marker.
-watch(activeTrip, () => buildActiveTripLayers())
+// Trip start/end, or a refreshed trips fetch: rebuild the route line and car marker, and
+// refit the view to the (possibly grown) route.
+watch(activeTrip, () => {
+  buildActiveTripLayers()
+  updateMapView()
+})
 
 onUnmounted(() => {
   clearActiveTripLayers()


### PR DESCRIPTION
## Summary
- On large screens (1440px+, 1920px+), the location map on the dashboard now gets more relative width compared to the tyre diagram.
- When a trip is in progress, the location map now fits the entire route travelled so far (start to current position) instead of just centering on the car's current location, and keeps refitting as the trip grows.

## Test plan
- [x] `pnpm test:unit` (144 passed)
- [x] `pnpm type-check` (clean)
- [x] `pnpm exec prettier --write` on changed files