### PR TITLE
Fix unusably small map on medium-width (tablet) screens

### DIFF
--- a/frontend/src/assets/map.css
+++ b/frontend/src/assets/map.css
@@ -401,8 +401,10 @@
   white-space: nowrap;
 }
 
-@media (max-width: 767px) {
-  /* Map: column direction on mobile (base already sets flex: 1 / min-height: 0) */
+/* Trips above the map: below the tablet breakpoint the nav sidebar (220px) plus the fixed
+   290px trip sidebar leave too little width for a usable map, so stack them here rather than
+   waiting for the general mobile breakpoint below. */
+@media (max-width: 1023px) {
   .map-layout {
     flex-direction: column;
   }
@@ -419,7 +421,9 @@
     min-height: 200px;
     height: auto;
   }
+}
 
+@media (max-width: 767px) {
   .map-controls {
     flex-wrap: wrap;
     gap: 0.4rem;


### PR DESCRIPTION
## Summary
- On MapView, the nav sidebar (220px) plus the fixed 290px trip sidebar left almost no room for the map at viewport widths just above the old 767px mobile breakpoint (e.g. ~784px tablet landscape).
- The "trips above map" stacked layout now kicks in at 1023px instead of 767px, matching the tablet breakpoint boundary already used elsewhere in the app (`main.css`'s 600-1023px tablet range).

## Test plan
- [x] Verified with a Playwright screenshot harness reusing the real CSS: at 784px/900px/1023px the layout now stacks (map gets full width); at 1024px+ it's still side-by-side.
- [x] `pnpm test:unit` (144 passed)
- [x] `pnpm type-check` (clean)
- [x] `pnpm exec prettier --write` on the changed file