### PR TITLE
Keep car centered on dashboard map during active trip

### DIFF
--- a/frontend/src/components/LocationMapWidget.vue
+++ b/frontend/src/components/LocationMapWidget.vue
@@ -70,23 +70,43 @@ function buildActiveTripLayers() {
   }).addTo(map)
 }
 
+function fitBoundsSafe(map: LeafletMap, bounds: ReturnType<typeof L.latLngBounds>) {
+  if (bounds.getNorthEast().equals(bounds.getSouthWest())) {
+    map.setView(bounds.getCenter(), 15, { animate: false })
+  } else {
+    map.fitBounds(bounds, { padding: [24, 24], animate: false })
+  }
+}
+
 // While a trip is in progress, fit the view to the entire route travelled so far (start to
-// current position) instead of just centering on the car, so the whole trip stays visible as
-// it grows. Falls back to centering on the car when parked (no active trip).
+// current position) while keeping the car centered, so the whole trip stays visible as it
+// grows without the view drifting off the car. Built by taking the largest lat/lng offset from
+// the car to any trip point and mirroring it on the opposite side, which keeps the car at the
+// exact centre of the resulting bounds. Falls back to centering on the car when parked.
 function updateMapView() {
   const map = mapInstance.value
   if (!map) return
   const trip = activeTrip.value
-  if (trip) {
-    const coords = trip.points.map((p) => [p.latitude, p.longitude] as [number, number])
-    if (hasLocation.value) coords.push(center.value)
-    if (coords.length === 0) return
-    const bounds = L.latLngBounds(coords)
-    if (bounds.getNorthEast().equals(bounds.getSouthWest())) {
-      map.setView(bounds.getCenter(), 15, { animate: false })
-    } else {
-      map.fitBounds(bounds, { padding: [24, 24], animate: false })
+  if (trip && hasLocation.value) {
+    const car = center.value
+    let maxLatDelta = 0
+    let maxLngDelta = 0
+    for (const p of trip.points) {
+      maxLatDelta = Math.max(maxLatDelta, Math.abs(p.latitude - car[0]))
+      maxLngDelta = Math.max(maxLngDelta, Math.abs(p.longitude - car[1]))
     }
+    fitBoundsSafe(
+      map,
+      L.latLngBounds(
+        [car[0] - maxLatDelta, car[1] - maxLngDelta],
+        [car[0] + maxLatDelta, car[1] + maxLngDelta],
+      ),
+    )
+  } else if (trip && trip.points.length > 0) {
+    fitBoundsSafe(
+      map,
+      L.latLngBounds(trip.points.map((p) => [p.latitude, p.longitude] as [number, number])),
+    )
   } else if (hasLocation.value) {
     map.setView(center.value, 14, { animate: false })
   }


### PR DESCRIPTION
## Summary
- The dashboard location map already fit the entire in-progress trip in view; this keeps the car centered in that view too, instead of centering on the trip's bounding-box midpoint (which can drift away from the car).
- Achieved by building the fit bounds symmetrically around the car (largest lat/lng offset to any trip point, mirrored on the opposite side), so the car is always the geometric center while the full route still fits.

## Test plan
- [x] Verified the centering math: bounds built this way always average back to the car's exact coordinates, while still containing every trip point.
- [x] `pnpm test:unit` (188 passed)
- [x] `pnpm type-check` (clean)
- [x] `pnpm exec prettier --write` on the changed file