### PR TITLE
fix(ci): pin pnpm/action-setup to 11.1.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
 
       - uses: pnpm/action-setup@v6
         with:
-          version: 11
+          version: 11.1.3
 
       - uses: actions/setup-node@v6
         with:
@@ -56,7 +56,7 @@ jobs:
 
       - uses: pnpm/action-setup@v6
         with:
-          version: 11
+          version: 11.1.3
 
       - uses: actions/setup-node@v6
         with:
@@ -82,7 +82,7 @@ jobs:
 
       - uses: pnpm/action-setup@v6
         with:
-          version: 11
+          version: 11.1.3
 
       - uses: actions/setup-node@v6
         with:


### PR DESCRIPTION
## Summary
- CI is currently broken on every PR: `pnpm/action-setup@v6` was configured with a floating major version (`version: 11`), which resolves to the latest v11 release at runtime.
- pnpm just published `11.12.0`, which crashes the action's self-installer during its version-switch step (`Cannot use 'in' operator to search for 'integrity' in undefined`). This is a confirmed, currently-open upstream bug: https://github.com/pnpm/action-setup/issues/276
- Pinned all three `pnpm/action-setup` steps in `ci.yml` to `11.1.3`, matching the `packageManager` field already declared in `frontend/package.json`, avoiding the broken release entirely.

## Test plan
- [ ] Confirm the `frontend-lint`, `frontend-typecheck`, and `frontend-test` CI jobs pass on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)