### PR TITLE
fix: derive SAIC_REST_URI from SAIC_REGION for known endpoints

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,8 +6,12 @@
 # Use a separate account for the MG iSmart phone app to avoid session conflicts.
 SAIC_USER=your_mg_account@example.com
 SAIC_PASSWORD=your_mg_account_password
-# Region the car is registered in. eu | cn | row
+# Region the car is registered in: eu (default), au, or tr -- automatically mapped
+# to the right API endpoint. For any other region, set SAIC_REST_URI below directly
+# to your gateway's endpoint instead.
 SAIC_REGION=eu
+# Optional override, only needed for a region not listed above.
+# SAIC_REST_URI=https://gateway-mg-eu.soimt.com/api.app/v1/
 
 # ── PostgreSQL ───────────────────────────────────────────────────────────────
 # To use your own existing Postgres server set POSTGRES_HOST to its address and

--- a/README.md
+++ b/README.md
@@ -160,7 +160,8 @@ Then open `.env` and fill in at minimum:
 | ---------- | ----------- |
 | `SAIC_USER` | MG iSmart account email |
 | `SAIC_PASSWORD` | MG iSmart account password |
-| `SAIC_REGION` | `eu`, `cn`, or `row` |
+| `SAIC_REGION` | Region the car is registered in: `eu` (default), `au`, or `tr` -- automatically mapped to the right API endpoint |
+| `SAIC_REST_URI` | Optional, only needed for a region not listed above -- set directly to your gateway's endpoint |
 | `JWT_SECRET` | At least 32 random characters -- generate with `openssl rand -base64 32` |
 | `CORS_ORIGIN` | The URL you open in your browser, e.g. `http://192.168.1.100:8080` |
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,6 +37,11 @@ services:
       MQTT_USER: "${MQTT_BROKER_USERNAME:-garagestack}"
       MQTT_PASSWORD: "${MQTT_BROKER_PASSWORD:-garagestack}"
       SAIC_REGION: "${SAIC_REGION:-eu}"
+      SAIC_REST_URI: "${SAIC_REST_URI:-}"
+    volumes:
+      - ./docker/resolve-saic-rest-uri.sh:/resolve-saic-rest-uri.sh:ro
+    entrypoint: ["/bin/sh", "-c"]
+    command: [". /resolve-saic-rest-uri.sh && exec python ./main.py"]
 
   # Bundled Postgres - only starts when you pass --profile bundled-postgres.
   # Skip this and set POSTGRES_HOST to your own server to reuse an existing instance.

--- a/docker/all-in-one/Dockerfile
+++ b/docker/all-in-one/Dockerfile
@@ -125,9 +125,10 @@ COPY docker/all-in-one/supervisord.conf /etc/supervisor/supervisord.conf
 COPY docker/all-in-one/entrypoint.sh   /entrypoint.sh
 COPY docker/all-in-one/wait-for-postgres.sh  /wait-for-postgres.sh
 COPY docker/all-in-one/wait-for-mosquitto.sh /wait-for-mosquitto.sh
+COPY docker/resolve-saic-rest-uri.sh /resolve-saic-rest-uri.sh
 
 RUN rm -f /etc/nginx/sites-enabled/default \
-    && chmod +x /entrypoint.sh /wait-for-postgres.sh /wait-for-mosquitto.sh \
+    && chmod +x /entrypoint.sh /wait-for-postgres.sh /wait-for-mosquitto.sh /resolve-saic-rest-uri.sh \
     && mkdir -p /data/db/postgres /data/db/mosquitto /data/logs /data/dataprotection /data/api /data/worker
 
 # Port 80  -- nginx (web UI + API proxy)

--- a/docker/all-in-one/README.md
+++ b/docker/all-in-one/README.md
@@ -45,7 +45,7 @@ Mount a single volume at `/data`. The container creates the following layout ins
 |----------|-------------|
 | `SAIC_USER` | MG iSmart account email (must be the vehicle owner account) |
 | `SAIC_PASSWORD` | MG iSmart account password |
-| `SAIC_REGION` | Region: `eu`, `cn`, or `row` (default: `eu`) |
+| `SAIC_REGION` | Region the car is registered in: `eu` (default), `au`, or `tr` -- automatically mapped to the right API endpoint |
 | `JWT_SECRET` | Token signing key, minimum 32 characters. Generate: `openssl rand -base64 32` |
 | `CORS_ORIGIN` | Exact URL you use to open the app, e.g. `http://192.168.1.100:8080` |
 
@@ -61,6 +61,7 @@ The web login uses the same `SAIC_USER` and `SAIC_PASSWORD` credentials. There i
 | `WIDGET_API_KEY` | Static API key for the Homepage dashboard widget endpoint (`/api/widget/{vin}/status`). Leave empty to disable. Generate: `openssl rand -base64 32` |
 | `OPENCHARGEMAP_API_KEY` | API key for the EV charging station map overlay, sourced from [Open Charge Map](https://openchargemap.org/site/develop). Free to obtain. Leave empty to disable the feature. |
 | `OVERPASS__BASEURL` | Overpass API endpoint used for the fuel station and motorway service area map overlays. Defaults to the public endpoint (`https://overpass-api.de/api/interpreter`). Set this only if you self-host an Overpass instance. No API key is required for the default public endpoint. |
+| `SAIC_REST_URI` | Override for the SAIC gateway API endpoint. Only needed if your region isn't listed in the `SAIC_REGION` row above -- set it directly to your gateway's endpoint. |
 | `POSTGRES_DB` | Database name (default: `garagestack`) |
 | `POSTGRES_USER` | Database user (default: `garagestack`) |
 | `AUTH_COOKIE_SECURE` | Set to `true` when serving behind a TLS-terminating reverse proxy. Defaults to `false` so plain-HTTP LAN installs work out of the box. |

--- a/docker/all-in-one/entrypoint.sh
+++ b/docker/all-in-one/entrypoint.sh
@@ -10,6 +10,10 @@ POSTGRES_USER="${POSTGRES_USER:-garagestack}"
 SAIC_USER="${SAIC_USER:?SAIC_USER environment variable is required}"
 SAIC_PASSWORD="${SAIC_PASSWORD:?SAIC_PASSWORD environment variable is required}"
 
+# Derives SAIC_REST_URI from SAIC_REGION for known regions (unless already set) so
+# the SAIC gateway hits the right API endpoint -- see the script for details.
+. /resolve-saic-rest-uri.sh
+
 # Auto-generate POSTGRES_PASSWORD on first run and persist it so subsequent
 # restarts use the same password as the already-initialised database cluster.
 if [ -z "${POSTGRES_PASSWORD:-}" ]; then

--- a/docker/resolve-saic-rest-uri.sh
+++ b/docker/resolve-saic-rest-uri.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+# Derives SAIC_REST_URI from SAIC_REGION for known endpoints, unless SAIC_REST_URI
+# is already set explicitly (so a user can always override for a region not listed
+# here). Source of truth: the "API Endpoints" table in the saic-python-mqtt-gateway
+# README (SAIC-iSmart-API/saic-python-mqtt-gateway).
+if [ -z "${SAIC_REST_URI:-}" ]; then
+    case "${SAIC_REGION:-eu}" in
+        eu) export SAIC_REST_URI="https://gateway-mg-eu.soimt.com/api.app/v1/" ;;
+        au) export SAIC_REST_URI="https://gateway-mg-au.soimt.com/api.app/v1/" ;;
+        tr) export SAIC_REST_URI="https://gateway-mg-tr.soimt.com/api.app/v1/" ;;
+    esac
+fi

--- a/unraid/garagestack.xml
+++ b/unraid/garagestack.xml
@@ -95,7 +95,7 @@
     Target="SAIC_REGION"
     Default="eu"
     Mode=""
-    Description="Region your vehicle is registered in: eu (Europe), cn (China), or row (Rest of World)."
+    Description="Region your vehicle is registered in: eu (Europe, default), au (Australia/New Zealand), or tr (Turkiye). Automatically mapped to the right API endpoint."
     Type="Variable"
     Display="always"
     Required="true"
@@ -135,6 +135,17 @@
     Mask="false">http://localhost:8080</Config>
 
   <!-- ── Optional variables ─────────────────────────────────────────────────── -->
+
+  <Config
+    Name="MG API Endpoint Override"
+    Target="SAIC_REST_URI"
+    Default=""
+    Mode=""
+    Description="Optional. Only needed if your region isn't eu, au, or tr -- set directly to your gateway's endpoint."
+    Type="Variable"
+    Display="advanced"
+    Required="false"
+    Mask="false"></Config>
 
   <Config
     Name="VAPID Public Key"


### PR DESCRIPTION
## Summary
- `SAIC_REGION` and `SAIC_REST_URI` were independent settings all the way down the stack (GarageStack, the upstream MQTT gateway, and the SAIC API client library) -- region was never translated into an endpoint URL, so setting `SAIC_REGION=au` alone did nothing and the gateway kept hitting the EU endpoint, failing with "The account is not registered."
- Adds `docker/resolve-saic-rest-uri.sh`, a shared region -> URI mapping for the endpoints that are actually documented as working upstream (`eu`, `au`, `tr`), applied only when `SAIC_REST_URI` isn't already set so a manual override always wins.
- Wires the script into both deployment paths: the all-in-one image's entrypoint, and `docker-compose.yml`'s `saic-mqtt-gateway` service (which previously didn't even pass `SAIC_REST_URI` through).
- Corrects docs (`.env.example`, `README.md`, `docker/all-in-one/README.md`, `unraid/garagestack.xml`) that claimed a fictitious `eu | cn | row` enum, and documents `SAIC_REST_URI` as the escape hatch for any other region.

Fixes #260

## Test plan
- [x] `docker compose config` resolves the new entrypoint/command override on `saic-mqtt-gateway` correctly
- [x] Ran `resolve-saic-rest-uri.sh` directly for `au`, default/no-region (`eu`), `tr`, an unlisted region (`cn`, left untouched), and region+explicit-override (override wins) -- all resolved as expected
- [ ] Manual end-to-end test with a real AU/TR account against the live MG API (not available in this environment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)