### PR TITLE
fix: correct doc/config gaps and bind demo API to localhost

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,6 +32,10 @@ MQTT_HOST=mosquitto
 MQTT_PORT=1883
 # Host port Mosquitto is published on (only relevant for the bundled broker).
 MQTT_EXTERNAL_PORT=1883
+# Interface MQTT_EXTERNAL_PORT is bound to. Defaults to loopback-only; set to
+# 0.0.0.0 (or a specific LAN address) only if you need to reach the broker
+# from other devices, and set MQTT_BROKER_USERNAME/PASSWORD below first.
+MQTT_BIND_ADDRESS=127.0.0.1
 # Dedicated broker credentials -- decoupled from your SAIC/MG account so a
 # LAN-exposed broker does not leak your cloud account password.
 # Optional when using the bundled Mosquitto -- defaults to "garagestack".

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: false
 contact_links:
   - name: Ask a question / General support
-    url: https://github.com/joszz/garagestack/discussions
-    about: For usage questions, setup help, or general discussion, please use GitHub Discussions.
+    url: https://github.com/joszz/garagestack/issues/new?labels=question
+    about: For usage questions or setup help, open an issue with the "question" label.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,10 +5,10 @@ Thank you for your interest in contributing! This document explains how to get i
 ## Getting Started
 
 1. Fork the repository and clone it locally.
-2. Install prerequisites: .NET (latest LTS), Node.js, PNPM, PostgreSQL, Redis, Docker (optional).
+2. Install prerequisites: .NET (latest LTS), Node.js, PNPM, PostgreSQL, Docker (optional).
 3. Copy `.env.example` to `.env` and fill in your values.
 4. Run `pnpm install` inside the `frontend/` directory.
-5. Run `dotnet restore` in the backend directory.
+5. Run `dotnet restore` from the repository root (the solution spans multiple projects under `src/`).
 
 ## Development Workflow
 
@@ -16,7 +16,7 @@ Thank you for your interest in contributing! This document explains how to get i
 - Keep changes focused -- one feature or fix per pull request.
 - Run the test suite before opening a PR:
   - Backend: `dotnet test`
-  - Frontend: `pnpm test`
+  - Frontend: `pnpm test:unit`
 - Make sure linting passes: `pnpm lint`
 
 ## Commit Style

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -36,7 +36,7 @@ This project interacts with the MG/SAIC iSmart API and stores vehicle data. Area
 - Authentication and session handling
 - API credential storage and transmission
 - Personally identifiable information (PII) and location/route data
-- Redis and PostgreSQL access controls
+- PostgreSQL access controls
 - PWA push notification endpoints and VAPID key handling
 - Third-party dependency vulnerabilities with direct exploit paths
 
@@ -78,10 +78,9 @@ This project follows a coordinated vulnerability disclosure model. Good-faith se
 - Subresource Integrity (SRI) is used for third-party assets where supported
 - No sensitive data is stored in `localStorage` or `sessionStorage`
 
-### Database and Cache
+### Database
 
 - PostgreSQL connections use least-privilege credentials per service role
-- Redis is not exposed publicly; access is restricted to internal service communication
 - Sensitive fields (e.g., tokens, location history) are not logged in plaintext
 
 ### Dependencies

--- a/docker-compose.demo.yml
+++ b/docker-compose.demo.yml
@@ -15,10 +15,10 @@ services:
       Auth__Username: "${AUTH_USERNAME:-demo}"
       Auth__Password: "${AUTH_PASSWORD:-demo}"
     ports:
-      - "${API_PORT:-5001}:8080"
+      - "127.0.0.1:${API_PORT:-5001}:8080"
     volumes:
       - api_demo_logs:/app/logs
-      - api_demo_dataprotection:/root/.aspnet/DataProtection-Keys
+      - api_demo_dataprotection:/app/keys
 
   frontend:
     build:

--- a/docker/all-in-one/README.md
+++ b/docker/all-in-one/README.md
@@ -64,6 +64,8 @@ The web login uses the same `SAIC_USER` and `SAIC_PASSWORD` credentials. There i
 | `POSTGRES_DB` | Database name (default: `garagestack`) |
 | `POSTGRES_USER` | Database user (default: `garagestack`) |
 | `AUTH_COOKIE_SECURE` | Set to `true` when serving behind a TLS-terminating reverse proxy. Defaults to `false` so plain-HTTP LAN installs work out of the box. |
+| `MQTT_BROKER_USERNAME` | Username for the embedded Mosquitto broker (default: `garagestack`). Only matters if you expose port 1883 to the LAN. |
+| `MQTT_BROKER_PASSWORD` | Password for the embedded Mosquitto broker. If not set, a random password is auto-generated on first start. Set explicitly if you expose port 1883 and want a known value. |
 
 ## Building the image
 


### PR DESCRIPTION
## Summary
Batch of low-risk documentation/config corrections found during a full-project review:
- `CONTRIBUTING.md`: `pnpm test` doesn't exist (`test:unit` does), fixed `dotnet restore` instructions, dropped the unused Redis prerequisite
- `SECURITY.md`: removed stale Redis references (Redis isn't part of the stack)
- `.env.example` / `docker/all-in-one/README.md`: documented `MQTT_BIND_ADDRESS` and `MQTT_BROKER_USERNAME`/`PASSWORD`, all already read by the code but undocumented
- `docker-compose.demo.yml`: bound the demo API to `127.0.0.1` (it ships with `demo`/`demo` credentials and was exposed on all interfaces), and fixed its DataProtection keys volume, which still pointed at the old `/root/.aspnet/DataProtection-Keys` path, the app now resolves key storage relative to its working directory (`/app/keys`), so demo sessions were silently not persisting across restarts
- `.github/ISSUE_TEMPLATE/config.yml`: repointed the support link away from GitHub Discussions (not enabled on this repo, dead link) to a pre-labeled issue
- Removed a stray untracked `docker/all-in-one/entrypoint.sh;C` directory

## Test plan
- [ ] Doc-only + config changes, no app code touched
- [ ] `docker compose -f docker-compose.demo.yml up`: confirm API is only reachable via `127.0.0.1:5001`, not from another host on the LAN
- [ ] Demo login session survives `docker compose -f docker-compose.demo.yml restart api`

🤖 Generated with [Claude Code](https://claude.com/claude-code)