### PR TITLE
chore(deps): ignore typescript major bumps until vue-tsc supports v7

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,14 @@ updates:
     open-pull-requests-limit: 8
     cooldown:
       default-days: 3
+    ignore:
+      # TypeScript 7 restructured its package exports and dropped the
+      # ./lib/tsc subpath vue-tsc relies on, breaking `vue-tsc --build`
+      # with ERR_PACKAGE_PATH_NOT_EXPORTED. vue-tsc has no fix yet, tracked
+      # at https://github.com/vuejs/language-tools/issues/5381. Stay on the
+      # 6.x line until vue-tsc adds TypeScript 7 support.
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]
     groups:
       # Vue runtime + all official plugins that ship together
       vue-ecosystem:


### PR DESCRIPTION
## Summary
- PR #259 (dependabot bump of `typescript` 6.0.3 -> 7.0.2) breaks the `frontend-typecheck` CI job: `vue-tsc --build` fails with `ERR_PACKAGE_PATH_NOT_EXPORTED: Package subpath './lib/tsc' is not defined by "exports"`.
- TypeScript 7 restructured its package layout and no longer exposes the `./lib/tsc` subpath that vue-tsc's CLI wrapper resolves at runtime. `vue-tsc` has no fix yet: https://github.com/vuejs/language-tools/issues/6124 was closed as a duplicate of the open tracking issue https://github.com/vuejs/language-tools/issues/5381.
- Added an `ignore` rule for `typescript` major-version bumps in the frontend npm block of `dependabot.yml`, matching the existing pattern already used there for `Microsoft.OpenApi` and the Node LTS pin. Minor/patch updates on the 6.x line are unaffected.

## Test plan
- [ ] N/A - config-only change, no app code affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)