### PR TITLE
feat: add API health check, resource limits, and backup docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,44 @@ docker stop garagestack && docker rm garagestack
 
 ---
 
+## Backup and restore
+
+The only data that matters for disaster recovery is your PostgreSQL database (all vehicle telemetry/trip history) and the DataProtection keys used to sign login cookies -- losing the keys just logs everyone out, it doesn't lose any vehicle data.
+
+**Docker Compose:** back up the database with `pg_dump` (works whether you're using the bundled Postgres or your own external server):
+
+```bash
+docker compose exec postgres pg_dump -U garagestack garagestack > garagestack-backup.sql
+```
+
+Restore into a fresh database:
+
+```bash
+cat garagestack-backup.sql | docker compose exec -T postgres psql -U garagestack garagestack
+```
+
+(Replace `garagestack`/`garagestack` with your `POSTGRES_USER`/`POSTGRES_DB` if you customised them.) The DataProtection keys live in the `api_dataprotection` named volume -- back it up with the API stopped so nothing is mid-write:
+
+```bash
+docker compose stop api
+docker run --rm -v garagestack_api_dataprotection:/keys -v "$(pwd)":/backup alpine tar czf /backup/dataprotection-backup.tar.gz -C /keys .
+docker compose start api
+```
+
+(Volume names are prefixed with the Compose project name -- run `docker volume ls` to confirm yours if it's not `garagestack`.) The `mosquitto_data`, `worker_logs`, and `api_logs` volumes hold disposable/regeneratable data and don't need backing up.
+
+**All-in-one container:** everything lives under the single `/data` bind mount (`garagestack-data/` by default). Stop the container first so nothing is mid-write, then copy the whole directory:
+
+```bash
+docker stop garagestack
+cp -r garagestack-data garagestack-data-backup
+docker start garagestack
+```
+
+To restore, stop the container, replace `garagestack-data` with the backup, and start it again.
+
+---
+
 ## Push notifications
 
 GarageStack checks your vehicle's state every 5 minutes and sends both a browser push notification and an in-app notification (bell icon) when any of the following conditions are detected. Each alert has a 1-hour cooldown per vehicle to avoid repeated notifications.

--- a/docker-compose.demo.yml
+++ b/docker-compose.demo.yml
@@ -29,7 +29,8 @@ services:
     container_name: garagestack-frontend-demo
     restart: unless-stopped
     depends_on:
-      - api
+      api:
+        condition: service_healthy
     ports:
       - "${FRONTEND_PORT:-8080}:80"
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,8 @@ services:
     image: eclipse-mosquitto:2
     container_name: mosquitto
     restart: unless-stopped
+    mem_limit: 128m
+    cpus: 0.5
     entrypoint: /bin/sh
     command: >
       -c "
@@ -24,6 +26,8 @@ services:
     image: saicismartapi/saic-python-mqtt-gateway:0.12.0
     container_name: saic-mqtt
     restart: unless-stopped
+    mem_limit: 256m
+    cpus: 0.5
     depends_on:
       - mosquitto
     environment:
@@ -42,6 +46,8 @@ services:
     image: postgres:18-alpine
     container_name: garagestack-postgres
     restart: unless-stopped
+    mem_limit: 512m
+    cpus: 1.0
     environment:
       POSTGRES_DB: "${POSTGRES_DB:-garagestack}"
       POSTGRES_USER: "${POSTGRES_USER:-garagestack}"
@@ -60,6 +66,8 @@ services:
       dockerfile: src/GarageStack.Worker/Dockerfile
     container_name: garagestack-worker
     restart: unless-stopped
+    mem_limit: 256m
+    cpus: 0.5
     labels:
       net.unraid.docker.icon: "https://raw.githubusercontent.com/joszz/garagestack/main/frontend/public/pwa-192x192.png"
     depends_on:
@@ -69,7 +77,7 @@ services:
       mosquitto:
         condition: service_started
       api:
-        condition: service_started
+        condition: service_healthy
     env_file:
       - .env
     environment:
@@ -91,6 +99,8 @@ services:
       dockerfile: src/GarageStack.Api/Dockerfile
     container_name: garagestack-api
     restart: unless-stopped
+    mem_limit: 512m
+    cpus: 1.0
     labels:
       net.unraid.docker.icon: "https://raw.githubusercontent.com/joszz/garagestack/main/frontend/public/pwa-192x192.png"
     depends_on:
@@ -132,11 +142,14 @@ services:
       dockerfile: Dockerfile
     container_name: garagestack-frontend
     restart: unless-stopped
+    mem_limit: 128m
+    cpus: 0.5
     labels:
       net.unraid.docker.icon: "https://raw.githubusercontent.com/joszz/garagestack/main/frontend/public/pwa-192x192.png"
       net.unraid.docker.webui: "http://[IP]:[PORT:80]/"
     depends_on:
-      - api
+      api:
+        condition: service_healthy
     ports:
       - "${FRONTEND_PORT:-8080}:80"
 

--- a/docker/all-in-one/Dockerfile
+++ b/docker/all-in-one/Dockerfile
@@ -123,14 +123,19 @@ COPY docker/all-in-one/nginx.conf       /etc/nginx/conf.d/default.conf
 COPY docker/all-in-one/mosquitto.conf   /etc/mosquitto/conf.d/garagestack.conf
 COPY docker/all-in-one/supervisord.conf /etc/supervisor/supervisord.conf
 COPY docker/all-in-one/entrypoint.sh   /entrypoint.sh
+COPY docker/all-in-one/wait-for-postgres.sh  /wait-for-postgres.sh
+COPY docker/all-in-one/wait-for-mosquitto.sh /wait-for-mosquitto.sh
 
 RUN rm -f /etc/nginx/sites-enabled/default \
-    && chmod +x /entrypoint.sh \
+    && chmod +x /entrypoint.sh /wait-for-postgres.sh /wait-for-mosquitto.sh \
     && mkdir -p /data/db/postgres /data/db/mosquitto /data/logs /data/dataprotection /data/api /data/worker
 
 # Port 80  -- nginx (web UI + API proxy)
 # Port 1883 -- Mosquitto MQTT broker
 EXPOSE 80 1883
+
+HEALTHCHECK --interval=10s --timeout=5s --start-period=30s --retries=5 \
+    CMD curl -fsS http://127.0.0.1:9000/health || exit 1
 
 VOLUME ["/data"]
 

--- a/docker/all-in-one/README.md
+++ b/docker/all-in-one/README.md
@@ -167,6 +167,24 @@ docker rm -f garagestack
 Remove-Item -Recurse -Force garagestack-data
 ```
 
+### Backup and restore
+
+Everything -- the PostgreSQL database, Mosquitto retained messages, logs, and DataProtection keys -- lives under `garagestack-data`. Stop the container first so nothing is mid-write, then copy the whole directory:
+
+```powershell
+docker stop garagestack
+Copy-Item -Recurse garagestack-data garagestack-data-backup
+docker start garagestack
+```
+
+```bash
+docker stop garagestack
+cp -r garagestack-data garagestack-data-backup
+docker start garagestack
+```
+
+To restore, stop the container, replace `garagestack-data` with the backup, and start it again. Only the database (`garagestack-data/db/postgres`) and DataProtection keys (`garagestack-data/dataprotection`) actually matter for disaster recovery -- losing the keys just logs everyone out, it doesn't lose any vehicle data.
+
 ## Troubleshooting
 
 ### 28P01: password authentication failed for user "garagestack"

--- a/docker/all-in-one/supervisord.conf
+++ b/docker/all-in-one/supervisord.conf
@@ -37,10 +37,10 @@ stdout_logfile=/data/logs/mosquitto.log
 stderr_logfile=/data/logs/mosquitto.log
 
 ; ── SAIC MQTT Gateway (polls MG iSmart API, publishes to Mosquitto) ────────────
-; Delayed start so Mosquitto is ready before connecting.
+; Polls Mosquitto's port instead of a fixed sleep before connecting -- see wait-for-mosquitto.sh.
 ; Runs via the venv copied from the official saicismartapi Docker image.
 [program:saic-gateway]
-command=/bin/bash -c "sleep 10 && cd /opt/saic/app && exec gosu appuser /opt/saic/app/.venv/bin/python ./main.py"
+command=/bin/bash -c "/wait-for-mosquitto.sh; cd /opt/saic/app && exec gosu appuser /opt/saic/app/.venv/bin/python ./main.py"
 priority=30
 autostart=true
 autorestart=true
@@ -49,7 +49,7 @@ stdout_logfile=/data/logs/saic-gateway.log
 stderr_logfile=/data/logs/saic-gateway.log
 
 ; ── GarageStack API (.NET) ────────────────────────────────────────────────────
-; Delayed start so PostgreSQL has time to accept connections.
+; Polls PostgreSQL's port instead of a fixed sleep before starting -- see wait-for-postgres.sh.
 ; directory= must stay at the DLL's own folder: ASP.NET Core resolves its content root
 ; (where it looks for appsettings.json) from the process's working directory, not its
 ; executable path, so pointing this anywhere else breaks config loading. The "logs" and
@@ -57,7 +57,7 @@ stderr_logfile=/data/logs/saic-gateway.log
 [program:api]
 directory=/app/api
 environment=HOME="/home/appuser",DOTNET_CLI_TELEMETRY_OPTOUT="1",DOTNET_NOLOGO="1"
-command=/bin/bash -c "sleep 20 && exec gosu appuser dotnet /app/api/GarageStack.Api.dll"
+command=/bin/bash -c "/wait-for-postgres.sh; exec gosu appuser dotnet /app/api/GarageStack.Api.dll"
 priority=40
 autostart=true
 autorestart=true
@@ -69,7 +69,7 @@ stderr_logfile=/data/logs/api-supervisor.log
 [program:worker]
 directory=/app/worker
 environment=HOME="/home/appuser",DOTNET_CLI_TELEMETRY_OPTOUT="1",DOTNET_NOLOGO="1"
-command=/bin/bash -c "sleep 25 && exec gosu appuser dotnet /app/worker/GarageStack.Worker.dll"
+command=/bin/bash -c "/wait-for-postgres.sh; exec gosu appuser dotnet /app/worker/GarageStack.Worker.dll"
 priority=50
 autostart=true
 autorestart=true

--- a/docker/all-in-one/wait-for-mosquitto.sh
+++ b/docker/all-in-one/wait-for-mosquitto.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# Polls the embedded Mosquitto broker instead of a fixed sleep before starting the SAIC
+# gateway. Falls through after the timeout so a stuck broker doesn't hang supervisord forever --
+# the gateway's own startretries and autorestart take over from there.
+set -u
+
+for _ in $(seq 1 30); do
+    timeout 1 bash -c 'cat < /dev/tcp/127.0.0.1/1883' 2>/dev/null && exit 0
+    sleep 1
+done
+
+echo "[garagestack] mosquitto did not become ready within 30s, starting anyway" >&2

--- a/docker/all-in-one/wait-for-postgres.sh
+++ b/docker/all-in-one/wait-for-postgres.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# Polls the embedded PostgreSQL instance instead of a fixed sleep before starting api/worker.
+# Falls through after the timeout so a stuck postgres doesn't hang supervisord forever --
+# the .NET services' own connection retries and supervisord's autorestart take over from there.
+set -u
+
+for _ in $(seq 1 60); do
+    /usr/lib/postgresql/18/bin/pg_isready -h 127.0.0.1 -p 5432 -q && exit 0
+    sleep 1
+done
+
+echo "[garagestack] postgres did not become ready within 60s, starting anyway" >&2

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -17,3 +17,5 @@ RUN echo "os patch date: ${OS_PATCH_DATE}" && apk upgrade --no-cache
 COPY --from=build /app/dist /usr/share/nginx/html
 COPY nginx.conf /etc/nginx/conf.d/default.conf
 EXPOSE 80
+HEALTHCHECK --interval=10s --timeout=5s --start-period=5s --retries=5 \
+	CMD wget --quiet --tries=1 --spider http://127.0.0.1/ || exit 1

--- a/src/GarageStack.Api/Dockerfile
+++ b/src/GarageStack.Api/Dockerfile
@@ -19,10 +19,12 @@ ARG OS_PATCH_DATE=0
 RUN echo "os patch date: ${OS_PATCH_DATE}" \
 	&& apt-get update \
 	&& apt-get upgrade -y \
-	&& apt-get install -y --no-install-recommends libgssapi-krb5-2 gosu \
+	&& apt-get install -y --no-install-recommends libgssapi-krb5-2 gosu curl \
 	&& rm -rf /var/lib/apt/lists/*
 COPY --from=build /app .
 COPY src/GarageStack.Api/docker-entrypoint.sh /docker-entrypoint.sh
 RUN chmod +x /docker-entrypoint.sh
 EXPOSE 8080
+HEALTHCHECK --interval=10s --timeout=5s --start-period=15s --retries=5 \
+	CMD curl -fsS http://127.0.0.1:8080/health || exit 1
 ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/src/GarageStack.Api/Endpoints/HealthEndpoints.cs
+++ b/src/GarageStack.Api/Endpoints/HealthEndpoints.cs
@@ -1,0 +1,19 @@
+namespace GarageStack.Api.Endpoints;
+
+public static class HealthEndpoints
+{
+    // Liveness only -- confirms the ASP.NET Core pipeline is up and serving requests, which is
+    // what Docker HEALTHCHECK and compose's depends_on: condition: service_healthy need to stop
+    // the frontend/worker starting before the API is actually listening. Deliberately does not
+    // check database connectivity: DEMO_MODE has no database at all, and a deep check here would
+    // make the container report unhealthy during a transient DB reconnect even though the API
+    // itself is fine.
+    public static IEndpointRouteBuilder MapHealthEndpoints(this IEndpointRouteBuilder app)
+    {
+        app.MapGet("/health", () => Results.Ok(new { status = "ok" }))
+            .WithTags("Health")
+            .ExcludeFromDescription();
+
+        return app;
+    }
+}

--- a/src/GarageStack.Api/Program.cs
+++ b/src/GarageStack.Api/Program.cs
@@ -395,6 +395,7 @@ try
             .AddHttpAuthentication("Bearer", _ => { }));
     }
 
+    app.MapHealthEndpoints();
     app.MapHub<TelemetryHub>("/hubs/telemetry").RequireAuthorization();
     app.MapAuthEndpoints();
     app.MapVehicleEndpoints();


### PR DESCRIPTION
## Summary
Third batch from a full-project review: infrastructure reliability.

- **`HealthEndpoints.cs`**: added a liveness-only `GET /health` endpoint. Deliberately doesn't check database connectivity, `DEMO_MODE` has no database at all, and a deep check would make the container report unhealthy during a transient DB reconnect even though the API itself is fine.
- **API/frontend/all-in-one Dockerfiles**: added `HEALTHCHECK` directives, wired into `docker-compose.yml`/`docker-compose.demo.yml` via `depends_on: condition: service_healthy` for worker/frontend so they wait for the API to actually be listening rather than just started. This is what caused raw 502s on first boot previously (no HEALTHCHECK existed anywhere except Postgres).
- **All-in-one image**: replaced the fixed `sleep 10/20/25` startup delays with real readiness polling (`wait-for-postgres.sh`, `wait-for-mosquitto.sh`, shared rather than duplicated inline across `api`/`worker`/`saic-gateway`). Falls through after a timeout so a stuck dependency doesn't hang supervisord forever.
- **`docker-compose.yml`**: added `mem_limit`/`cpus` to every service so a runaway container has a ceiling on a shared home-lab host.
- **Backup/restore documentation** in `README.md` and `docker/all-in-one/README.md` — this was the single biggest documentation gap found in the review, previously undocumented anywhere for either deployment mode.

## Caveat
Not verified with a real `docker build`/`docker compose up` locally, Docker Desktop wasn't running in this environment. Validated with `docker compose config` (both compose files parse cleanly) and manual review of the Dockerfile/script changes.

## Test plan
- [x] `dotnet build` / `dotnet test` — 314/314 passing
- [x] `docker compose -f docker-compose.yml config` — valid
- [x] `docker compose -f docker-compose.demo.yml config` — valid
- [ ] `docker compose up` — confirm frontend/worker actually wait for API health before starting, and no raw 502 window on first boot
- [ ] All-in-one image: confirm `wait-for-postgres.sh`/`wait-for-mosquitto.sh` correctly gate startup and the container reports healthy
- [ ] Confirm memory/cpu limits don't starve the API under normal load

🤖 Generated with [Claude Code](https://claude.com/claude-code)