### PR TITLE
Coalesce fuel station brand variants in map filter

### DIFF
--- a/frontend/src/composables/usePoiLayers.ts
+++ b/frontend/src/composables/usePoiLayers.ts
@@ -7,6 +7,7 @@ import type { VehicleType } from '@/stores/vehicle'
 import { useMapSettingsStore } from '@/stores/settingsMap'
 import { mapApi } from '@/services/mapApi'
 import type { ChargingStation, PoiItem } from '@/services/mapApi'
+import { canonicalFuelBrand } from '@/utils/fuelBrands'
 
 type ClusterFactory = {
   markerClusterGroup: (options?: {
@@ -182,12 +183,14 @@ export function usePoiLayers({ mapInstance, vehicleType, isHev, isBev }: UsePoiL
   const poiLoadingCount = ref(0)
   const poiLoading = computed(() => poiLoadingCount.value > 0)
 
+  // Coalesced brand names shown in the filter dropdown (e.g. "BP" covers "BP" and "BP express").
+  // See canonicalFuelBrand for the raw-variant -> canonical mapping.
   const availableFuelBrands = computed(() => {
-    const brands = new Set<string>(cachedFuelBrands.value)
+    const brands = new Set<string>(cachedFuelBrands.value.map(canonicalFuelBrand))
     for (const item of fuelAllItems.values()) {
       const tags = item.tags ?? {}
       const brand = tags['brand'] ?? tags['operator'] ?? null
-      if (brand) brands.add(brand)
+      if (brand) brands.add(canonicalFuelBrand(brand))
     }
     return [...brands].sort((a, b) => a.localeCompare(b))
   })
@@ -337,7 +340,12 @@ export function usePoiLayers({ mapInstance, vehicleType, isHev, isBev }: UsePoiL
     for (const item of fuelAllItems.values()) {
       const tags = item.tags ?? {}
       const brand = tags['brand'] ?? tags['operator'] ?? null
-      if (selectedBrands.length > 0 && (brand === null || !selectedBrands.includes(brand))) continue
+      const canonicalBrand = brand ? canonicalFuelBrand(brand) : null
+      if (
+        selectedBrands.length > 0 &&
+        (canonicalBrand === null || !selectedBrands.includes(canonicalBrand))
+      )
+        continue
       const icon = L.divIcon({
         className: '',
         html: '<div class="poi-marker poi-marker--fuel">&#9981;</div>',

--- a/frontend/src/utils/__tests__/fuelBrands.spec.ts
+++ b/frontend/src/utils/__tests__/fuelBrands.spec.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest'
+import { canonicalFuelBrand } from '@/utils/fuelBrands'
+
+describe('canonicalFuelBrand', () => {
+  it.each([
+    ['BP', 'BP'],
+    ['BP express', 'BP'],
+    ['Shell', 'Shell'],
+    ['Shell Express', 'Shell'],
+    ['Esso', 'Esso'],
+    ['Esso Express', 'Esso'],
+    ['TotalEnergies', 'TotalEnergies'],
+    ['TotalEnergies Express', 'TotalEnergies'],
+    ['Texaco', 'Texaco'],
+    ['Texaco Pouw BV', 'Texaco'],
+    ['Tamoil', 'Tamoil'],
+    ['Tamoil express', 'Tamoil'],
+    ['Argos', 'Argos'],
+    ['ArgosOil', 'Argos'],
+    ['Avia', 'Avia'],
+    ['AVIA', 'Avia'],
+    ['Avia Marees', 'Avia'],
+    ['AVIA Truck', 'Avia'],
+    ['Avia Xpress', 'Avia'],
+    ['AVIA XPress', 'Avia'],
+    ['Lukoil', 'Lukoil'],
+    ['Lukoil Express', 'Lukoil'],
+    ['OK', 'OK'],
+    ['OK express', 'OK'],
+    ['Haan', 'Haan'],
+    ['Haan Express', 'Haan'],
+    ['T-Energy', 'T-Energy'],
+    ['T-Energy express', 'T-Energy'],
+    ['Pin&Go', 'Pin&Go'],
+    ['Pin&GO', 'Pin&Go'],
+    ['De meeuw', 'De Meeuw'],
+    ['De Meeuw', 'De Meeuw'],
+    ['Fieten olie', 'Fieten Olie'],
+    ['Fieten Olie', 'Fieten Olie'],
+    ['Dirk', 'Dirk'],
+    ['Dirk vd Broek', 'Dirk'],
+  ])('coalesces %s to %s', (raw, expected) => {
+    expect(canonicalFuelBrand(raw)).toBe(expected)
+  })
+
+  it.each(['Q8', 'Gulf', 'TinQ', 'Tango', 'GT24', 'Skippy', 'Autofood'])(
+    'leaves unrelated brand %s unchanged',
+    (raw) => {
+      expect(canonicalFuelBrand(raw)).toBe(raw)
+    },
+  )
+
+  it('trims whitespace', () => {
+    expect(canonicalFuelBrand('  BP express  ')).toBe('BP')
+  })
+})

--- a/frontend/src/utils/fuelBrands.ts
+++ b/frontend/src/utils/fuelBrands.ts
@@ -1,0 +1,31 @@
+// OSM `brand`/`operator` tags for fuel stations contain inconsistent spellings of the same
+// chain (casing, "Express"/"Xpress" suffixes for shop-only sub-brands, abbreviated vs full
+// company names). This maps each known raw variant to one canonical display name so the brand
+// filter shows a single "BP" entry instead of "BP" / "BP express" side by side. Keys are
+// lowercased+trimmed raw brand strings; anything not listed here keeps its own name unchanged.
+const BRAND_ALIASES: Record<string, string> = {
+  argosoil: 'Argos',
+  avia: 'Avia',
+  'avia marees': 'Avia',
+  'avia truck': 'Avia',
+  'avia xpress': 'Avia',
+  'bp express': 'BP',
+  'de meeuw': 'De Meeuw',
+  'dirk vd broek': 'Dirk',
+  'esso express': 'Esso',
+  'fieten olie': 'Fieten Olie',
+  'haan express': 'Haan',
+  'lukoil express': 'Lukoil',
+  'ok express': 'OK',
+  'pin&go': 'Pin&Go',
+  'shell express': 'Shell',
+  't-energy express': 'T-Energy',
+  'tamoil express': 'Tamoil',
+  'texaco pouw bv': 'Texaco',
+  'totalenergies express': 'TotalEnergies',
+}
+
+export function canonicalFuelBrand(raw: string): string {
+  const trimmed = raw.trim()
+  return BRAND_ALIASES[trimmed.toLowerCase()] ?? trimmed
+}


### PR DESCRIPTION
## Summary
- OSM `brand`/`operator` tags contain inconsistent spellings of the same fuel chain (e.g. `BP` / `BP express`, `Avia` / `AVIA` / `Avia Xpress`, `Shell` / `Shell Express`). Added `canonicalFuelBrand()` to normalize known variants into a single display name.
- The map's fuel brand filter dropdown now shows one entry per brand family instead of near-duplicates.
- Marker filtering matches on the canonicalized brand, so selecting the coalesced "BP" option still shows BP Express stations - no stations are hidden.

## Test plan
- [x] `pnpm exec vitest run` - 188 tests pass, including 44 new cases in `fuelBrands.spec.ts`
- [x] `pnpm exec vue-tsc --noEmit` - clean
- [x] `pnpm exec eslint` on changed files - clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)