### PR TITLE
perf: reduce map/telemetry hot-path cost, harden widget and MQTT log exposure

### DIFF
--- a/frontend/src/stores/vehicle.ts
+++ b/frontend/src/stores/vehicle.ts
@@ -1,5 +1,5 @@
 import { defineStore } from 'pinia'
-import { ref, computed, nextTick } from 'vue'
+import { ref, shallowRef, computed, nextTick } from 'vue'
 import type { Ref } from 'vue'
 import { vehicleApi, type Vehicle, type TelemetrySnapshot, type Trip } from '@/services/vehicleApi'
 
@@ -9,8 +9,10 @@ export const useVehicleStore = defineStore('vehicle', () => {
   const vehicles = ref<Vehicle[]>([])
   const currentStatus = ref<TelemetrySnapshot | null>(null)
   const vehicleConfig = ref<Record<string, string>>({})
-  const history = ref<TelemetrySnapshot[]>([])
-  const trips = ref<Trip[]>([])
+  // shallowRef: these are only ever replaced wholesale on fetch, never mutated
+  // field-by-field, so deep reactivity on every GPS point/telemetry snapshot is wasted work.
+  const history = shallowRef<TelemetrySnapshot[]>([])
+  const trips = shallowRef<Trip[]>([])
   const loadingCount = ref(0)
   const loading = computed(() => loadingCount.value > 0)
   const sendingCount = ref(0)

--- a/frontend/src/views/MapView.vue
+++ b/frontend/src/views/MapView.vue
@@ -233,7 +233,7 @@ function buildHeatLayer() {
     heatLayer = null
   }
   heatLayer = leafWithHeat
-    .heatLayer(allPoints.value, {
+    .heatLayer(downsample(allPoints.value, MAX_HEATMAP_POINTS), {
       radius: 18,
       blur: 22,
       maxZoom: 17,
@@ -262,22 +262,27 @@ function buildRouteLines() {
   })
 }
 
+function downsample<T>(items: T[], max: number): T[] {
+  if (items.length <= max) return items
+  const stride = items.length / max
+  const sampled: T[] = []
+  for (let i = 0; i < max; i++) {
+    sampled.push(items[Math.floor(i * stride)]!)
+  }
+  const last = items[items.length - 1]!
+  if (sampled[sampled.length - 1] !== last) sampled.push(last)
+  return sampled
+}
+
 // Speed overlay renders one Leaflet polyline layer per segment. A long trip can have thousands
 // of GPS points, which would create thousands of DOM elements - downsample first so the map
 // stays responsive; a few hundred segments is already more color resolution than is visible.
 const MAX_SPEED_OVERLAY_SEGMENTS = 500
 
-function downsampleForOverlay(pts: Trip['points']): Trip['points'] {
-  if (pts.length <= MAX_SPEED_OVERLAY_SEGMENTS) return pts
-  const stride = pts.length / MAX_SPEED_OVERLAY_SEGMENTS
-  const sampled: Trip['points'] = []
-  for (let i = 0; i < MAX_SPEED_OVERLAY_SEGMENTS; i++) {
-    sampled.push(pts[Math.floor(i * stride)]!)
-  }
-  const last = pts[pts.length - 1]!
-  if (sampled[sampled.length - 1] !== last) sampled.push(last)
-  return sampled
-}
+// Heatmap renders to a canvas rather than one DOM element per point, so it tolerates far more
+// points than the polyline overlay, but a 90-day range with dense GPS logging can still reach
+// tens of thousands of points across all trips - cap it so it stays responsive to rebuild.
+const MAX_HEATMAP_POINTS = 5000
 
 function buildSelectedLine() {
   const map = mapInstance.value
@@ -298,7 +303,7 @@ function buildSelectedLine() {
   }
 
   if (speedOverlayEnabled.value) {
-    const speedPts = downsampleForOverlay(pts)
+    const speedPts = downsample(pts, MAX_SPEED_OVERLAY_SEGMENTS)
     for (let i = 0; i < speedPts.length - 1; i++) {
       const p0 = speedPts[i]!
       const p1 = speedPts[i + 1]!

--- a/src/GarageStack.Api/Endpoints/WidgetEndpoints.cs
+++ b/src/GarageStack.Api/Endpoints/WidgetEndpoints.cs
@@ -10,6 +10,7 @@ public static class WidgetEndpoints
     {
         var group = app.MapGroup("/api/widget")
             .WithTags("Widget")
+            .RequireRateLimiting("widget")
             .AddEndpointFilter(async (ctx, next) =>
             {
                 var config = ctx.HttpContext.RequestServices.GetRequiredService<IConfiguration>();

--- a/src/GarageStack.Api/Program.cs
+++ b/src/GarageStack.Api/Program.cs
@@ -176,6 +176,23 @@ try
                     AutoReplenishment = true,
                 });
         });
+
+        // Tighter limit on the widget endpoint to slow down guessing WIDGET_API_KEY, which the
+        // global limiter alone (120/min) would allow at a much higher rate. Still generous
+        // enough for a handful of dashboard widgets behind the same NAT polling every 30s.
+        opts.AddPolicy("widget", httpContext =>
+        {
+            var ip = httpContext.Connection.RemoteIpAddress?.ToString() ?? "unknown";
+            return RateLimitPartition.GetFixedWindowLimiter(
+                partitionKey: ip,
+                factory: _ => new FixedWindowRateLimiterOptions
+                {
+                    Window = TimeSpan.FromMinutes(5),
+                    PermitLimit = 60,
+                    QueueLimit = 0,
+                    AutoReplenishment = true,
+                });
+        });
     });
 
     builder.Services.AddCors(opts =>

--- a/src/GarageStack.Api/Services/MqttPublisher.cs
+++ b/src/GarageStack.Api/Services/MqttPublisher.cs
@@ -1,6 +1,7 @@
 using GarageStack.Core.Interfaces;
 using MQTTnet;
 using System.Text;
+using System.Text.RegularExpressions;
 
 namespace GarageStack.Api.Services;
 
@@ -64,7 +65,15 @@ public class MqttPublisher(IConfiguration config, ILogger<MqttPublisher> logger)
             .Build();
 
         await _client.PublishAsync(message, ct);
-        logger.LogInformation("Published MQTT topic={Topic} payloadBytes={PayloadBytes}", topic.ReplaceLineEndings(" "), Encoding.UTF8.GetByteCount(payload));
+
+        var sanitizedTopic = topic.ReplaceLineEndings(" ");
+        // Topics carry the MG account email and VIN (saic/{email}/vehicles/{vin}/...) - redact
+        // both before logging at Information level, which persists to 30-day rotating files.
+        // The full topic (including the command path, useful for troubleshooting) is still
+        // available at Debug level when DEBUG_LOGS is enabled.
+        var redactedTopic = Regex.Replace(sanitizedTopic, @"^saic/[^/]+/vehicles/[^/]+/", "saic/***/vehicles/***/");
+        logger.LogInformation("Published MQTT topic={Topic} payloadBytes={PayloadBytes}", redactedTopic, Encoding.UTF8.GetByteCount(payload));
+        logger.LogDebug("Published MQTT full topic={Topic}", sanitizedTopic);
     }
 
     public async Task StopAsync(CancellationToken ct)

--- a/src/GarageStack.Data/Repositories/TelemetryRepository.cs
+++ b/src/GarageStack.Data/Repositories/TelemetryRepository.cs
@@ -23,9 +23,34 @@ public class TelemetryRepository(AppDbContext db, ILogger<TelemetryRepository>? 
         nameof(TelemetrySnapshot.RawTopic),
     ];
 
-    private static readonly PropertyInfo[] MergeableProperties = typeof(TelemetrySnapshot)
+    // Compiled expression-tree accessors instead of live reflection (PropertyInfo.GetValue/
+    // SetValue): this runs on every MQTT message merge, multiple times per second per vehicle,
+    // and reflection's per-call overhead is avoidable since the property set is fixed at
+    // startup. Built once here, then invoked like a regular delegate call from then on.
+    private sealed record PropertyAccessor(string Name, Func<TelemetrySnapshot, object?> Get, Action<TelemetrySnapshot, object?> Set);
+
+    private static PropertyAccessor BuildAccessor(PropertyInfo prop)
+    {
+        var instance = Expression.Parameter(typeof(TelemetrySnapshot), "instance");
+        var value = Expression.Parameter(typeof(object), "value");
+
+        var getter = Expression.Lambda<Func<TelemetrySnapshot, object?>>(
+            Expression.Convert(Expression.Property(instance, prop), typeof(object)),
+            instance).Compile();
+
+        var setter = Expression.Lambda<Action<TelemetrySnapshot, object?>>(
+            Expression.Assign(
+                Expression.Property(instance, prop),
+                Expression.Convert(value, prop.PropertyType)),
+            instance, value).Compile();
+
+        return new PropertyAccessor(prop.Name, getter, setter);
+    }
+
+    private static readonly PropertyAccessor[] MergeableProperties = typeof(TelemetrySnapshot)
         .GetProperties(BindingFlags.Public | BindingFlags.Instance)
         .Where(p => p.CanRead && p.CanWrite && !NonMergeableProperties.Contains(p.Name))
+        .Select(BuildAccessor)
         .ToArray();
 
     // Daily counters reset at midnight - a stale value from a prior day must not be carried
@@ -40,8 +65,8 @@ public class TelemetryRepository(AppDbContext db, ILogger<TelemetryRepository>? 
     {
         foreach (var prop in MergeableProperties)
         {
-            var value = prop.GetValue(source);
-            if (value is not null) prop.SetValue(target, value);
+            var value = prop.Get(source);
+            if (value is not null) prop.Set(target, value);
         }
     }
 
@@ -51,9 +76,9 @@ public class TelemetryRepository(AppDbContext db, ILogger<TelemetryRepository>? 
         foreach (var prop in MergeableProperties)
         {
             if (skip is not null && skip.Contains(prop.Name)) continue;
-            if (prop.GetValue(target) is not null) continue;
-            var value = prop.GetValue(source);
-            if (value is not null) prop.SetValue(target, value);
+            if (prop.Get(target) is not null) continue;
+            var value = prop.Get(source);
+            if (value is not null) prop.Set(target, value);
         }
     }
 

--- a/src/GarageStack.Data/Services/OcmApiClient.cs
+++ b/src/GarageStack.Data/Services/OcmApiClient.cs
@@ -18,6 +18,12 @@ public sealed class OcmApiClient(
     private DateTimeOffset _lastRequestAt = DateTimeOffset.MinValue;
     private static readonly TimeSpan MinInterval = TimeSpan.FromMilliseconds(500);
 
+    // Written and read under _gate, so a plain field (not Interlocked) is safe here -- unlike
+    // OverpassApiClient's foreground path, every caller of this method already goes through
+    // _gate, there is no lock-free pre-check path.
+    private DateTimeOffset _backoffUntil = DateTimeOffset.MinValue;
+    private static readonly TimeSpan RetryAfter429 = TimeSpan.FromSeconds(60);
+
     private const string BaseUrl = "https://api.openchargemap.io/v3/poi/";
 
     public bool IsConfigured => !string.IsNullOrWhiteSpace(configuration["OpenChargeMap:ApiKey"]);
@@ -37,6 +43,13 @@ public sealed class OcmApiClient(
         await _gate.WaitAsync(ct);
         try
         {
+            // Fail fast without hitting the network if a prior request was rate-limited. Both
+            // the on-demand API path and the Worker's pre-caching pass (which loops over many
+            // tiles) share this gate, so this stops a sustained rate-limit from being hammered
+            // every MinInterval by every remaining tile in the current pass.
+            if (_backoffUntil > DateTimeOffset.UtcNow)
+                throw new HttpRequestException($"OCM rate-limited, backing off until {_backoffUntil:O}");
+
             var wait = MinInterval - (DateTimeOffset.UtcNow - _lastRequestAt);
             if (wait > TimeSpan.Zero) await Task.Delay(wait, ct);
 
@@ -53,6 +66,14 @@ public sealed class OcmApiClient(
             var client = httpClientFactory.CreateClient("ocm");
             _lastRequestAt = DateTimeOffset.UtcNow;
             var response = await client.SendAsync(request, ct);
+
+            if ((int)response.StatusCode is 429 or 503 or 504)
+            {
+                _backoffUntil = DateTimeOffset.UtcNow + RetryAfter429;
+                throw new HttpRequestException(
+                    $"OCM rate-limited ({(int)response.StatusCode}), backing off {(int)RetryAfter429.TotalSeconds}s");
+            }
+
             response.EnsureSuccessStatusCode();
 
             await using var stream = await response.Content.ReadAsStreamAsync(ct);


### PR DESCRIPTION
## Summary
Second batch from a full-project review: performance and low-risk security hardening.

- **`stores/vehicle.ts`**: `trips`/`history` switched to `shallowRef` — both are only ever replaced wholesale on fetch, never mutated field-by-field, so deep-wrapping every GPS point/telemetry snapshot in a reactive proxy was wasted work.
- **`MapView.vue`**: capped the heatmap layer at 5000 points (`MAX_HEATMAP_POINTS`), mirroring the existing speed-overlay cap. A 90-day range with dense GPS logging could otherwise feed tens of thousands of points into `leaflet.heat` on every rebuild. Generalized the existing downsample helper so both overlays share it.
- **`TelemetryRepository.cs`**: replaced live reflection (`PropertyInfo.GetValue/SetValue`) with compiled expression-tree accessors for the telemetry merge, which runs on every MQTT message, multiple times a second per vehicle.
- **`WidgetEndpoints.cs`/`Program.cs`**: added a dedicated rate-limit policy for the `X-Widget-Key` check (60/5min per IP). It previously only inherited the global 120/min limiter, allowing ~120 key guesses/minute.
- **`OcmApiClient.cs`**: added a 60s backoff window on 429/503/504, mirroring the pattern `OverpassApiClient` already has. Both the on-demand API path and the Worker's pre-caching pass share this client, so a sustained rate-limit was previously hammered every 500ms by both.
- **`MqttPublisher.cs`**: redacted the MG account email and VIN from the Information-level publish log (persists to 30-day rotating files); the full topic is still available at Debug level for troubleshooting.

## Test plan
- [x] `dotnet build` — succeeds, 0 warnings
- [x] `dotnet test` — 314/314 passing
- [x] `pnpm run type-check` — passes
- [x] `pnpm run test:unit` — 205/205 passing
- [x] `pnpm run lint` — clean
- [ ] Manual: confirm heatmap still renders correctly on a long date range
- [ ] Manual: confirm widget endpoint still works normally under typical polling load

🤖 Generated with [Claude Code](https://claude.com/claude-code)