### PR TITLE
Make tyre pressure colour/notification thresholds configurable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -105,3 +105,11 @@ OPENCHARGEMAP_API_KEY=
 # the map. No API key is required (free/FOSS data). The default public endpoint
 # is used automatically. Override only if you self-host an Overpass instance.
 # OVERPASS__BASEURL=https://overpass-api.de/api/interpreter
+
+# ── Tyre pressure thresholds ───────────────────────────────────────────────────
+# Colour-code thresholds (bar) for the Overview diagram's tyre dots and for
+# low/high tyre-pressure notifications. Defaults suit ~2.5 bar passenger cars --
+# override with your vehicle's placarded pressure, e.g. TYRE_PRESSURE_GOOD_BAR=2.55.
+TYRE_PRESSURE_LOW_BAR=2.2
+TYRE_PRESSURE_GOOD_BAR=2.6
+TYRE_PRESSURE_HIGH_BAR=3.2

--- a/README.md
+++ b/README.md
@@ -169,6 +169,8 @@ Then open `.env` and fill in at minimum:
 
 `VAPID_PUBLIC_KEY` / `VAPID_PRIVATE_KEY` are optional; leave them empty to disable push notifications.
 
+`TYRE_PRESSURE_LOW_BAR` / `TYRE_PRESSURE_GOOD_BAR` / `TYRE_PRESSURE_HIGH_BAR` are optional and default to `2.2` / `2.6` / `3.2` bar; override them to match your vehicle's placarded tyre pressure (see [Push notifications](#push-notifications) below).
+
 #### 3. Start the stack
 
 With the bundled PostgreSQL container:
@@ -253,13 +255,16 @@ GarageStack checks your vehicle's state every 5 minutes and sends both a browser
 | Alert | Condition |
 | ------- | --------- |
 | Engine started | Engine transitions from off to running |
-| Low tyre pressure | Any tyre below 2.2 bar |
+| Low tyre pressure | Any tyre below `TYRE_PRESSURE_LOW_BAR` (default 2.2 bar) |
+| High tyre pressure | Any tyre above `TYRE_PRESSURE_HIGH_BAR` (default 3.2 bar) |
 | Low EV battery | EV state-of-charge below 20 % |
 | Car left unlocked | `doors/locked = false` while engine is off |
 | Door left open | Any door, boot, or bonnet open while engine is off |
 | Window left open | Any window or sunroof open while engine is off |
 
 Push notifications require VAPID keys to be configured (`VAPID_PUBLIC_KEY` / `VAPID_PRIVATE_KEY`). Without them, alerts still appear in the in-app notification panel. The "engine started" alert is also triggered in real time when the event arrives over MQTT, independently of the 5-minute polling cycle.
+
+The tyre pressure thresholds (`TYRE_PRESSURE_LOW_BAR` / `TYRE_PRESSURE_GOOD_BAR` / `TYRE_PRESSURE_HIGH_BAR`) also drive the colour-coded dots on the dashboard's vehicle diagram and the in-browser low/high pressure alert -- set them once in your `.env` (or container environment) to match your vehicle's placarded pressure instead of the app's generic defaults.
 
 To generate a VAPID key pair (requires Node.js):
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -95,6 +95,9 @@ services:
       Vapid__PublicKey: "${VAPID_PUBLIC_KEY}"
       Vapid__PrivateKey: "${VAPID_PRIVATE_KEY}"
       Vapid__Subject: "mailto:${SAIC_USER}"
+      TyrePressure__LowBar: "${TYRE_PRESSURE_LOW_BAR:-2.2}"
+      TyrePressure__GoodBar: "${TYRE_PRESSURE_GOOD_BAR:-2.6}"
+      TyrePressure__HighBar: "${TYRE_PRESSURE_HIGH_BAR:-3.2}"
     volumes:
       - worker_logs:/app/logs
 
@@ -135,6 +138,9 @@ services:
       Widget__ApiKey: "${WIDGET_API_KEY:-}"
       OpenChargeMap__ApiKey: "${OPENCHARGEMAP_API_KEY:-}"
       Auth__CookieSecure: "${AUTH_COOKIE_SECURE:-false}"
+      TyrePressure__LowBar: "${TYRE_PRESSURE_LOW_BAR:-2.2}"
+      TyrePressure__GoodBar: "${TYRE_PRESSURE_GOOD_BAR:-2.6}"
+      TyrePressure__HighBar: "${TYRE_PRESSURE_HIGH_BAR:-3.2}"
     ports:
       - "127.0.0.1:${API_PORT:-5000}:8080"
     volumes:

--- a/docker/all-in-one/README.md
+++ b/docker/all-in-one/README.md
@@ -61,6 +61,7 @@ The web login uses the same `SAIC_USER` and `SAIC_PASSWORD` credentials. There i
 | `WIDGET_API_KEY` | Static API key for the Homepage dashboard widget endpoint (`/api/widget/{vin}/status`). Leave empty to disable. Generate: `openssl rand -base64 32` |
 | `OPENCHARGEMAP_API_KEY` | API key for the EV charging station map overlay, sourced from [Open Charge Map](https://openchargemap.org/site/develop). Free to obtain. Leave empty to disable the feature. |
 | `OVERPASS__BASEURL` | Overpass API endpoint used for the fuel station and motorway service area map overlays. Defaults to the public endpoint (`https://overpass-api.de/api/interpreter`). Set this only if you self-host an Overpass instance. No API key is required for the default public endpoint. |
+| `TYRE_PRESSURE_LOW_BAR` / `TYRE_PRESSURE_GOOD_BAR` / `TYRE_PRESSURE_HIGH_BAR` | Colour-coding and notification thresholds (bar) for tyre pressure. Default to `2.2` / `2.6` / `3.2`. Override to match your vehicle's placarded pressure, e.g. `TYRE_PRESSURE_GOOD_BAR=2.55`. |
 | `SAIC_REST_URI` | Override for the SAIC gateway API endpoint. Only needed if your region isn't listed in the `SAIC_REGION` row above -- set it directly to your gateway's endpoint. |
 | `POSTGRES_DB` | Database name (default: `garagestack`) |
 | `POSTGRES_USER` | Database user (default: `garagestack`) |

--- a/docker/all-in-one/entrypoint.sh
+++ b/docker/all-in-one/entrypoint.sh
@@ -65,6 +65,12 @@ export Cors__Origins__0="${CORS_ORIGIN:-http://localhost:8080}"
 # Homepage widget API key (optional -- leave empty to disable the widget endpoint)
 export Widget__ApiKey="${WIDGET_API_KEY:-}"
 
+# Tyre pressure colour-coding / notification thresholds (bar). Optional -- defaults to
+# 2.2 / 2.6 / 3.2 (the app's built-in values) when unset.
+export TyrePressure__LowBar="${TYRE_PRESSURE_LOW_BAR:-2.2}"
+export TyrePressure__GoodBar="${TYRE_PRESSURE_GOOD_BAR:-2.6}"
+export TyrePressure__HighBar="${TYRE_PRESSURE_HIGH_BAR:-3.2}"
+
 # .NET API listens on an internal port; nginx proxies port 80 to it
 export ASPNETCORE_URLS="http://127.0.0.1:9000"
 

--- a/frontend/src/components/CarDiagram.vue
+++ b/frontend/src/components/CarDiagram.vue
@@ -3,8 +3,10 @@ import { useI18n } from 'vue-i18n'
 import { computed } from 'vue'
 import CardInfoWrap from './CardInfoWrap.vue'
 import { CAR_SILHOUETTE_VIEWBOX, CAR_SILHOUETTE_MARKUP } from '@/assets/carSilhouette'
+import { useTyrePressureThresholds, pressureVariant } from '@/composables/useTyrePressureThresholds'
 
 const { t } = useI18n()
+const tyreThresholds = useTyrePressureThresholds()
 
 const props = defineProps<{
   frontLeft: number | null
@@ -27,15 +29,8 @@ const props = defineProps<{
   speed?: number | null
 }>()
 
-function pressureVariant(bar: number | null): string {
-  if (bar === null) return 'unknown'
-  if (bar < 2.2) return 'danger'
-  if (bar < 2.6) return 'warning'
-  return 'ok'
-}
-
 function pressureColor(bar: number | null): string {
-  const v = pressureVariant(bar)
+  const v = pressureVariant(bar, tyreThresholds.value)
   if (v === 'danger') return 'var(--tyre-danger, #dc3545)'
   if (v === 'warning') return 'var(--tyre-warning, #fd7e14)'
   if (v === 'ok') return 'var(--tyre-ok, #198754)'
@@ -202,7 +197,15 @@ const activeLightKey = computed(() => {
             <font-awesome-icon icon="circle" class="tyre-legend-dot tyre-legend-dot--danger" />
             {{ t('vehicle.diagram.infoTyreTitle') }}
           </p>
-          <p class="card-info-desc">{{ t('vehicle.diagram.infoTyreDesc') }}</p>
+          <p class="card-info-desc">
+            {{
+              t('vehicle.diagram.infoTyreDesc', {
+                low: tyreThresholds.lowBar,
+                good: tyreThresholds.goodBar,
+                high: tyreThresholds.highBar,
+              })
+            }}
+          </p>
         </div>
         <div class="card-info-section">
           <p class="card-info-section__title">
@@ -455,7 +458,7 @@ const activeLightKey = computed(() => {
               :class="[
                 'tyre-label',
                 `tyre-label--${label.suffix}`,
-                `tyre-label--${pressureVariant(label.value)}`,
+                `tyre-label--${pressureVariant(label.value, tyreThresholds)}`,
               ]"
               :title="t(`vehicle.diagram.tyrePosition.${label.key}`)"
             >

--- a/frontend/src/composables/__tests__/useTyrePressureThresholds.spec.ts
+++ b/frontend/src/composables/__tests__/useTyrePressureThresholds.spec.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, afterEach, vi } from 'vitest'
+import { nextTick } from 'vue'
+import { pressureVariant, DEFAULT_TYRE_PRESSURE_THRESHOLDS } from '../useTyrePressureThresholds'
+
+describe('pressureVariant', () => {
+  it('returns unknown for null', () => {
+    expect(pressureVariant(null, DEFAULT_TYRE_PRESSURE_THRESHOLDS)).toBe('unknown')
+  })
+
+  it('returns danger below the low threshold', () => {
+    expect(pressureVariant(2.1, DEFAULT_TYRE_PRESSURE_THRESHOLDS)).toBe('danger')
+  })
+
+  it('returns warning between low and good', () => {
+    expect(pressureVariant(2.4, DEFAULT_TYRE_PRESSURE_THRESHOLDS)).toBe('warning')
+  })
+
+  it('returns ok at and above good, up to high', () => {
+    expect(pressureVariant(2.6, DEFAULT_TYRE_PRESSURE_THRESHOLDS)).toBe('ok')
+    expect(pressureVariant(3.2, DEFAULT_TYRE_PRESSURE_THRESHOLDS)).toBe('ok')
+  })
+
+  it('returns danger above the high threshold', () => {
+    expect(pressureVariant(3.3, DEFAULT_TYRE_PRESSURE_THRESHOLDS)).toBe('danger')
+  })
+
+  it('honours custom thresholds instead of the defaults', () => {
+    const custom = { lowBar: 2.4, goodBar: 2.55, highBar: 2.7 }
+    expect(pressureVariant(2.5, custom)).toBe('warning')
+    expect(pressureVariant(2.55, custom)).toBe('ok')
+  })
+})
+
+describe('useTyrePressureThresholds', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.resetModules()
+  })
+
+  it('starts at the default thresholds and updates once the fetch resolves', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({ lowBar: 2.4, goodBar: 2.55, highBar: 2.7 }),
+      }),
+    )
+
+    const { useTyrePressureThresholds } = await import('../useTyrePressureThresholds')
+    const thresholds = useTyrePressureThresholds()
+    expect(thresholds.value).toEqual(DEFAULT_TYRE_PRESSURE_THRESHOLDS)
+
+    await nextTick()
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(thresholds.value).toEqual({ lowBar: 2.4, goodBar: 2.55, highBar: 2.7 })
+  })
+
+  it('keeps the default thresholds when the fetch fails', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({ ok: false, status: 500, json: () => Promise.resolve() }),
+    )
+
+    const { useTyrePressureThresholds } = await import('../useTyrePressureThresholds')
+    const thresholds = useTyrePressureThresholds()
+
+    await nextTick()
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(thresholds.value).toEqual(DEFAULT_TYRE_PRESSURE_THRESHOLDS)
+  })
+})

--- a/frontend/src/composables/__tests__/useVehicleAlerts.spec.ts
+++ b/frontend/src/composables/__tests__/useVehicleAlerts.spec.ts
@@ -190,11 +190,21 @@ describe('getTyrePressureAlerts', () => {
     expect(
       getTyrePressureAlerts(
         makeSnapshot({
-          tyrePressureFrontLeft: 1.8,
+          tyrePressureFrontLeft: 2.2,
           tyrePressureFrontRight: 3.2,
         }),
       ),
     ).toEqual([])
+  })
+
+  it('uses custom thresholds when provided', () => {
+    const alerts = getTyrePressureAlerts(makeSnapshot({ tyrePressureFrontLeft: 2.3 }), {
+      lowBar: 2.4,
+      goodBar: 2.55,
+      highBar: 2.7,
+    })
+    expect(alerts).toHaveLength(1)
+    expect(alerts[0]).toContain('FL')
   })
 })
 
@@ -215,10 +225,21 @@ describe('useVehicleAlerts', () => {
       writable: true,
       configurable: true,
     })
+    // useVehicleAlerts fetches the tyre pressure thresholds on setup; stub it so tests don't
+    // hit the network (the composable already has sane defaults before this resolves).
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({ lowBar: 2.2, goodBar: 2.6, highBar: 3.2 }),
+      }),
+    )
   })
 
   afterEach(() => {
     vi.restoreAllMocks()
+    vi.unstubAllGlobals()
   })
 
   it('does not fire when status is null', async () => {

--- a/frontend/src/composables/useTyrePressureThresholds.ts
+++ b/frontend/src/composables/useTyrePressureThresholds.ts
@@ -1,0 +1,45 @@
+import { ref } from 'vue'
+import { vehicleApi, type TyrePressureThresholds } from '@/services/vehicleApi'
+
+export type { TyrePressureThresholds }
+
+export const DEFAULT_TYRE_PRESSURE_THRESHOLDS: TyrePressureThresholds = {
+  lowBar: 2.2,
+  goodBar: 2.6,
+  highBar: 3.2,
+}
+
+// Module-scoped so every component/composable calling useTyrePressureThresholds() shares the
+// same fetch and the same reactive value, instead of each issuing its own request.
+const thresholds = ref<TyrePressureThresholds>({ ...DEFAULT_TYRE_PRESSURE_THRESHOLDS })
+let fetchPromise: Promise<void> | null = null
+
+function load(): Promise<void> {
+  if (!fetchPromise) {
+    fetchPromise = vehicleApi
+      .tyrePressureThresholds()
+      .then((result) => {
+        thresholds.value = result
+      })
+      .catch(() => {
+        // Keep defaults on failure (e.g. offline, not yet authenticated); retry on next call.
+        fetchPromise = null
+      })
+  }
+  return fetchPromise
+}
+
+export function useTyrePressureThresholds() {
+  void load()
+  return thresholds
+}
+
+export type PressureVariant = 'ok' | 'warning' | 'danger' | 'unknown'
+
+export function pressureVariant(bar: number | null, t: TyrePressureThresholds): PressureVariant {
+  if (bar === null) return 'unknown'
+  if (bar < t.lowBar) return 'danger'
+  if (bar < t.goodBar) return 'warning'
+  if (bar > t.highBar) return 'danger'
+  return 'ok'
+}

--- a/frontend/src/composables/useVehicleAlerts.ts
+++ b/frontend/src/composables/useVehicleAlerts.ts
@@ -1,9 +1,11 @@
 import { watch, ref } from 'vue'
 import type { Ref } from 'vue'
 import type { TelemetrySnapshot } from '@/services/vehicleApi'
-
-const TYRE_LOW = 1.8
-const TYRE_HIGH = 3.2
+import {
+  useTyrePressureThresholds,
+  DEFAULT_TYRE_PRESSURE_THRESHOLDS,
+  type TyrePressureThresholds,
+} from '@/composables/useTyrePressureThresholds'
 
 export function getOpenItems(s: TelemetrySnapshot): string[] {
   const open: string[] = []
@@ -20,10 +22,13 @@ export function getOpenItems(s: TelemetrySnapshot): string[] {
   return open
 }
 
-export function getTyrePressureAlerts(s: TelemetrySnapshot): string[] {
+export function getTyrePressureAlerts(
+  s: TelemetrySnapshot,
+  thresholds: TyrePressureThresholds = DEFAULT_TYRE_PRESSURE_THRESHOLDS,
+): string[] {
   const alerts: string[] = []
   const check = (label: string, val: number | null) => {
-    if (val !== null && (val < TYRE_LOW || val > TYRE_HIGH)) {
+    if (val !== null && (val < thresholds.lowBar || val > thresholds.highBar)) {
       alerts.push(`${label}: ${val.toFixed(2)} bar`)
     }
   }
@@ -58,6 +63,7 @@ function useStickyAlert<T>(notify: (issues: T[]) => void) {
 }
 
 export function useVehicleAlerts(status: Ref<TelemetrySnapshot | null>) {
+  const tyreThresholds = useTyrePressureThresholds()
   const checkOpenAlert = useStickyAlert<string>((open) =>
     showNotification('GarageStack', `Open while parked: ${open.join(', ')}`),
   )
@@ -74,6 +80,6 @@ export function useVehicleAlerts(status: Ref<TelemetrySnapshot | null>) {
       checkOpenAlert([])
     }
 
-    checkTyreAlert(getTyrePressureAlerts(s))
+    checkTyreAlert(getTyrePressureAlerts(s, tyreThresholds.value))
   })
 }

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -100,7 +100,7 @@
     "diagram": {
       "panelOpen": "Panel open",
       "infoTyreTitle": "Tyre Pressure",
-      "infoTyreDesc": "Colour-coded dots at each wheel corner show the current pressure. Green means healthy (>= 2.6 bar), orange means low (2.2 – 2.6 bar) and red means critically low (< 2.2 bar).",
+      "infoTyreDesc": "Colour-coded dots at each wheel corner show the current pressure. Green means healthy ({good} – {high} bar), orange means low ({low} – {good} bar) and red means critically low (< {low} bar) or over-inflated (> {high} bar).",
       "infoDoorsTitle": "Doors & Panels",
       "infoDoorsDesc": "A lock-open icon appears over any door, the bonnet or the boot that is currently open.",
       "infoLightsTitle": "Lights",

--- a/frontend/src/locales/nl.json
+++ b/frontend/src/locales/nl.json
@@ -100,7 +100,7 @@
     "diagram": {
       "panelOpen": "Paneel open",
       "infoTyreTitle": "Bandenspanning",
-      "infoTyreDesc": "Kleurgecodeerde stippen bij elke wielhoek tonen de actuele spanning. Groen is goed (>= 2,6 bar), oranje is laag (2,2 – 2,6 bar) en rood is kritiek laag (< 2,2 bar).",
+      "infoTyreDesc": "Kleurgecodeerde stippen bij elke wielhoek tonen de actuele spanning. Groen is goed ({good} – {high} bar), oranje is laag ({low} – {good} bar) en rood is kritiek laag (< {low} bar) of te hoog (> {high} bar).",
       "infoDoorsTitle": "Portieren & Panelen",
       "infoDoorsDesc": "Een open-slot-icoon verschijnt op elk portier, de motorkap of de kofferbak dat momenteel open staat.",
       "infoLightsTitle": "Verlichting",

--- a/frontend/src/services/vehicleApi.ts
+++ b/frontend/src/services/vehicleApi.ts
@@ -112,9 +112,17 @@ export interface LastTripSummary {
   recordedAt: string
 }
 
+export interface TyrePressureThresholds {
+  lowBar: number
+  goodBar: number
+  highBar: number
+}
+
 export const vehicleApi = {
   list: () => request<Vehicle[]>('/api/vehicles'),
   status: (vin: string) => request<TelemetrySnapshot>(`/api/vehicles/${vin}/status`),
+  tyrePressureThresholds: () =>
+    request<TyrePressureThresholds>('/api/vehicles/tyre-pressure-thresholds'),
   lastTrip: (vin: string) =>
     request<LastTripSummary | undefined>(`/api/vehicles/${vin}/trips/last`),
   config: (vin: string) => request<Record<string, string>>(`/api/vehicles/${vin}/config`),

--- a/src/GarageStack.Api/Endpoints/VehicleEndpoints.cs
+++ b/src/GarageStack.Api/Endpoints/VehicleEndpoints.cs
@@ -1,3 +1,4 @@
+using GarageStack.Core.Configuration;
 using GarageStack.Core.Helpers;
 using GarageStack.Core.Interfaces;
 using GarageStack.Core.Models;
@@ -72,6 +73,9 @@ public static class VehicleEndpoints
             return Results.Ok(vehicles);
         })
         .WithSummary("List all vehicles");
+
+        group.MapGet("/tyre-pressure-thresholds", (TyrePressureThresholds thresholds) => Results.Ok(thresholds))
+        .WithSummary("Get configured tyre pressure colour-coding thresholds");
 
         var vehicleGroup = group.MapGroup("/{vin}").AddEndpointFilter<ResolveVehicleFilter>();
 

--- a/src/GarageStack.Api/GarageStack.Api.csproj
+++ b/src/GarageStack.Api/GarageStack.Api.csproj
@@ -11,26 +11,26 @@
 
   <ItemGroup>
     <PackageReference Include="MinVer" Version="7.0.0" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.9" />
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.9" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.10" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.10" />
     <!-- Pinned above the transitive 2.0.0 pulled in by Microsoft.AspNetCore.OpenApi 10.0.9 to avoid CVE-2026-49451 (stack overflow on circular schema refs).
          Stay on the 2.x line - Microsoft.OpenApi 3.x breaks Microsoft.AspNetCore.OpenApi 10.0.9 at
          both compile time (XmlCommentGenerator) and runtime (OpenApiResponse.Content no longer
          exists in the same form), and no compatible Microsoft.AspNetCore.OpenApi release exists yet. -->
     <PackageReference Include="Microsoft.OpenApi" Version="2.10.0" />
-    <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="8.19.1" />
+    <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="8.19.2" />
     <PackageReference Include="MQTTnet" Version="5.2.0.1603" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.9">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.10">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Scalar.AspNetCore" Version="2.16.11" />
+    <PackageReference Include="Scalar.AspNetCore" Version="2.16.12" />
     <PackageReference Include="Serilog.AspNetCore" Version="10.0.0" />
     <PackageReference Include="Serilog.Extensions.Hosting" Version="10.0.0" />
     <PackageReference Include="Serilog.Settings.Configuration" Version="10.0.1" />
     <PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />
     <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.19.1" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.19.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/GarageStack.Api/Program.cs
+++ b/src/GarageStack.Api/Program.cs
@@ -5,6 +5,7 @@ using GarageStack.Api;
 using GarageStack.Api.Endpoints;
 using GarageStack.Api.Hubs;
 using GarageStack.Api.Services;
+using GarageStack.Core.Configuration;
 using GarageStack.Core.Interfaces;
 using GarageStack.Core.Models;
 using GarageStack.Data;
@@ -104,6 +105,9 @@ try
     var jwtSecretBytes = Encoding.UTF8.GetBytes(jwtSecret);
     if (jwtSecretBytes.Length < 32)
         throw new InvalidOperationException("Jwt:Secret must be at least 32 bytes.");
+
+    builder.Services.AddSingleton(builder.Configuration.GetSection("TyrePressure").Get<TyrePressureThresholds>()
+        ?? TyrePressureThresholds.Default);
 
     builder.Services.AddMemoryCache();
     builder.Services.AddScoped<ChargingStationService>();

--- a/src/GarageStack.Api/appsettings.json
+++ b/src/GarageStack.Api/appsettings.json
@@ -8,6 +8,11 @@
   "Overpass": {
     "BaseUrl": "https://overpass-api.de/api/interpreter"
   },
+  "TyrePressure": {
+    "LowBar": 2.2,
+    "GoodBar": 2.6,
+    "HighBar": 3.2
+  },
   "Serilog": {
     "MinimumLevel": {
       "Default": "Information",

--- a/src/GarageStack.Core/Configuration/TyrePressureThresholds.cs
+++ b/src/GarageStack.Core/Configuration/TyrePressureThresholds.cs
@@ -1,0 +1,6 @@
+namespace GarageStack.Core.Configuration;
+
+public record TyrePressureThresholds(double LowBar, double GoodBar, double HighBar)
+{
+    public static readonly TyrePressureThresholds Default = new(LowBar: 2.2, GoodBar: 2.6, HighBar: 3.2);
+}

--- a/src/GarageStack.Data/GarageStack.Data.csproj
+++ b/src/GarageStack.Data/GarageStack.Data.csproj
@@ -6,15 +6,15 @@
 
   <ItemGroup>
     <PackageReference Include="MinVer" Version="7.0.0" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.9" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.9">
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.10" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.10">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.2" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.9" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.9" />
-    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.9" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.3" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.10" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/src/GarageStack.Tests/GarageStack.Tests.csproj
+++ b/src/GarageStack.Tests/GarageStack.Tests.csproj
@@ -12,9 +12,9 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.2" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.9" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.3" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.10" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/GarageStack.Tests/PushNotificationCheckServiceTests.cs
+++ b/src/GarageStack.Tests/PushNotificationCheckServiceTests.cs
@@ -1,3 +1,4 @@
+using GarageStack.Core.Configuration;
 using GarageStack.Core.Models;
 using GarageStack.Worker.Services;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -9,11 +10,12 @@ namespace GarageStack.Tests;
 
 public class PushNotificationCheckServiceTests
 {
-    private static PushNotificationCheckService CreateService() =>
+    private static PushNotificationCheckService CreateService(TyrePressureThresholds? thresholds = null) =>
         new(
             NullLogger<PushNotificationCheckService>.Instance,
             new FakeServiceScopeFactory(),
-            new FakePushSender());
+            new FakePushSender(),
+            thresholds ?? TyrePressureThresholds.Default);
 
     private static TelemetrySnapshot Parked(Action<TelemetrySnapshot>? configure = null)
     {
@@ -305,5 +307,60 @@ public class PushNotificationCheckServiceTests
         svc.CheckChargingComplete(new TelemetrySnapshot { IsCharging = true }, "VIN1", "hev", alerts);
 
         Assert.Empty(alerts);
+    }
+
+    // ---------------------------------------------------------------------------
+    // CheckTyrePressure — configurable low/high thresholds
+    // ---------------------------------------------------------------------------
+
+    [Fact]
+    public void CheckTyrePressure_BelowDefaultLow_FiresLowAlert()
+    {
+        var svc = CreateService();
+        var alerts = new List<(string, string, string)>();
+
+        svc.CheckTyrePressure(new TelemetrySnapshot { TyrePressureFrontLeft = 2.0 }, alerts);
+
+        Assert.Single(alerts);
+        Assert.Equal("low-tyre", alerts[0].Item1);
+        Assert.Contains("FL", alerts[0].Item3);
+    }
+
+    [Fact]
+    public void CheckTyrePressure_AboveDefaultHigh_FiresHighAlert()
+    {
+        var svc = CreateService();
+        var alerts = new List<(string, string, string)>();
+
+        svc.CheckTyrePressure(new TelemetrySnapshot { TyrePressureRearRight = 3.5 }, alerts);
+
+        Assert.Single(alerts);
+        Assert.Equal("high-tyre", alerts[0].Item1);
+        Assert.Contains("RR", alerts[0].Item3);
+    }
+
+    [Fact]
+    public void CheckTyrePressure_WithinDefaultRange_NoAlert()
+    {
+        var svc = CreateService();
+        var alerts = new List<(string, string, string)>();
+
+        svc.CheckTyrePressure(new TelemetrySnapshot { TyrePressureFrontLeft = 2.5 }, alerts);
+
+        Assert.Empty(alerts);
+    }
+
+    [Fact]
+    public void CheckTyrePressure_UsesConfiguredThresholds_NotHardcodedDefaults()
+    {
+        var svc = CreateService(new TyrePressureThresholds(LowBar: 2.4, GoodBar: 2.55, HighBar: 2.7));
+        var alerts = new List<(string, string, string)>();
+
+        // 2.3 bar is below the default 2.2 low bar (would not alert with defaults), but below
+        // the configured 2.4 low bar here.
+        svc.CheckTyrePressure(new TelemetrySnapshot { TyrePressureFrontLeft = 2.3 }, alerts);
+
+        Assert.Single(alerts);
+        Assert.Equal("low-tyre", alerts[0].Item1);
     }
 }

--- a/src/GarageStack.Worker/GarageStack.Worker.csproj
+++ b/src/GarageStack.Worker/GarageStack.Worker.csproj
@@ -11,8 +11,8 @@
 
   <ItemGroup>
     <PackageReference Include="MinVer" Version="7.0.0" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.9" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.9" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.10" />
     <PackageReference Include="MQTTnet" Version="5.2.0.1603" />
     <PackageReference Include="Lib.Net.Http.WebPush" Version="3.3.1" />
     <PackageReference Include="Serilog.Extensions.Hosting" Version="10.0.0" />

--- a/src/GarageStack.Worker/Program.cs
+++ b/src/GarageStack.Worker/Program.cs
@@ -1,3 +1,4 @@
+using GarageStack.Core.Configuration;
 using GarageStack.Data.Extensions;
 using GarageStack.Worker.Mqtt;
 using GarageStack.Worker.Services;
@@ -34,6 +35,8 @@ try
 
     builder.Services.AddGarageStackData(connectionString);
     builder.Services.Configure<MqttOptions>(builder.Configuration.GetSection("Mqtt"));
+    builder.Services.AddSingleton(builder.Configuration.GetSection("TyrePressure").Get<TyrePressureThresholds>()
+        ?? TyrePressureThresholds.Default);
     builder.Services.AddSingleton<GarageStack.Core.Interfaces.IPushSender, GarageStack.Worker.Services.PushSenderService>();
     builder.Services.AddHostedService<MqttConsumerService>();
     builder.Services.AddHostedService<PushNotificationCheckService>();

--- a/src/GarageStack.Worker/Services/PushNotificationCheckService.cs
+++ b/src/GarageStack.Worker/Services/PushNotificationCheckService.cs
@@ -1,3 +1,4 @@
+using GarageStack.Core.Configuration;
 using GarageStack.Core.Helpers;
 using GarageStack.Core.Interfaces;
 using GarageStack.Data;
@@ -11,7 +12,8 @@ namespace GarageStack.Worker.Services;
 public class PushNotificationCheckService(
     ILogger<PushNotificationCheckService> logger,
     IServiceScopeFactory scopeFactory,
-    IPushSender pushSender) : BackgroundService
+    IPushSender pushSender,
+    TyrePressureThresholds tyrePressureThresholds) : BackgroundService
 {
     private readonly Dictionary<string, DateTime> _lastNotified = new();
     private readonly TimeSpan _cooldown = TimeSpan.FromHours(1);
@@ -97,16 +99,25 @@ public class PushNotificationCheckService(
         }
     }
 
-    private static void CheckTyrePressure(Core.Models.TelemetrySnapshot s, List<(string, string, string)> alerts)
+    internal void CheckTyrePressure(Core.Models.TelemetrySnapshot s, List<(string, string, string)> alerts)
     {
         var low = new List<string>();
-        if (s.TyrePressureFrontLeft is not null && s.TyrePressureFrontLeft < 2.2) low.Add("FL");
-        if (s.TyrePressureFrontRight is not null && s.TyrePressureFrontRight < 2.2) low.Add("FR");
-        if (s.TyrePressureRearLeft is not null && s.TyrePressureRearLeft < 2.2) low.Add("RL");
-        if (s.TyrePressureRearRight is not null && s.TyrePressureRearRight < 2.2) low.Add("RR");
+        if (s.TyrePressureFrontLeft is not null && s.TyrePressureFrontLeft < tyrePressureThresholds.LowBar) low.Add("FL");
+        if (s.TyrePressureFrontRight is not null && s.TyrePressureFrontRight < tyrePressureThresholds.LowBar) low.Add("FR");
+        if (s.TyrePressureRearLeft is not null && s.TyrePressureRearLeft < tyrePressureThresholds.LowBar) low.Add("RL");
+        if (s.TyrePressureRearRight is not null && s.TyrePressureRearRight < tyrePressureThresholds.LowBar) low.Add("RR");
 
         if (low.Count > 0)
             alerts.Add(("low-tyre", "Low Tyre Pressure", $"Tyre pressure low: {string.Join(", ", low)}"));
+
+        var high = new List<string>();
+        if (s.TyrePressureFrontLeft is not null && s.TyrePressureFrontLeft > tyrePressureThresholds.HighBar) high.Add("FL");
+        if (s.TyrePressureFrontRight is not null && s.TyrePressureFrontRight > tyrePressureThresholds.HighBar) high.Add("FR");
+        if (s.TyrePressureRearLeft is not null && s.TyrePressureRearLeft > tyrePressureThresholds.HighBar) high.Add("RL");
+        if (s.TyrePressureRearRight is not null && s.TyrePressureRearRight > tyrePressureThresholds.HighBar) high.Add("RR");
+
+        if (high.Count > 0)
+            alerts.Add(("high-tyre", "High Tyre Pressure", $"Tyre pressure high: {string.Join(", ", high)}"));
     }
 
     private static void CheckEvSoc(Core.Models.TelemetrySnapshot s, string vehicleType, List<(string, string, string)> alerts)

--- a/src/GarageStack.Worker/appsettings.json
+++ b/src/GarageStack.Worker/appsettings.json
@@ -6,6 +6,11 @@
     "Host": "mosquitto",
     "Port": 1883
   },
+  "TyrePressure": {
+    "LowBar": 2.2,
+    "GoodBar": 2.6,
+    "HighBar": 3.2
+  },
   "Serilog": {
     "MinimumLevel": {
       "Default": "Information",

--- a/unraid/garagestack.xml
+++ b/unraid/garagestack.xml
@@ -203,6 +203,39 @@
     Mask="false">https://overpass-api.de/api/interpreter</Config>
 
   <Config
+    Name="Tyre Pressure - Low (bar)"
+    Target="TYRE_PRESSURE_LOW_BAR"
+    Default="2.2"
+    Mode=""
+    Description="Tyre pressure (bar) below which a tyre is shown red / triggers a low-pressure alert. Override to match your vehicle's placarded pressure."
+    Type="Variable"
+    Display="advanced"
+    Required="false"
+    Mask="false">2.2</Config>
+
+  <Config
+    Name="Tyre Pressure - Good (bar)"
+    Target="TYRE_PRESSURE_GOOD_BAR"
+    Default="2.6"
+    Mode=""
+    Description="Tyre pressure (bar) at and above which a tyre is shown green (healthy). Below this and above the low threshold, it is shown orange."
+    Type="Variable"
+    Display="advanced"
+    Required="false"
+    Mask="false">2.6</Config>
+
+  <Config
+    Name="Tyre Pressure - High (bar)"
+    Target="TYRE_PRESSURE_HIGH_BAR"
+    Default="3.2"
+    Mode=""
+    Description="Tyre pressure (bar) above which a tyre is shown red / triggers an over-inflation alert."
+    Type="Variable"
+    Display="advanced"
+    Required="false"
+    Mask="false">3.2</Config>
+
+  <Config
     Name="Database Name"
     Target="POSTGRES_DB"
     Default="garagestack"


### PR DESCRIPTION
## Summary
- Closes #261: the Overview diagram's tyre pressure dot colours, browser push alerts, and server-side push alerts each hardcoded their own (inconsistent) low/high pressure thresholds. All three now read from one configurable `TyrePressure:LowBar/GoodBar/HighBar` setting instead.
- New env vars `TYRE_PRESSURE_LOW_BAR` / `TYRE_PRESSURE_GOOD_BAR` / `TYRE_PRESSURE_HIGH_BAR` (defaults `2.2` / `2.6` / `3.2`, matching today's behaviour) — set once in `.env` / container environment to match your vehicle's placarded pressure, no settings UI needed.
- Adds a new over-inflation ("high tyre pressure") push notification, which didn't exist before.
- New `GET /api/vehicles/tyre-pressure-thresholds` endpoint so the frontend picks up the configured values at runtime (works with prebuilt Docker images, no rebuild required).
- Docs updated: README, docker-compose, all-in-one entrypoint/README, Unraid template, `.env.example`.
- Includes a routine NuGet patch bump (10.0.9 → 10.0.10 etc.) picked up incidentally while working in this branch.

## Test plan
- [x] `dotnet test` — 326 backend tests pass
- [x] `pnpm exec vitest run` — 214 frontend tests pass
- [x] `vue-tsc --build` type-check clean
- [x] `eslint` clean on changed files
- [ ] Manual: set `TYRE_PRESSURE_GOOD_BAR=2.55` in `.env`, restart `api`+`worker`, confirm the Overview diagram turns green at 2.55 bar and `GET /api/vehicles/tyre-pressure-thresholds` returns the override

🤖 Generated with [Claude Code](https://claude.com/claude-code)