### PR TITLE
chore(deps): pin node docker images below Node 26 until it goes LTS

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -175,6 +175,12 @@ updates:
     open-pull-requests-limit: 2
     cooldown:
       default-days: 3
+    ignore:
+      # Node 25 is an odd-numbered "Current" release, not LTS. Node 26 doesn't
+      # become LTS until October 2026. Stay on the 24-alpine LTS line until
+      # 26 actually goes LTS, then update this ignore rule.
+      - dependency-name: "node"
+        versions: [">=25"]
 
   - package-ecosystem: docker
     directory: /docker/all-in-one
@@ -186,6 +192,12 @@ updates:
     open-pull-requests-limit: 2
     cooldown:
       default-days: 3
+    ignore:
+      # Node 25 is an odd-numbered "Current" release, not LTS. Node 26 doesn't
+      # become LTS until October 2026. Stay on the 24-alpine LTS line until
+      # 26 actually goes LTS, then update this ignore rule.
+      - dependency-name: "node"
+        versions: [">=25"]
 
   # ── GitHub Actions ───────────────────────────────────────────────────────────
   - package-ecosystem: github-actions


### PR DESCRIPTION
## Summary
- Node 24 is the current LTS; Node 25 is a non-LTS "Current" release and Node 26 won't be LTS until October 2026.
- Dependabot had opened PRs to bump the `node` docker base image (`docker/all-in-one/Dockerfile`, `frontend/Dockerfile`) from `24-alpine` to `25-alpine`/`26-alpine` (#244, #245, #232) - closed as premature.
- Adds an `ignore` rule to the two affected `docker` ecosystem blocks in `.github/dependabot.yml` blocking `node >= 25` until 26 actually goes LTS.

## Test plan
- [x] N/A - config-only change to `.github/dependabot.yml`, no app code affected