### PR TITLE
fix: climate control batching, steering wheel heating removal, and container hardening

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -125,6 +125,54 @@ updates:
           - "Microsoft.NET.Test.Sdk"
           - "coverlet.*"
 
+  # ── Docker base images ───────────────────────────────────────────────────────
+  # Covers both Dockerfile FROM lines and docker-compose.yml image: references
+  # (e.g. the pinned saicismartapi/saic-python-mqtt-gateway tag) in each directory.
+  - package-ecosystem: docker
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "07:00"
+      timezone: "Europe/Amsterdam"
+    open-pull-requests-limit: 4
+
+  - package-ecosystem: docker
+    directory: /src/GarageStack.Api
+    schedule:
+      interval: weekly
+      day: monday
+      time: "07:00"
+      timezone: "Europe/Amsterdam"
+    open-pull-requests-limit: 2
+
+  - package-ecosystem: docker
+    directory: /src/GarageStack.Worker
+    schedule:
+      interval: weekly
+      day: monday
+      time: "07:00"
+      timezone: "Europe/Amsterdam"
+    open-pull-requests-limit: 2
+
+  - package-ecosystem: docker
+    directory: /frontend
+    schedule:
+      interval: weekly
+      day: monday
+      time: "07:00"
+      timezone: "Europe/Amsterdam"
+    open-pull-requests-limit: 2
+
+  - package-ecosystem: docker
+    directory: /docker/all-in-one
+    schedule:
+      interval: weekly
+      day: monday
+      time: "07:00"
+      timezone: "Europe/Amsterdam"
+    open-pull-requests-limit: 2
+
   # ── GitHub Actions ───────────────────────────────────────────────────────────
   - package-ecosystem: github-actions
     directory: /

--- a/README.md
+++ b/README.md
@@ -80,14 +80,14 @@ The Statistics view shows insight cards and charts for a configurable period (7,
 
 > **Important:** The MG iSmart API only allows one active session per account at a time. Logging in anywhere else with the same credentials -- including the official MG app -- will immediately invalidate GarageStack's session, causing telemetry to stop until GarageStack reconnects.
 
-To use GarageStack alongside the official MG app without interrupting either, set up a secondary account:
+GarageStack needs the vehicle **owner account**: shared or secondary accounts lack the write permissions required to register alarm switches and will fail with error 1100003. So instead of moving GarageStack off the owner account, set up a secondary account for the official MG app to use, and keep the owner account free for GarageStack:
 
 1. Open the MG app and go to **Settings > Account management > Add secondary account** (exact wording varies by region and app version).
 2. Invite a second email address and accept the invite on that account.
 3. Grant the secondary account access to your vehicle.
-4. Use the secondary account's credentials for `SAIC_USER` / `SAIC_PASSWORD` in GarageStack.
+4. Sign in to the official MG app with the secondary account, and use the owner account's credentials for `SAIC_USER` / `SAIC_PASSWORD` in GarageStack.
 
-This way the official app keeps its own session on the owner account and GarageStack runs independently on the secondary account.
+This way the official app runs independently on the secondary account and GarageStack keeps its own session on the owner account.
 
 ---
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       - mosquitto_data:/mosquitto/data/
 
   saic-mqtt-gateway:
-    image: saicismartapi/saic-python-mqtt-gateway:latest
+    image: saicismartapi/saic-python-mqtt-gateway:0.12.0
     container_name: saic-mqtt
     restart: unless-stopped
     depends_on:
@@ -124,7 +124,7 @@ services:
       - "127.0.0.1:${API_PORT:-5000}:8080"
     volumes:
       - api_logs:/app/logs
-      - api_dataprotection:/root/.aspnet/DataProtection-Keys
+      - api_dataprotection:/app/keys
 
   frontend:
     build:

--- a/docker/all-in-one/Dockerfile
+++ b/docker/all-in-one/Dockerfile
@@ -36,7 +36,7 @@ RUN dotnet publish GarageStack.Api/GarageStack.Api.csproj -c Release -o /publish
 # ── Stage 3: Pull SAIC MQTT Gateway (source of truth for the gateway app) ────
 # The gateway is not on PyPI. We copy its pre-built venv + source directly from
 # the official image so we always match the tested Python/dependency versions.
-FROM saicismartapi/saic-python-mqtt-gateway:latest AS saic-source
+FROM saicismartapi/saic-python-mqtt-gateway:0.12.0 AS saic-source
 
 # ── Stage 4: Final all-in-one runtime image ───────────────────────────────────
 # python:3.14-slim is Debian trixie (13) -- the same base the saic gateway uses,

--- a/frontend/src/components/ClimateDetailCard.vue
+++ b/frontend/src/components/ClimateDetailCard.vue
@@ -17,11 +17,11 @@ const props = defineProps<{
   heatedSeatFrontLeft: number | null
   heatedSeatFrontRight: number | null
   rearWindowDefroster: boolean | null
-  steeringWheelHeating: boolean | null
 }>()
 
 const modalOpen = ref(false)
-const { sending, lastResult, isPending, send } = useVehicleCommand()
+const applyInProgress = ref(false)
+const { sending, lastResult, isPending, send, waitUntilSettled } = useVehicleCommand()
 
 const TEMP_MIN = 16
 const TEMP_MAX = 28
@@ -35,7 +35,6 @@ const seatLabels = computed(() => [
 
 const localClimateOn = ref<boolean | null>(props.climateOn)
 const localRearDefroster = ref<boolean | null>(props.rearWindowDefroster)
-const localSteeringWheel = ref<boolean | null>(props.steeringWheelHeating ?? false)
 const sliderTemp = ref<number>(props.remoteTemperature ?? 22)
 const seatLeftLocal = ref<number>(props.heatedSeatFrontLeft ?? 0)
 const seatRightLocal = ref<number>(props.heatedSeatFrontRight ?? 0)
@@ -44,7 +43,6 @@ watch(modalOpen, (open) => {
   if (open) {
     localClimateOn.value = props.climateOn
     localRearDefroster.value = props.rearWindowDefroster
-    localSteeringWheel.value = props.steeringWheelHeating ?? false
     sliderTemp.value = props.remoteTemperature ?? 22
     seatLeftLocal.value = props.heatedSeatFrontLeft ?? 0
     seatRightLocal.value = props.heatedSeatFrontRight ?? 0
@@ -67,14 +65,12 @@ const hasAnyData = computed(
     props.exteriorTemperature !== null ||
     props.heatedSeatFrontLeft !== null ||
     props.heatedSeatFrontRight !== null ||
-    props.rearWindowDefroster !== null ||
-    props.steeringWheelHeating !== null,
+    props.rearWindowDefroster !== null,
 )
 
 const commandKeys = [
   'climate',
   'rear-defroster',
-  'steering-wheel',
   'climate-temperature',
   'seat-left',
   'seat-right',
@@ -88,11 +84,6 @@ const hasPendingChanges = computed(() => {
   if (props.rearWindowDefroster !== null && localRearDefroster.value !== props.rearWindowDefroster)
     return true
   if (
-    (props.steeringWheelHeating !== null || props.rearWindowDefroster !== null) &&
-    localSteeringWheel.value !== (props.steeringWheelHeating ?? false)
-  )
-    return true
-  if (
     (props.climateOn !== null || props.remoteTemperature !== null) &&
     sliderTemp.value !== (props.remoteTemperature ?? 22)
   )
@@ -104,46 +95,59 @@ const hasPendingChanges = computed(() => {
   return false
 })
 
+// The real vehicle API only processes one command at a time (each can take up to ~30s
+// to reach the car), so a batch of changes must be sent one at a time, waiting for each
+// to settle before sending the next - firing them all at once queues later commands
+// behind earlier ones and makes them miss their own confirmation window.
 async function applyAll() {
-  if (
-    (props.climateOn !== null || props.remoteTemperature !== null) &&
-    sliderTemp.value !== (props.remoteTemperature ?? 22)
-  ) {
-    await send(props.vin, 'climate-temperature', String(sliderTemp.value))
-  }
-  if (props.climateOn !== null && localClimateOn.value !== props.climateOn) {
-    const target = localClimateOn.value
-    await send(props.vin, 'climate', target ? 'on' : 'off', (s) => s.climateOn === target)
-  }
-  if (
-    props.rearWindowDefroster !== null &&
-    localRearDefroster.value !== props.rearWindowDefroster
-  ) {
-    const target = localRearDefroster.value
-    await send(
-      props.vin,
-      'rear-defroster',
-      target ? 'on' : 'off',
-      (s) => s.rearWindowDefroster === target,
-    )
-  }
-  if (
-    (props.steeringWheelHeating !== null || props.rearWindowDefroster !== null) &&
-    localSteeringWheel.value !== (props.steeringWheelHeating ?? false)
-  ) {
-    const target = localSteeringWheel.value
-    await send(
-      props.vin,
-      'steering-wheel',
-      target ? 'on' : 'off',
-      (s) => s.steeringWheelHeating === target,
-    )
-  }
-  if (props.heatedSeatFrontLeft !== null && seatLeftLocal.value !== props.heatedSeatFrontLeft) {
-    await send(props.vin, 'seat-left', String(seatLeftLocal.value))
-  }
-  if (props.heatedSeatFrontRight !== null && seatRightLocal.value !== props.heatedSeatFrontRight) {
-    await send(props.vin, 'seat-right', String(seatRightLocal.value))
+  applyInProgress.value = true
+  try {
+    if (
+      (props.climateOn !== null || props.remoteTemperature !== null) &&
+      sliderTemp.value !== (props.remoteTemperature ?? 22)
+    ) {
+      const target = sliderTemp.value
+      await send(
+        props.vin,
+        'climate-temperature',
+        String(target),
+        (s) => s.remoteTemperature === target,
+      )
+      await waitUntilSettled('climate-temperature')
+    }
+    if (props.climateOn !== null && localClimateOn.value !== props.climateOn) {
+      const target = localClimateOn.value
+      await send(props.vin, 'climate', target ? 'on' : 'off', (s) => s.climateOn === target)
+      await waitUntilSettled('climate')
+    }
+    if (
+      props.rearWindowDefroster !== null &&
+      localRearDefroster.value !== props.rearWindowDefroster
+    ) {
+      const target = localRearDefroster.value
+      await send(
+        props.vin,
+        'rear-defroster',
+        target ? 'on' : 'off',
+        (s) => s.rearWindowDefroster === target,
+      )
+      await waitUntilSettled('rear-defroster')
+    }
+    if (props.heatedSeatFrontLeft !== null && seatLeftLocal.value !== props.heatedSeatFrontLeft) {
+      const target = seatLeftLocal.value
+      await send(props.vin, 'seat-left', String(target), (s) => s.heatedSeatFrontLeft === target)
+      await waitUntilSettled('seat-left')
+    }
+    if (
+      props.heatedSeatFrontRight !== null &&
+      seatRightLocal.value !== props.heatedSeatFrontRight
+    ) {
+      const target = seatRightLocal.value
+      await send(props.vin, 'seat-right', String(target), (s) => s.heatedSeatFrontRight === target)
+      await waitUntilSettled('seat-right')
+    }
+  } finally {
+    applyInProgress.value = false
   }
 }
 
@@ -224,25 +228,6 @@ function onSeatRightChange(e: Event) {
         </div>
       </div>
 
-      <!-- Steering wheel heating toggle; shows with rear defroster since they share the same SAIC extra-heating API -->
-      <div
-        v-if="steeringWheelHeating !== null || rearWindowDefroster !== null"
-        class="detail-list__item detail-list__item--control"
-      >
-        <font-awesome-icon icon="life-ring" class="detail-list__item-icon" />
-        <span class="detail-list__item-label">{{ t('control.steeringWheelHeating') }}</span>
-        <div class="form-check form-switch">
-          <input
-            class="form-check-input"
-            type="checkbox"
-            role="switch"
-            :checked="localSteeringWheel ?? false"
-            :disabled="isApplying || !vin"
-            @change="localSteeringWheel = !localSteeringWheel"
-          />
-        </div>
-      </div>
-
       <!-- Interior temperature (read-only) -->
       <DetailListItem
         v-if="interiorTemperature !== null"
@@ -317,13 +302,10 @@ function onSeatRightChange(e: Event) {
       <button class="btn btn-outline-secondary" @click="close">
         {{ t('common.cancel') }}
       </button>
-      <CommandButton
-        class="btn-primary"
-        :pending="anyPending"
-        :sending="isApplying"
-        :disabled="!vin || !hasPendingChanges"
-        icon="check"
-        :label="t('common.apply')"
+      <button
+        class="btn btn-primary"
+        :class="anyPending ? 'btn--pending' : ''"
+        :disabled="applyInProgress || !vin || !hasPendingChanges"
         @click="applyAll"
       />
     </template>

--- a/frontend/src/components/ClimateDetailCard.vue
+++ b/frontend/src/components/ClimateDetailCard.vue
@@ -16,11 +16,11 @@ const props = defineProps<{
   heatedSeatFrontLeft: number | null
   heatedSeatFrontRight: number | null
   rearWindowDefroster: boolean | null
-  steeringWheelHeating: boolean | null
 }>()
 
 const modalOpen = ref(false)
-const { sending, lastResult, isPending, send } = useVehicleCommand()
+const applyInProgress = ref(false)
+const { sending, lastResult, isPending, send, waitUntilSettled } = useVehicleCommand()
 
 const TEMP_MIN = 16
 const TEMP_MAX = 28
@@ -34,7 +34,6 @@ const seatLabels = computed(() => [
 
 const localClimateOn = ref<boolean | null>(props.climateOn)
 const localRearDefroster = ref<boolean | null>(props.rearWindowDefroster)
-const localSteeringWheel = ref<boolean | null>(props.steeringWheelHeating ?? false)
 const sliderTemp = ref<number>(props.remoteTemperature ?? 22)
 const seatLeftLocal = ref<number>(props.heatedSeatFrontLeft ?? 0)
 const seatRightLocal = ref<number>(props.heatedSeatFrontRight ?? 0)
@@ -43,7 +42,6 @@ watch(modalOpen, (open) => {
   if (open) {
     localClimateOn.value = props.climateOn
     localRearDefroster.value = props.rearWindowDefroster
-    localSteeringWheel.value = props.steeringWheelHeating ?? false
     sliderTemp.value = props.remoteTemperature ?? 22
     seatLeftLocal.value = props.heatedSeatFrontLeft ?? 0
     seatRightLocal.value = props.heatedSeatFrontRight ?? 0
@@ -66,14 +64,12 @@ const hasAnyData = computed(
     props.exteriorTemperature !== null ||
     props.heatedSeatFrontLeft !== null ||
     props.heatedSeatFrontRight !== null ||
-    props.rearWindowDefroster !== null ||
-    props.steeringWheelHeating !== null,
+    props.rearWindowDefroster !== null,
 )
 
 const commandKeys = [
   'climate',
   'rear-defroster',
-  'steering-wheel',
   'climate-temperature',
   'seat-left',
   'seat-right',
@@ -87,11 +83,6 @@ const hasPendingChanges = computed(() => {
   if (props.rearWindowDefroster !== null && localRearDefroster.value !== props.rearWindowDefroster)
     return true
   if (
-    (props.steeringWheelHeating !== null || props.rearWindowDefroster !== null) &&
-    localSteeringWheel.value !== (props.steeringWheelHeating ?? false)
-  )
-    return true
-  if (
     (props.climateOn !== null || props.remoteTemperature !== null) &&
     sliderTemp.value !== (props.remoteTemperature ?? 22)
   )
@@ -103,46 +94,59 @@ const hasPendingChanges = computed(() => {
   return false
 })
 
+// The real vehicle API only processes one command at a time (each can take up to ~30s
+// to reach the car), so a batch of changes must be sent one at a time, waiting for each
+// to settle before sending the next - firing them all at once queues later commands
+// behind earlier ones and makes them miss their own confirmation window.
 async function applyAll() {
-  if (
-    (props.climateOn !== null || props.remoteTemperature !== null) &&
-    sliderTemp.value !== (props.remoteTemperature ?? 22)
-  ) {
-    await send(props.vin, 'climate-temperature', String(sliderTemp.value))
-  }
-  if (props.climateOn !== null && localClimateOn.value !== props.climateOn) {
-    const target = localClimateOn.value
-    await send(props.vin, 'climate', target ? 'on' : 'off', (s) => s.climateOn === target)
-  }
-  if (
-    props.rearWindowDefroster !== null &&
-    localRearDefroster.value !== props.rearWindowDefroster
-  ) {
-    const target = localRearDefroster.value
-    await send(
-      props.vin,
-      'rear-defroster',
-      target ? 'on' : 'off',
-      (s) => s.rearWindowDefroster === target,
-    )
-  }
-  if (
-    (props.steeringWheelHeating !== null || props.rearWindowDefroster !== null) &&
-    localSteeringWheel.value !== (props.steeringWheelHeating ?? false)
-  ) {
-    const target = localSteeringWheel.value
-    await send(
-      props.vin,
-      'steering-wheel',
-      target ? 'on' : 'off',
-      (s) => s.steeringWheelHeating === target,
-    )
-  }
-  if (props.heatedSeatFrontLeft !== null && seatLeftLocal.value !== props.heatedSeatFrontLeft) {
-    await send(props.vin, 'seat-left', String(seatLeftLocal.value))
-  }
-  if (props.heatedSeatFrontRight !== null && seatRightLocal.value !== props.heatedSeatFrontRight) {
-    await send(props.vin, 'seat-right', String(seatRightLocal.value))
+  applyInProgress.value = true
+  try {
+    if (
+      (props.climateOn !== null || props.remoteTemperature !== null) &&
+      sliderTemp.value !== (props.remoteTemperature ?? 22)
+    ) {
+      const target = sliderTemp.value
+      await send(
+        props.vin,
+        'climate-temperature',
+        String(target),
+        (s) => s.remoteTemperature === target,
+      )
+      await waitUntilSettled('climate-temperature')
+    }
+    if (props.climateOn !== null && localClimateOn.value !== props.climateOn) {
+      const target = localClimateOn.value
+      await send(props.vin, 'climate', target ? 'on' : 'off', (s) => s.climateOn === target)
+      await waitUntilSettled('climate')
+    }
+    if (
+      props.rearWindowDefroster !== null &&
+      localRearDefroster.value !== props.rearWindowDefroster
+    ) {
+      const target = localRearDefroster.value
+      await send(
+        props.vin,
+        'rear-defroster',
+        target ? 'on' : 'off',
+        (s) => s.rearWindowDefroster === target,
+      )
+      await waitUntilSettled('rear-defroster')
+    }
+    if (props.heatedSeatFrontLeft !== null && seatLeftLocal.value !== props.heatedSeatFrontLeft) {
+      const target = seatLeftLocal.value
+      await send(props.vin, 'seat-left', String(target), (s) => s.heatedSeatFrontLeft === target)
+      await waitUntilSettled('seat-left')
+    }
+    if (
+      props.heatedSeatFrontRight !== null &&
+      seatRightLocal.value !== props.heatedSeatFrontRight
+    ) {
+      const target = seatRightLocal.value
+      await send(props.vin, 'seat-right', String(target), (s) => s.heatedSeatFrontRight === target)
+      await waitUntilSettled('seat-right')
+    }
+  } finally {
+    applyInProgress.value = false
   }
 }
 
@@ -219,25 +223,6 @@ function onSeatRightChange(e: Event) {
             :checked="localRearDefroster ?? false"
             :disabled="isApplying || !vin"
             @change="localRearDefroster = !localRearDefroster"
-          />
-        </div>
-      </div>
-
-      <!-- Steering wheel heating toggle; shows with rear defroster since they share the same SAIC extra-heating API -->
-      <div
-        v-if="steeringWheelHeating !== null || rearWindowDefroster !== null"
-        class="detail-list__item detail-list__item--control"
-      >
-        <font-awesome-icon icon="life-ring" class="detail-list__item-icon" />
-        <span class="detail-list__item-label">{{ t('control.steeringWheelHeating') }}</span>
-        <div class="form-check form-switch">
-          <input
-            class="form-check-input"
-            type="checkbox"
-            role="switch"
-            :checked="localSteeringWheel ?? false"
-            :disabled="isApplying || !vin"
-            @change="localSteeringWheel = !localSteeringWheel"
           />
         </div>
       </div>
@@ -319,7 +304,7 @@ function onSeatRightChange(e: Event) {
       <button
         class="btn btn-primary"
         :class="anyPending ? 'btn--pending' : ''"
-        :disabled="sending !== null || !vin || !hasPendingChanges"
+        :disabled="applyInProgress || !vin || !hasPendingChanges"
         @click="applyAll"
       >
         <font-awesome-icon v-if="isApplying" icon="spinner" spin />

--- a/frontend/src/components/ClimateDetailCard.vue
+++ b/frontend/src/components/ClimateDetailCard.vue
@@ -3,7 +3,6 @@ import { computed, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import ExpandableStatusCard from './ExpandableStatusCard.vue'
 import DetailListItem from './DetailListItem.vue'
-import CommandButton from './CommandButton.vue'
 import { useVehicleCommand } from '@/composables/useVehicleCommand'
 
 const { t } = useI18n()

--- a/frontend/src/components/DashboardCardContent.vue
+++ b/frontend/src/components/DashboardCardContent.vue
@@ -265,7 +265,6 @@ const activeSimpleCard = computed(
       :heated-seat-front-left="status.heatedSeatFrontLeft"
       :heated-seat-front-right="status.heatedSeatFrontRight"
       :rear-window-defroster="status.rearWindowDefroster"
-      :steering-wheel-heating="status.steeringWheelHeating"
     />
 
     <!-- hvBattery -->

--- a/frontend/src/composables/__tests__/useVehicleAlerts.spec.ts
+++ b/frontend/src/composables/__tests__/useVehicleAlerts.spec.ts
@@ -56,7 +56,6 @@ function makeSnapshot(overrides: Partial<TelemetrySnapshot> = {}): TelemetrySnap
     heatedSeatFrontLeft: null,
     heatedSeatFrontRight: null,
     rearWindowDefroster: null,
-    steeringWheelHeating: null,
     isAvailable: null,
     lastVehicleStateAt: null,
     lastChargeStateAt: null,

--- a/frontend/src/composables/__tests__/useVehicleCommand.spec.ts
+++ b/frontend/src/composables/__tests__/useVehicleCommand.spec.ts
@@ -68,7 +68,6 @@ function makeSnapshot(overrides: Partial<TelemetrySnapshot> = {}): TelemetrySnap
     heatedSeatFrontLeft: null,
     heatedSeatFrontRight: null,
     rearWindowDefroster: null,
-    steeringWheelHeating: null,
     isAvailable: null,
     lastVehicleStateAt: null,
     lastChargeStateAt: null,

--- a/frontend/src/composables/useVehicleCommand.ts
+++ b/frontend/src/composables/useVehicleCommand.ts
@@ -16,6 +16,25 @@ export function useVehicleCommand() {
     return !!pendingSet.value[key]
   }
 
+  // The real vehicle API processes one command at a time and can take up to ~30s per
+  // command, so callers that need to send several commands in one batch must wait for
+  // each to settle (confirmed or timed out) before sending the next - otherwise they
+  // queue up behind each other on the gateway and miss their own confirmation window.
+  function waitUntilSettled(key: string): Promise<void> {
+    if (!isPending(key)) return Promise.resolve()
+    return new Promise((resolve) => {
+      const stop = watch(
+        () => pendingSet.value[key],
+        (pending) => {
+          if (!pending) {
+            stop()
+            resolve()
+          }
+        },
+      )
+    })
+  }
+
   function clearPending(key: string) {
     const t = timers.get(key)
     if (t) {
@@ -83,5 +102,5 @@ export function useVehicleCommand() {
     }
   }
 
-  return { sending, lastResult, isPending, clearPending, send }
+  return { sending, lastResult, isPending, clearPending, send, waitUntilSettled }
 }

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -197,7 +197,6 @@
     "unlock": "Unlock",
     "temperature": "AC temperature",
     "rearDefroster": "Rear defroster",
-    "steeringWheelHeating": "Steering wheel heating",
     "findMyCar": "Find my car",
     "findMyCarActivate": "Activate",
     "findMyCarStop": "Stop",

--- a/frontend/src/locales/nl.json
+++ b/frontend/src/locales/nl.json
@@ -197,7 +197,6 @@
     "unlock": "Ontgrendelen",
     "temperature": "AC temperatuur",
     "rearDefroster": "Achterruitsverwarming",
-    "steeringWheelHeating": "Stuurwielverwarming",
     "findMyCar": "Zoek mijn auto",
     "findMyCarActivate": "Activeren",
     "findMyCarStop": "Stoppen",

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -105,7 +105,6 @@ import {
   faChargingStation,
   faFlask,
   faGripLines,
-  faLifeRing,
   faTag,
 } from '@fortawesome/free-solid-svg-icons'
 
@@ -189,7 +188,6 @@ library.add(
   faChargingStation,
   faFlask,
   faGripLines,
-  faLifeRing,
   faTag,
 )
 

--- a/frontend/src/services/vehicleApi.ts
+++ b/frontend/src/services/vehicleApi.ts
@@ -60,7 +60,6 @@ export interface TelemetrySnapshot {
   heatedSeatFrontLeft: number | null
   heatedSeatFrontRight: number | null
   rearWindowDefroster: boolean | null
-  steeringWheelHeating: boolean | null
   isAvailable: boolean | null
   lastVehicleStateAt: string | null
   lastChargeStateAt: string | null

--- a/src/GarageStack.Api/Dockerfile
+++ b/src/GarageStack.Api/Dockerfile
@@ -19,8 +19,10 @@ ARG OS_PATCH_DATE=0
 RUN echo "os patch date: ${OS_PATCH_DATE}" \
 	&& apt-get update \
 	&& apt-get upgrade -y \
-	&& apt-get install -y --no-install-recommends libgssapi-krb5-2 \
+	&& apt-get install -y --no-install-recommends libgssapi-krb5-2 gosu \
 	&& rm -rf /var/lib/apt/lists/*
 COPY --from=build /app .
+COPY src/GarageStack.Api/docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
 EXPOSE 8080
-ENTRYPOINT ["dotnet", "GarageStack.Api.dll"]
+ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/src/GarageStack.Api/Endpoints/VehicleEndpoints.cs
+++ b/src/GarageStack.Api/Endpoints/VehicleEndpoints.cs
@@ -146,7 +146,6 @@ public static class VehicleEndpoints
                 "climate"             => "climate/remoteClimateState/set",
                 "climate-temperature" => "climate/remoteTemperature/set",
                 "rear-defroster"      => "climate/rearWindowDefrosterHeating/set",
-                "steering-wheel"      => "climate/steeringWheelHeating/set",
                 "seat-left"           => "climate/heatedSeatsFrontLeftLevel/set",
                 "seat-right"          => "climate/heatedSeatsFrontRightLevel/set",
                 "find-my-car"         => "location/findMyCar/set",
@@ -271,7 +270,7 @@ public static class VehicleEndpoints
 
     internal static string? ValidateCommandValue(string command, string value) => command switch
     {
-        "climate" or "rear-defroster" or "steering-wheel" =>
+        "climate" or "rear-defroster" =>
             value is "on" or "off" ? null : $"'{command}' value must be 'on' or 'off'",
         "climate-temperature" =>
             int.TryParse(value, out var temp) && temp is >= 16 and <= 28

--- a/src/GarageStack.Api/Endpoints/VehicleEndpoints.cs
+++ b/src/GarageStack.Api/Endpoints/VehicleEndpoints.cs
@@ -168,7 +168,6 @@ public static class VehicleEndpoints
                 "climate"             => "climate/remoteClimateState/set",
                 "climate-temperature" => "climate/remoteTemperature/set",
                 "rear-defroster"      => "climate/rearWindowDefrosterHeating/set",
-                "steering-wheel"      => "climate/steeringWheelHeating/set",
                 "seat-left"           => "climate/heatedSeatsFrontLeftLevel/set",
                 "seat-right"          => "climate/heatedSeatsFrontRightLevel/set",
                 "find-my-car"         => "location/findMyCar/set",
@@ -287,7 +286,7 @@ public static class VehicleEndpoints
 
     internal static string? ValidateCommandValue(string command, string value) => command switch
     {
-        "climate" or "rear-defroster" or "steering-wheel" =>
+        "climate" or "rear-defroster" =>
             value is "on" or "off" ? null : $"'{command}' value must be 'on' or 'off'",
         "climate-temperature" =>
             int.TryParse(value, out var temp) && temp is >= 16 and <= 28

--- a/src/GarageStack.Api/Program.cs
+++ b/src/GarageStack.Api/Program.cs
@@ -9,6 +9,7 @@ using GarageStack.Data;
 using GarageStack.Data.Demo;
 using GarageStack.Data.Extensions;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.AspNetCore.DataProtection;
 using Microsoft.AspNetCore.HttpOverrides;
 using Microsoft.AspNetCore.Localization;
 using Microsoft.AspNetCore.RateLimiting;
@@ -49,6 +50,13 @@ try
                   .MinimumLevel.Override("Microsoft", LogEventLevel.Information)
                   .MinimumLevel.Override("System", LogEventLevel.Warning);
     });
+
+    // Pin the key ring to a fixed, CWD-relative path (mirrors "logs/api-.log" above) instead of
+    // relying on ASP.NET Core's implicit default, which resolves against the OS user profile.
+    // A container running as a non-root user with no profile falls back to an in-memory key
+    // ring there, silently invalidating every auth cookie on each restart.
+    builder.Services.AddDataProtection()
+        .PersistKeysToFileSystem(new DirectoryInfo("keys"));
 
     var isDemoMode = builder.Configuration.GetValue<bool>("DEMO_MODE");
 

--- a/src/GarageStack.Api/docker-entrypoint.sh
+++ b/src/GarageStack.Api/docker-entrypoint.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+set -e
+
+# Volume-mounted directories may already be root-owned from images built before this
+# container dropped root, or from a fresh named volume Docker always creates as root.
+# Reclaim them for APP_UID on every start so an existing deployment keeps working after
+# upgrading, then hand off to the app as that non-root user.
+mkdir -p /app/logs /app/keys
+chown -R "$APP_UID" /app/logs /app/keys
+
+exec gosu "$APP_UID" dotnet GarageStack.Api.dll

--- a/src/GarageStack.Core/Models/TelemetrySnapshot.cs
+++ b/src/GarageStack.Core/Models/TelemetrySnapshot.cs
@@ -71,7 +71,6 @@ public class TelemetrySnapshot
     public int? HeatedSeatFrontLeft { get; set; }
     public int? HeatedSeatFrontRight { get; set; }
     public bool? RearWindowDefroster { get; set; }
-    public bool? SteeringWheelHeating { get; set; }
 
     // Online / availability
     public bool? IsAvailable { get; set; }

--- a/src/GarageStack.Data/Demo/DemoTelemetryRepository.cs
+++ b/src/GarageStack.Data/Demo/DemoTelemetryRepository.cs
@@ -146,7 +146,6 @@ public sealed class DemoTelemetryRepository : ITelemetryRepository
         HeatedSeatFrontLeft = 0,
         HeatedSeatFrontRight = 0,
         RearWindowDefroster = false,
-        SteeringWheelHeating = false,
         IsAvailable = true,
         LastVehicleStateAt = DateTime.UtcNow.AddMinutes(-3),
         LastChargeStateAt = DateTime.UtcNow.AddHours(-8),

--- a/src/GarageStack.Data/Demo/DemoTelemetryRepository.cs
+++ b/src/GarageStack.Data/Demo/DemoTelemetryRepository.cs
@@ -171,7 +171,6 @@ public sealed class DemoTelemetryRepository : ITelemetryRepository
             HeatedSeatFrontLeft = 0,
             HeatedSeatFrontRight = 0,
             RearWindowDefroster = false,
-            SteeringWheelHeating = false,
             IsAvailable = true,
             LastVehicleStateAt = DateTime.UtcNow,
             LastChargeStateAt = DateTime.UtcNow.AddHours(-8),

--- a/src/GarageStack.Data/Migrations/20260706092437_RemoveSteeringWheelHeating.Designer.cs
+++ b/src/GarageStack.Data/Migrations/20260706092437_RemoveSteeringWheelHeating.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using GarageStack.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace GarageStack.Data.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260706092437_RemoveSteeringWheelHeating")]
+    partial class RemoveSteeringWheelHeating
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/GarageStack.Data/Migrations/20260706092437_RemoveSteeringWheelHeating.cs
+++ b/src/GarageStack.Data/Migrations/20260706092437_RemoveSteeringWheelHeating.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace GarageStack.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class RemoveSteeringWheelHeating : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "SteeringWheelHeating",
+                table: "TelemetrySnapshots");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "SteeringWheelHeating",
+                table: "TelemetrySnapshots",
+                type: "boolean",
+                nullable: true);
+        }
+    }
+}

--- a/src/GarageStack.Data/Repositories/TelemetryRepository.cs
+++ b/src/GarageStack.Data/Repositories/TelemetryRepository.cs
@@ -82,7 +82,7 @@ public class TelemetryRepository(AppDbContext db, ILogger<TelemetryRepository>? 
              s.ChargerConnected != null || s.HvBatteryActive != null ||
              s.LightsMainBeam != null || s.LightsDippedBeam != null || s.LightsSide != null ||
              s.HeatedSeatFrontLeft != null || s.HeatedSeatFrontRight != null ||
-             s.RearWindowDefroster != null || s.SteeringWheelHeating != null ||
+             s.RearWindowDefroster != null ||
              s.IsAvailable != null || s.LastVehicleStateAt != null || s.LastChargeStateAt != null ||
              s.CurrentJourneyDistance != null ||
              s.ChargingType != null || s.ChargingCableLock != null || s.RemainingChargingTime != null ||

--- a/src/GarageStack.Tests/TelemetryMapperTests.cs
+++ b/src/GarageStack.Tests/TelemetryMapperTests.cs
@@ -369,17 +369,6 @@ public class TelemetryMapperTests
         Assert.True(snapshot.RearWindowDefroster);
     }
 
-    [Theory]
-    [InlineData("climate/steeringWheelHeating")]
-    [InlineData("climate/heatedSteeringWheel")]
-    [InlineData("climate/steeringWheelHeat")]
-    public void ApplyMessage_SteeringWheelHeatingAliases_SetsSteeringWheelHeating(string subtopic)
-    {
-        var snapshot = new TelemetrySnapshot();
-        TelemetryMapper.ApplyMessage(snapshot, subtopic, "true");
-        Assert.True(snapshot.SteeringWheelHeating);
-    }
-
     [Fact]
     public void ApplyMessage_HeatedSeatFrontLeft_SetsLevel()
     {

--- a/src/GarageStack.Worker/Dockerfile
+++ b/src/GarageStack.Worker/Dockerfile
@@ -19,7 +19,9 @@ ARG OS_PATCH_DATE=0
 RUN echo "os patch date: ${OS_PATCH_DATE}" \
 	&& apt-get update \
 	&& apt-get upgrade -y \
-	&& apt-get install -y --no-install-recommends libgssapi-krb5-2 \
+	&& apt-get install -y --no-install-recommends libgssapi-krb5-2 gosu \
 	&& rm -rf /var/lib/apt/lists/*
 COPY --from=build /app .
-ENTRYPOINT ["dotnet", "GarageStack.Worker.dll"]
+COPY src/GarageStack.Worker/docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/src/GarageStack.Worker/Mqtt/TelemetryMapper.cs
+++ b/src/GarageStack.Worker/Mqtt/TelemetryMapper.cs
@@ -225,11 +225,6 @@ public static class TelemetryMapper
             case "climate/rearWindowDefrosterHeating":
                 s.RearWindowDefroster = asBool;
                 return true;
-            case "climate/steeringWheelHeating":
-            case "climate/heatedSteeringWheel":
-            case "climate/steeringWheelHeat":
-                s.SteeringWheelHeating = asBool;
-                return true;
 
             default:
                 return null;

--- a/src/GarageStack.Worker/Mqtt/TelemetryMapper.cs
+++ b/src/GarageStack.Worker/Mqtt/TelemetryMapper.cs
@@ -215,11 +215,6 @@ public static class TelemetryMapper
             case "climate/rearWindowDefrosterHeating":
                 s.RearWindowDefroster = asBool;
                 return true;
-            case "climate/steeringWheelHeating":
-            case "climate/heatedSteeringWheel":
-            case "climate/steeringWheelHeat":
-                s.SteeringWheelHeating = asBool;
-                return true;
 
             default:
                 return null;

--- a/src/GarageStack.Worker/docker-entrypoint.sh
+++ b/src/GarageStack.Worker/docker-entrypoint.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+set -e
+
+# Volume-mounted logs may already be root-owned from images built before this container
+# dropped root, or from a fresh named volume Docker always creates as root. Reclaim it for
+# APP_UID on every start so an existing deployment keeps working after upgrading, then hand
+# off to the app as that non-root user.
+mkdir -p /app/logs
+chown -R "$APP_UID" /app/logs
+
+exec gosu "$APP_UID" dotnet GarageStack.Worker.dll


### PR DESCRIPTION
## Summary

- Steering wheel heating never worked: the real SAIC MQTT gateway has no `climate/steeringWheelHeating/set` topic, so the command silently published to nobody. Removed it end-to-end (frontend toggle, backend command mapping, telemetry ingestion, DB column via migration, related tests/i18n).
- The vehicle API only processes one command at a time and each can take up to ~30s to reach the car. `ClimateDetailCard`'s Apply button fired every changed command back-to-back with no delay, so a batch of changes could queue up behind each other and miss their own confirmation window. Added `waitUntilSettled()` and reworked `applyAll()` to send one command, wait for it to settle, then send the next.
- Hardened the API and Worker containers to run as non-root instead of root, using a small entrypoint that reclaims ownership of the volume-mounted logs/keys directories on every start (so existing deployments keep working after upgrading) before dropping to the built-in non-root user via `gosu`.
- Pinned `saicismartapi/saic-python-mqtt-gateway` to `0.12.0` instead of `:latest` (it was rebuilt into our images on a weekly cron with no corresponding commit here to review what changed), and added a Dependabot `docker` ecosystem so pinned image versions get update PRs instead of going stale.
- Fixed README's MG account guidance, which told users to run GarageStack on a *secondary* account when it actually requires the vehicle *owner* account (secondary accounts fail remote commands with error 1100003).

## Type of Change

- [x] Bug fix
- [x] Dependency update
- [x] Documentation

## Checklist

- [x] Tests added or updated
- [x] Linting passes (`pnpm lint` / `dotnet build`)
- [x] No secrets or personal data committed
- [x] Responsive on mobile
- [x] i18n keys added for any new UI strings

🤖 Generated with [Claude Code](https://claude.com/claude-code)