### PR TITLE
fix: run all-in-one image's api/worker/gateway processes as non-root

### DIFF
--- a/docker/all-in-one/Dockerfile
+++ b/docker/all-in-one/Dockerfile
@@ -68,6 +68,12 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
         libgssapi-krb5-2 libicu-dev \
     && rm -rf /var/lib/apt/lists/*
 
+# Dedicated non-root user for the .NET API/Worker and the SAIC gateway. Postgres and
+# Mosquitto already run as their own unprivileged users via gosu (see supervisord.conf),
+# and nginx already drops its worker processes to www-data via the Debian package default,
+# only its master process stays root to bind port 80.
+RUN useradd --system --create-home --home-dir /home/appuser --shell /usr/sbin/nologin appuser
+
 # .NET 10 ASP.NET Core runtime -- installed via the official script, no apt repo needed.
 RUN curl -sSL https://dot.net/v1/dotnet-install.sh -o /tmp/dotnet-install.sh \
     && chmod +x /tmp/dotnet-install.sh \
@@ -94,6 +100,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
 # Layout in the saic image: WORKDIR=/usr/src/app, venv at /usr/src/app/.venv,
 # entry point: python ./main.py
 COPY --from=saic-source /usr/src/app /opt/saic/app
+RUN chown -R appuser:appuser /opt/saic/app
 
 # Frontend SPA
 COPY --from=frontend-build /app/dist /usr/share/nginx/html
@@ -101,6 +108,15 @@ COPY --from=frontend-build /app/dist /usr/share/nginx/html
 # .NET apps
 COPY --from=dotnet-build /publish/api    /app/api
 COPY --from=dotnet-build /publish/worker /app/worker
+
+# The API/Worker resolve "logs" and "keys" relative to their working directory (which
+# supervisord pins to /app/api and /app/worker, see supervisord.conf), so symlink those
+# names to the persisted /data volume the same way postgres/mosquitto already are. Reuses
+# /data/dataprotection so upgrades from older images keep the same DataProtection keys
+# (and therefore the same auth cookies) instead of silently invalidating every login.
+RUN ln -sfn /data/api /app/api/logs \
+ && ln -sfn /data/dataprotection /app/api/keys \
+ && ln -sfn /data/worker /app/worker/logs
 
 # Configuration
 COPY docker/all-in-one/nginx.conf       /etc/nginx/conf.d/default.conf
@@ -110,7 +126,7 @@ COPY docker/all-in-one/entrypoint.sh   /entrypoint.sh
 
 RUN rm -f /etc/nginx/sites-enabled/default \
     && chmod +x /entrypoint.sh \
-    && mkdir -p /data/db/postgres /data/db/mosquitto /data/logs /data/dataprotection
+    && mkdir -p /data/db/postgres /data/db/mosquitto /data/logs /data/dataprotection /data/api /data/worker
 
 # Port 80  -- nginx (web UI + API proxy)
 # Port 1883 -- Mosquitto MQTT broker

--- a/docker/all-in-one/entrypoint.sh
+++ b/docker/all-in-one/entrypoint.sh
@@ -2,7 +2,7 @@
 set -e
 
 # Ensure volume subdirectories exist on a fresh mount
-mkdir -p /data/db/postgres /data/db/mosquitto /data/logs /data/dataprotection
+mkdir -p /data/db/postgres /data/db/mosquitto /data/logs /data/dataprotection /data/api /data/worker
 
 PGDATA="/data/db/postgres"
 POSTGRES_DB="${POSTGRES_DB:-garagestack}"
@@ -64,9 +64,11 @@ export Widget__ApiKey="${WIDGET_API_KEY:-}"
 # .NET API listens on an internal port; nginx proxies port 80 to it
 export ASPNETCORE_URLS="http://127.0.0.1:9000"
 
-# Data Protection keys persist to the data volume
-mkdir -p /data/dataprotection /root/.aspnet
-ln -sfn /data/dataprotection /root/.aspnet/DataProtection-Keys
+# /app/api/logs, /app/api/keys, and /app/worker/logs are symlinked (in the Dockerfile) into
+# these /data paths, so the non-root API/Worker processes need write access here. Volume
+# contents may be root-owned from an image built before these processes dropped root, or
+# from a fresh named volume Docker always creates as root -- reclaim them on every start.
+chown -R appuser:appuser /data/api /data/worker /data/dataprotection
 
 # Generate Mosquitto password and ACL files from SAIC credentials.
 # Mosquitto 2.x refuses to load password/ACL files unless they are owned by

--- a/docker/all-in-one/supervisord.conf
+++ b/docker/all-in-one/supervisord.conf
@@ -40,7 +40,7 @@ stderr_logfile=/data/logs/mosquitto.log
 ; Delayed start so Mosquitto is ready before connecting.
 ; Runs via the venv copied from the official saicismartapi Docker image.
 [program:saic-gateway]
-command=/bin/bash -c "sleep 10 && cd /opt/saic/app && exec /opt/saic/app/.venv/bin/python ./main.py"
+command=/bin/bash -c "sleep 10 && cd /opt/saic/app && exec gosu appuser /opt/saic/app/.venv/bin/python ./main.py"
 priority=30
 autostart=true
 autorestart=true
@@ -49,9 +49,15 @@ stdout_logfile=/data/logs/saic-gateway.log
 stderr_logfile=/data/logs/saic-gateway.log
 
 ; ── GarageStack API (.NET) ────────────────────────────────────────────────────
-; Delayed start so PostgreSQL has time to accept connections
+; Delayed start so PostgreSQL has time to accept connections.
+; directory= must stay at the DLL's own folder: ASP.NET Core resolves its content root
+; (where it looks for appsettings.json) from the process's working directory, not its
+; executable path, so pointing this anywhere else breaks config loading. The "logs" and
+; "keys" folders app-relative paths resolve to are symlinked into /data in the Dockerfile.
 [program:api]
-command=/bin/bash -c "sleep 20 && exec dotnet /app/api/GarageStack.Api.dll"
+directory=/app/api
+environment=HOME="/home/appuser",DOTNET_CLI_TELEMETRY_OPTOUT="1",DOTNET_NOLOGO="1"
+command=/bin/bash -c "sleep 20 && exec gosu appuser dotnet /app/api/GarageStack.Api.dll"
 priority=40
 autostart=true
 autorestart=true
@@ -61,7 +67,9 @@ stderr_logfile=/data/logs/api-supervisor.log
 
 ; ── GarageStack Worker (.NET) ─────────────────────────────────────────────────
 [program:worker]
-command=/bin/bash -c "sleep 25 && exec dotnet /app/worker/GarageStack.Worker.dll"
+directory=/app/worker
+environment=HOME="/home/appuser",DOTNET_CLI_TELEMETRY_OPTOUT="1",DOTNET_NOLOGO="1"
+command=/bin/bash -c "sleep 25 && exec gosu appuser dotnet /app/worker/GarageStack.Worker.dll"
 priority=50
 autostart=true
 autorestart=true


### PR DESCRIPTION
## Summary
- Closes the remaining gap from #231's non-root work: the all-in-one image's `api`, `worker`, and `saic-gateway` supervisord programs still ran fully as root (only `postgres`/`mosquitto` dropped to unprivileged users via `gosu`). All three now run as a dedicated `appuser` via `gosu`.
- Fixes a related regression along the way: with no `directory=` set for `api`/`worker` in supervisord, ASP.NET Core's content root (and therefore `appsettings.json` lookup) and the CWD-relative `logs`/`keys` paths were resolving against an arbitrary root-level working directory instead of `/app/api`, silently breaking config loading and invalidating auth cookies on every container recreate. Fixed by pinning `directory=` to the DLL's own folder and symlinking `logs`/`keys` out to the persisted `/data` volume, reusing the pre-existing `/data/dataprotection` path so upgrading deployments keep their sessions.

## Test plan
- [ ] `docker build -f docker/all-in-one/Dockerfile .` succeeds
- [ ] Fresh container start: `api`, `worker`, `saic-gateway` run as non-root (`ps aux` inside container shows `appuser`, not `root`)
- [ ] Login persists across `docker restart` (DataProtection keys land in `/data/dataprotection`)
- [ ] API/Worker logs land in `/data/api` and `/data/worker` respectively
- [ ] Upgrade path from an existing `/data` volume (pre-existing root-owned files) still starts cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)