### PR TITLE
security: revoke JWTs server-side on logout, serialize vehicle commands per VIN

### DIFF
--- a/README.md
+++ b/README.md
@@ -445,7 +445,7 @@ All three POI types share the same tile-based PostgreSQL cache:
 ## Security defaults
 
 - API routes require login.
-- Login reuses the configured MG account credentials (`SAIC_USER`/`SAIC_PASSWORD`) and issues short-lived JWT tokens.
+- Login reuses the configured MG account credentials (`SAIC_USER`/`SAIC_PASSWORD`) and issues JWT tokens (12 hours by default, 30 days with "remember me"). Logout revokes the token server-side, not just the client-side cookie.
 - MQTT now requires credentials and ACLs, and broker exposure defaults to localhost-only in Docker Compose.
 
 ---

--- a/src/GarageStack.Api/Endpoints/AuthEndpoints.cs
+++ b/src/GarageStack.Api/Endpoints/AuthEndpoints.cs
@@ -2,6 +2,7 @@ using System.IdentityModel.Tokens.Jwt;
 using System.Security.Claims;
 using System.Security.Cryptography;
 using System.Text;
+using GarageStack.Data;
 using Microsoft.IdentityModel.Tokens;
 
 namespace GarageStack.Api.Endpoints;
@@ -15,12 +16,25 @@ public static class AuthEndpoints
         var group = app.MapGroup("/api/auth")
             .WithTags("Authentication");
 
-        group.MapPost("/logout", (HttpContext httpContext) =>
+        group.MapPost("/logout", async (HttpContext httpContext, AppDbContext db, CancellationToken ct) =>
         {
             httpContext.Response.Cookies.Delete(CookieName, new CookieOptions { Path = "/" });
+
+            // Revoke the token server-side so a copy captured before logout (e.g. from a
+            // compromised device) can't keep authenticating for the rest of its lifetime.
+            // Not required to be authenticated for logout to succeed -- an already-expired or
+            // missing token has nothing to revoke, and the cookie is cleared either way above.
+            var jti = httpContext.User.FindFirst(JwtRegisteredClaimNames.Jti)?.Value;
+            var expClaim = httpContext.User.FindFirst(JwtRegisteredClaimNames.Exp)?.Value;
+            if (!string.IsNullOrEmpty(jti) && long.TryParse(expClaim, out var expUnix))
+            {
+                var expiresAtUtc = DateTimeOffset.FromUnixTimeSeconds(expUnix).UtcDateTime;
+                await TokenRevocation.RevokeAsync(db, jti, expiresAtUtc, ct);
+            }
+
             return Results.NoContent();
         })
-        .WithSummary("Clear the authentication cookie");
+        .WithSummary("Clear the authentication cookie and revoke the token server-side");
 
         group.MapGet("/me", (HttpContext httpContext) =>
         {
@@ -98,6 +112,9 @@ public static class AuthEndpoints
                 new Claim(JwtRegisteredClaimNames.Sub, providedUsername),
                 new Claim(JwtRegisteredClaimNames.UniqueName, providedUsername),
                 new Claim(ClaimTypes.Name, providedUsername),
+                // Lets logout revoke this specific token server-side (see RevokedToken) instead
+                // of only clearing the client-side cookie.
+                new Claim(JwtRegisteredClaimNames.Jti, Guid.NewGuid().ToString("N")),
             };
 
             var token = new JwtSecurityToken(

--- a/src/GarageStack.Api/Endpoints/VehicleEndpoints.cs
+++ b/src/GarageStack.Api/Endpoints/VehicleEndpoints.cs
@@ -147,6 +147,7 @@ public static class VehicleEndpoints
             string command,
             JsonElement body,
             IMqttPublisher mqtt,
+            VehicleCommandGate commandGate,
             CancellationToken ct) =>
         {
             var vehicle = ResolveVehicleFilter.GetResolvedVehicle(httpContext);
@@ -187,7 +188,7 @@ public static class VehicleEndpoints
                 return Results.BadRequest(new { error = validationError });
 
             var topic = $"saic/{vehicle.SaicUser}/vehicles/{vin}/{topicSuffix}";
-            await mqtt.PublishAsync(topic, value, ct);
+            await commandGate.RunAsync(vin, () => mqtt.PublishAsync(topic, value, ct), ct);
 
             return Results.Ok(new { topic, value });
         })

--- a/src/GarageStack.Api/Program.cs
+++ b/src/GarageStack.Api/Program.cs
@@ -1,4 +1,5 @@
 using System.Globalization;
+using System.IdentityModel.Tokens.Jwt;
 using System.Text.Json.Serialization;
 using GarageStack.Api;
 using GarageStack.Api.Endpoints;
@@ -107,6 +108,7 @@ try
     builder.Services.AddMemoryCache();
     builder.Services.AddScoped<ChargingStationService>();
     builder.Services.AddScoped<PoiService>();
+    builder.Services.AddSingleton<VehicleCommandGate>();
 
     builder.Services.AddSignalR();
 
@@ -130,6 +132,17 @@ try
                     if (ctx.Request.Cookies.TryGetValue(AuthEndpoints.CookieName, out var cookie))
                         ctx.Token = cookie;
                     return Task.CompletedTask;
+                },
+                OnTokenValidated = async ctx =>
+                {
+                    // Checked after signature/lifetime validation already passed, so this only
+                    // needs to catch tokens explicitly revoked via /api/auth/logout.
+                    var jti = ctx.Principal?.FindFirst(JwtRegisteredClaimNames.Jti)?.Value;
+                    if (string.IsNullOrEmpty(jti)) return;
+
+                    var db = ctx.HttpContext.RequestServices.GetRequiredService<AppDbContext>();
+                    var isRevoked = await TokenRevocation.IsRevokedAsync(db, jti, ctx.HttpContext.RequestAborted);
+                    if (isRevoked) ctx.Fail("Token has been revoked");
                 },
             };
             options.TokenValidationParameters = new TokenValidationParameters

--- a/src/GarageStack.Api/TokenRevocation.cs
+++ b/src/GarageStack.Api/TokenRevocation.cs
@@ -1,0 +1,24 @@
+using GarageStack.Core.Models;
+using GarageStack.Data;
+using Microsoft.EntityFrameworkCore;
+
+namespace GarageStack.Api;
+
+internal static class TokenRevocation
+{
+    // Revokes the given token and opportunistically prunes rows past their own token's expiry --
+    // once a token has expired, JwtBearer's ValidateLifetime already rejects it regardless of
+    // this table, so there's no need for a dedicated background sweep.
+    internal static async Task RevokeAsync(AppDbContext db, string jti, DateTime expiresAtUtc, CancellationToken ct)
+    {
+        db.RevokedTokens.Add(new RevokedToken { Jti = jti, ExpiresAtUtc = expiresAtUtc });
+
+        var expired = db.RevokedTokens.Where(r => r.ExpiresAtUtc < DateTime.UtcNow);
+        db.RevokedTokens.RemoveRange(expired);
+
+        await db.SaveChangesAsync(ct);
+    }
+
+    internal static Task<bool> IsRevokedAsync(AppDbContext db, string jti, CancellationToken ct) =>
+        db.RevokedTokens.AnyAsync(r => r.Jti == jti, ct);
+}

--- a/src/GarageStack.Api/VehicleCommandGate.cs
+++ b/src/GarageStack.Api/VehicleCommandGate.cs
@@ -1,0 +1,41 @@
+using System.Collections.Concurrent;
+
+namespace GarageStack.Api;
+
+/// <summary>
+/// Serializes vehicle commands per VIN server-side. The real SAIC MQTT gateway only processes
+/// one command at a time and takes up to ~30s to reach the car, so two commands published back
+/// to back can queue up behind each other at the gateway. The frontend already serializes its
+/// own batched sends (ClimateDetailCard.applyAll), this is a backstop against any other caller
+/// (a second browser tab, a script against the API, a future frontend regression) doing the same
+/// thing unserialized.
+/// </summary>
+internal sealed class VehicleCommandGate(TimeSpan? holdDuration = null)
+{
+    private readonly TimeSpan _holdDuration = holdDuration ?? TimeSpan.FromSeconds(30);
+    private readonly ConcurrentDictionary<string, SemaphoreSlim> _gates = new();
+
+    /// <summary>
+    /// Waits for any other in-flight command for <paramref name="vin"/> to finish, then runs
+    /// <paramref name="publish"/>. On success, holds the gate for the configured duration before
+    /// releasing it, without blocking the caller for that long, so the next command for this VIN
+    /// doesn't reach the gateway until the current one has had time to be processed. On failure
+    /// (the command never reached the vehicle) releases immediately so the caller can retry.
+    /// </summary>
+    internal async Task RunAsync(string vin, Func<Task> publish, CancellationToken ct)
+    {
+        var gate = _gates.GetOrAdd(vin, static _ => new SemaphoreSlim(1, 1));
+        await gate.WaitAsync(ct);
+        try
+        {
+            await publish();
+            _ = Task.Delay(_holdDuration, CancellationToken.None)
+                .ContinueWith(_ => gate.Release(), TaskScheduler.Default);
+        }
+        catch
+        {
+            gate.Release();
+            throw;
+        }
+    }
+}

--- a/src/GarageStack.Core/Models/RevokedToken.cs
+++ b/src/GarageStack.Core/Models/RevokedToken.cs
@@ -1,0 +1,13 @@
+namespace GarageStack.Core.Models;
+
+// Records a JWT's jti (unique ID) as revoked so logout actually invalidates the token
+// server-side, instead of only removing the client-side cookie. ExpiresAtUtc mirrors the
+// token's own "exp" claim so rows past their token's natural expiry can be pruned -- once a
+// token has expired, JwtBearer's own ValidateLifetime already rejects it regardless of this
+// table, so there's no need to keep the row around.
+public class RevokedToken
+{
+    public long Id { get; set; }
+    public string Jti { get; set; } = string.Empty;
+    public DateTime ExpiresAtUtc { get; set; }
+}

--- a/src/GarageStack.Data/AppDbContext.cs
+++ b/src/GarageStack.Data/AppDbContext.cs
@@ -13,6 +13,7 @@ public class AppDbContext(DbContextOptions<AppDbContext> options) : DbContext(op
     public DbSet<PoiCacheTile> PoiCacheTiles => Set<PoiCacheTile>();
     public DbSet<MaintenanceItem> MaintenanceItems => Set<MaintenanceItem>();
     public DbSet<MaintenanceLogEntry> MaintenanceLogEntries => Set<MaintenanceLogEntry>();
+    public DbSet<RevokedToken> RevokedTokens => Set<RevokedToken>();
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
@@ -99,6 +100,13 @@ public class AppDbContext(DbContextOptions<AppDbContext> options) : DbContext(op
              .WithMany(m => m.LogEntries)
              .HasForeignKey(l => l.MaintenanceItemId)
              .OnDelete(DeleteBehavior.Cascade);
+        });
+
+        modelBuilder.Entity<RevokedToken>(e =>
+        {
+            e.HasKey(r => r.Id);
+            e.HasIndex(r => r.Jti).IsUnique();
+            e.Property(r => r.Jti).HasMaxLength(64).IsRequired();
         });
 
     }

--- a/src/GarageStack.Data/Migrations/20260710105223_AddRevokedTokens.Designer.cs
+++ b/src/GarageStack.Data/Migrations/20260710105223_AddRevokedTokens.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using GarageStack.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace GarageStack.Data.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260710105223_AddRevokedTokens")]
+    partial class AddRevokedTokens
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/GarageStack.Data/Migrations/20260710105223_AddRevokedTokens.cs
+++ b/src/GarageStack.Data/Migrations/20260710105223_AddRevokedTokens.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace GarageStack.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddRevokedTokens : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "RevokedTokens",
+                columns: table => new
+                {
+                    Id = table.Column<long>(type: "bigint", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    Jti = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: false),
+                    ExpiresAtUtc = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_RevokedTokens", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_RevokedTokens_Jti",
+                table: "RevokedTokens",
+                column: "Jti",
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "RevokedTokens");
+        }
+    }
+}

--- a/src/GarageStack.Tests/TokenRevocationTests.cs
+++ b/src/GarageStack.Tests/TokenRevocationTests.cs
@@ -1,0 +1,62 @@
+using GarageStack.Api;
+using GarageStack.Data;
+using Microsoft.EntityFrameworkCore;
+
+namespace GarageStack.Tests;
+
+public class TokenRevocationTests
+{
+    private static AppDbContext CreateDb() =>
+        new(new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options);
+
+    [Fact]
+    public async Task IsRevokedAsync_UnknownJti_ReturnsFalse()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        await using var db = CreateDb();
+
+        Assert.False(await TokenRevocation.IsRevokedAsync(db, "never-issued", ct));
+    }
+
+    [Fact]
+    public async Task RevokeAsync_ThenIsRevokedAsync_ReturnsTrue()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        await using var db = CreateDb();
+
+        await TokenRevocation.RevokeAsync(db, "abc123", DateTime.UtcNow.AddHours(1), ct);
+
+        Assert.True(await TokenRevocation.IsRevokedAsync(db, "abc123", ct));
+    }
+
+    [Fact]
+    public async Task RevokeAsync_DifferentJti_DoesNotAffectOtherTokens()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        await using var db = CreateDb();
+
+        await TokenRevocation.RevokeAsync(db, "revoked-token", DateTime.UtcNow.AddHours(1), ct);
+
+        Assert.False(await TokenRevocation.IsRevokedAsync(db, "still-valid-token", ct));
+    }
+
+    [Fact]
+    public async Task RevokeAsync_PrunesRowsPastTheirOwnExpiry()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        await using var db = CreateDb();
+
+        // Simulate a stale revocation from a token that has since naturally expired.
+        await TokenRevocation.RevokeAsync(db, "long-expired", DateTime.UtcNow.AddDays(-1), ct);
+        Assert.Equal(1, await db.RevokedTokens.CountAsync(ct));
+
+        // Revoking a new, still-valid token should sweep the stale row above.
+        await TokenRevocation.RevokeAsync(db, "freshly-revoked", DateTime.UtcNow.AddHours(1), ct);
+
+        Assert.False(await TokenRevocation.IsRevokedAsync(db, "long-expired", ct));
+        Assert.True(await TokenRevocation.IsRevokedAsync(db, "freshly-revoked", ct));
+        Assert.Equal(1, await db.RevokedTokens.CountAsync(ct));
+    }
+}

--- a/src/GarageStack.Tests/VehicleCommandGateTests.cs
+++ b/src/GarageStack.Tests/VehicleCommandGateTests.cs
@@ -1,0 +1,80 @@
+using GarageStack.Api;
+
+namespace GarageStack.Tests;
+
+public class VehicleCommandGateTests
+{
+    [Fact]
+    public async Task RunAsync_InvokesPublish()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var gate = new VehicleCommandGate(TimeSpan.FromMilliseconds(10));
+        var published = false;
+
+        await gate.RunAsync("VIN1", () => { published = true; return Task.CompletedTask; }, ct);
+
+        Assert.True(published);
+    }
+
+    [Fact]
+    public async Task RunAsync_SameVin_WaitsForHoldWindowBeforeNextCommand()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var holdDuration = TimeSpan.FromMilliseconds(150);
+        var gate = new VehicleCommandGate(holdDuration);
+
+        var firstPublishedAt = DateTime.MinValue;
+        var secondStartedAt = DateTime.MinValue;
+
+        await gate.RunAsync("VIN1", () =>
+        {
+            firstPublishedAt = DateTime.UtcNow;
+            return Task.CompletedTask;
+        }, ct);
+
+        await gate.RunAsync("VIN1", () =>
+        {
+            secondStartedAt = DateTime.UtcNow;
+            return Task.CompletedTask;
+        }, ct);
+
+        Assert.True(secondStartedAt - firstPublishedAt >= holdDuration);
+    }
+
+    [Fact]
+    public async Task RunAsync_DifferentVins_AreNotSerialized()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        // Deliberately long hold: if VIN2 incorrectly shared VIN1's gate, the second RunAsync
+        // below would still be waiting when the 2s timeout below elapses.
+        var gate = new VehicleCommandGate(TimeSpan.FromSeconds(30));
+
+        await gate.RunAsync("VIN1", () => Task.CompletedTask, ct);
+
+        var vin2Ran = false;
+        var vin2Task = gate.RunAsync("VIN2", () => { vin2Ran = true; return Task.CompletedTask; }, ct);
+        var completed = await Task.WhenAny(vin2Task, Task.Delay(TimeSpan.FromSeconds(2), ct));
+
+        Assert.Same(vin2Task, completed);
+        Assert.True(vin2Ran);
+    }
+
+    [Fact]
+    public async Task RunAsync_PublishThrows_ReleasesGateImmediatelyAndRethrows()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        // Deliberately long hold: if a failed publish still held the gate, the second RunAsync
+        // below would still be waiting when the 2s timeout below elapses.
+        var gate = new VehicleCommandGate(TimeSpan.FromSeconds(30));
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            gate.RunAsync("VIN1", () => throw new InvalidOperationException("boom"), ct));
+
+        var secondRan = false;
+        var secondTask = gate.RunAsync("VIN1", () => { secondRan = true; return Task.CompletedTask; }, ct);
+        var completed = await Task.WhenAny(secondTask, Task.Delay(TimeSpan.FromSeconds(2), ct));
+
+        Assert.Same(secondTask, completed);
+        Assert.True(secondRan);
+    }
+}


### PR DESCRIPTION
## Summary
Final batch from a full-project review: the two items that needed a design decision rather than a mechanical fix, flagging both clearly below so they're easy to redirect on review.

### JWT revocation on logout
Logout previously only cleared the client-side cookie, the JWT itself stayed valid until its natural expiry (up to 30 days with "remember me"), so a token captured before logout kept authenticating. Design chosen: add a `jti` claim to issued tokens, a `RevokedToken` table (with migration), and a `JwtBearerEvents.OnTokenValidated` check so logout actually invalidates the token server-side. Rows past their own token's expiry are pruned opportunistically on each new revocation, no dedicated cleanup job, since `ValidateLifetime` already rejects expired tokens regardless of this table's contents.

**Alternative considered:** just shortening the "remember me" lifetime instead of adding a revocation table. Went with real revocation since it fully closes the gap rather than narrowing the window, and the DB-backed approach was cheap given Postgres is already there (no Redis or other new infra needed).

### Server-side per-vehicle command serialization
The real SAIC MQTT gateway only processes one vehicle command at a time and takes up to ~30s to reach the car. The frontend already serializes its own batched sends (`ClimateDetailCard.applyAll`, commit `6529351`), but nothing stopped a second browser tab, a script against the API, or a future frontend regression from firing commands unserialized. Added `VehicleCommandGate`: a per-VIN in-memory semaphore that holds for 30s after a successful publish (without blocking the HTTP response for that long) and releases immediately on failure so the caller can retry right away.

**Alternative considered:** waiting for telemetry confirmation (like the frontend's `waitUntilSettled`) instead of a fixed 30s hold. Went with the simpler fixed-duration approach since this is meant as a defense-in-depth backstop, not the primary UX, the frontend already owns the more sophisticated confirmation-based flow.

Both pieces of logic are extracted into small standalone classes (`TokenRevocation`, `VehicleCommandGate`) so they're unit-testable in isolation, matching the existing `CsrfPolicy`/`ValidateCommandValue` pattern already in this codebase rather than embedding the logic inline in `Program.cs` or the minimal API lambdas.

## Test plan
- [x] `dotnet build` — 0 warnings, 0 errors
- [x] `dotnet test` — 322/322 passing (8 new tests: `TokenRevocationTests`, `VehicleCommandGateTests`)
- [x] Migration generated via `dotnet ef migrations add`
- [ ] Manual: log in, log out, confirm the old cookie value (if replayed) is rejected with 401
- [ ] Manual: fire two commands for the same VIN back to back, confirm the second doesn't reach the gateway until ~30s after the first

🤖 Generated with [Claude Code](https://claude.com/claude-code)