### PR TITLE
fix: patch outdated pip in copied SAIC gateway venv (CVE-2026-8643)

### DIFF
--- a/docker/all-in-one/Dockerfile
+++ b/docker/all-in-one/Dockerfile
@@ -100,7 +100,12 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
 # Layout in the saic image: WORKDIR=/usr/src/app, venv at /usr/src/app/.venv,
 # entry point: python ./main.py
 COPY --from=saic-source /usr/src/app /opt/saic/app
-RUN chown -R appuser:appuser /opt/saic/app
+# The upstream 0.12.0 image ships pip 26.1.1 (CVE-2026-8643, path traversal via a
+# malicious entry point name during wheel install). Nothing in this image ever runs
+# pip again, so it's not reachable at runtime, but patch it anyway to keep the image
+# scan clean until upstream bumps it.
+RUN /opt/saic/app/.venv/bin/python -m pip install --no-cache-dir --upgrade "pip>=26.1.2" \
+    && chown -R appuser:appuser /opt/saic/app
 
 # Frontend SPA
 COPY --from=frontend-build /app/dist /usr/share/nginx/html


### PR DESCRIPTION
## Summary
- Fixes code scanning alert [#453](https://github.com/joszz/GarageStack/security/code-scanning/453): Trivy flagged pip 26.1.1 in the all-in-one image (CVE-2026-8643, path traversal via malicious entry point name during wheel installation).
- The all-in-one image copies the pre-built venv wholesale from the upstream `saicismartapi/saic-python-mqtt-gateway:0.12.0` image (no PyPI package exists for the gateway). That upstream image, already the latest stable tag, still ships pip 26.1.1.
- Added a `RUN` step right after the `COPY --from=saic-source` to upgrade pip in place to `>=26.1.2`, before the ownership `chown`.
- Confirmed pip is never invoked at runtime in this image (grepped entrypoint/supervisord scripts), so this was a dormant flagged package rather than an active exploit path, but patching it keeps the image scan clean.
- Only the all-in-one image bundles the SAIC venv; the frontend/api/worker images build independently and are unaffected.

## Test plan
- [x] `docker build -f docker/all-in-one/Dockerfile -t garagestack-pip-fix-test .` completes successfully
- [x] Build log confirms pip upgrades 26.1.1 → 26.1.2 in the copied venv
- [ ] CI Trivy image scan (`trivy-image-garagestack`) passes clean on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)