### PR TITLE
chore: add 3-day cooldown to Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,8 @@ updates:
       time: "07:00"
       timezone: "Europe/Amsterdam"
     open-pull-requests-limit: 8
+    cooldown:
+      default-days: 3
     groups:
       # Vue runtime + all official plugins that ship together
       vue-ecosystem:
@@ -84,6 +86,8 @@ updates:
       time: "07:00"
       timezone: "Europe/Amsterdam"
     open-pull-requests-limit: 6
+    cooldown:
+      default-days: 3
     ignore:
       # Microsoft.OpenApi 3.x breaks Microsoft.AspNetCore.OpenApi 10.0.9 at both compile
       # time and runtime (see the pin comment on the Microsoft.OpenApi PackageReference
@@ -136,6 +140,8 @@ updates:
       time: "07:00"
       timezone: "Europe/Amsterdam"
     open-pull-requests-limit: 4
+    cooldown:
+      default-days: 3
 
   - package-ecosystem: docker
     directory: /src/GarageStack.Api
@@ -145,6 +151,8 @@ updates:
       time: "07:00"
       timezone: "Europe/Amsterdam"
     open-pull-requests-limit: 2
+    cooldown:
+      default-days: 3
 
   - package-ecosystem: docker
     directory: /src/GarageStack.Worker
@@ -154,6 +162,8 @@ updates:
       time: "07:00"
       timezone: "Europe/Amsterdam"
     open-pull-requests-limit: 2
+    cooldown:
+      default-days: 3
 
   - package-ecosystem: docker
     directory: /frontend
@@ -163,6 +173,8 @@ updates:
       time: "07:00"
       timezone: "Europe/Amsterdam"
     open-pull-requests-limit: 2
+    cooldown:
+      default-days: 3
 
   - package-ecosystem: docker
     directory: /docker/all-in-one
@@ -172,6 +184,8 @@ updates:
       time: "07:00"
       timezone: "Europe/Amsterdam"
     open-pull-requests-limit: 2
+    cooldown:
+      default-days: 3
 
   # ── GitHub Actions ───────────────────────────────────────────────────────────
   - package-ecosystem: github-actions
@@ -182,6 +196,8 @@ updates:
       time: "07:00"
       timezone: "Europe/Amsterdam"
     open-pull-requests-limit: 3
+    cooldown:
+      default-days: 3
     groups:
       # Docker build actions ship together; one PR for all of them
       docker-actions:


### PR DESCRIPTION
## Summary
- Add a 3-day `cooldown` to every update block in `.github/dependabot.yml` (npm/frontend, nuget, all 5 docker directories, github-actions)
- Dependabot will now wait at least 3 days after a package release before opening a PR, instead of firing immediately on release, giving time for broken releases to get yanked/patched

## Test plan
- [ ] Confirm dependabot.yml is accepted by GitHub (Dependabot config validation runs automatically on push)
- [ ] Watch the next scheduled Dependabot run (Monday 07:00 Europe/Amsterdam) to confirm cooldown is respected