### PR TITLE
Add notification type filter to settings

### DIFF
--- a/frontend/src/assets/main.css
+++ b/frontend/src/assets/main.css
@@ -1,3 +1,5 @@
+@import '@vueform/multiselect/themes/default.css';
+
 :root {
   --color-bg: #0f1117;
   --color-surface: #1a1d27;
@@ -324,7 +326,7 @@ body,
   background: var(--color-surface);
   border: 1px solid var(--color-border);
   border-radius: var(--radius);
-  padding: 1rem 1.1rem;
+  padding: 0.5rem;
   display: flex;
   align-items: center;
   gap: 1rem;
@@ -383,12 +385,6 @@ body,
   font-size: 0.78rem;
   color: var(--color-text-muted);
   font-weight: 400;
-}
-
-.status-card__subtitle {
-  font-size: 0.68rem;
-  color: var(--color-text-muted);
-  margin-top: 0.1rem;
 }
 
 .status-card--clickable {
@@ -1422,9 +1418,8 @@ body,
   gap: 0.75rem;
 }
 
-.vehicle-type-override select {
+.vehicle-type-override .vehicle-type-select {
   flex: 1;
-  max-width: 280px;
 }
 
 .settings-toggles {
@@ -1497,6 +1492,85 @@ body,
 
 .settings-toggle__side-icon--active {
   color: var(--color-primary);
+}
+
+/* ── Multiselect (fuel brand filter, notification type filter) ──────────── */
+
+/* --ms-* vars set on :root so they cascade to the body-teleported dropdown too */
+:root {
+  --ms-bg: var(--color-surface-2);
+  --ms-bg-disabled: var(--color-surface);
+  --ms-border-color: var(--color-border);
+  --ms-border-width: 1px;
+  --ms-radius: 6px;
+  --ms-py: 0.375rem;
+  --ms-px: 0.625rem;
+  --ms-font-size: 0.875rem;
+  --ms-line-height: 1.375;
+  --ms-spinner-color: var(--color-primary);
+  --ms-caret-color: var(--color-text-muted);
+  --ms-clear-color: var(--color-text-muted);
+  --ms-clear-color-hover: var(--color-text);
+
+  --ms-tag-font-size: 0.8rem;
+  --ms-tag-font-weight: 500;
+  --ms-tag-line-height: 1.25;
+  --ms-tag-py: 0.2rem;
+  --ms-tag-px: 0.5rem;
+  --ms-tag-my: 0.2rem;
+  --ms-tag-mx: 0.2rem;
+  --ms-tag-bg: var(--color-primary);
+  --ms-tag-bg-disabled: var(--color-surface);
+  --ms-tag-color: #fff;
+  --ms-tag-color-disabled: var(--color-text-muted);
+  --ms-tag-radius: 4px;
+  --ms-tag-remove-radius: 3px;
+  --ms-tag-remove-py: 0.2rem;
+  --ms-tag-remove-px: 0.2rem;
+
+  --ms-dropdown-bg: var(--color-surface);
+  --ms-dropdown-border-color: var(--color-border);
+  --ms-dropdown-border-width: 1px;
+  --ms-dropdown-radius: 6px;
+
+  --ms-placeholder-color: var(--color-text-muted);
+
+  --ms-option-font-size: 0.875rem;
+  --ms-option-bg-pointed: var(--color-surface-2);
+  --ms-option-color-pointed: var(--color-text);
+  --ms-option-bg-selected: var(--color-primary);
+  --ms-option-color-selected: #fff;
+  --ms-option-bg-selected-pointed: color-mix(in srgb, var(--color-primary) 85%, #000);
+  --ms-option-color-selected-pointed: #fff;
+  --ms-option-bg-disabled: transparent;
+  --ms-option-color-disabled: var(--color-text-muted);
+  --ms-option-py: 0.5rem;
+  --ms-option-px: 0.75rem;
+
+  --ms-empty-color: var(--color-text-muted);
+
+  --ms-ring-width: 2px;
+  --ms-ring-color: color-mix(in srgb, var(--color-primary) 30%, transparent);
+}
+
+/* Teleported dropdown must sit above the modal (z-index 1100) */
+.multiselect-dropdown {
+  z-index: 1200;
+}
+
+/* Ensure the search input inside the multiselect also uses the theme background */
+.multiselect-search,
+.multiselect-tags-search {
+  background: var(--color-surface-2);
+  color: var(--color-text);
+}
+
+.notif-type-filter {
+  padding: 0.25rem 0 0.5rem;
+}
+
+.notif-type-filter__header {
+  margin-bottom: 0.5rem;
 }
 
 /* ── Car colour picker ────────────────────────────────────── */

--- a/frontend/src/components/AppFooter.vue
+++ b/frontend/src/components/AppFooter.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
+import Multiselect from '@vueform/multiselect'
 import { useUiSettingsStore } from '@/stores/settingsUi'
 import gbFlag from 'flag-icons/flags/4x3/gb.svg'
 import nlFlag from 'flag-icons/flags/4x3/nl.svg'
@@ -12,6 +13,10 @@ import DetailModal from './DetailModal.vue'
 import SettingsToggle from './SettingsToggle.vue'
 import type { VehicleTypeOverride } from '@/stores/settingsUi'
 import { CAR_COLOR_SCHEMES } from '@/stores/settingsUi'
+import {
+  NOTIFICATION_CATEGORY_IDS,
+  type NotificationCategoryId,
+} from '@/utils/notificationCategories'
 
 const { t } = useI18n()
 const settings = useUiSettingsStore()
@@ -36,6 +41,25 @@ const typeOptions: { value: VehicleTypeOverride; label: string }[] = [
   { value: 'phev', label: t('settings.vehicleType.phev') },
   { value: 'bev', label: t('settings.vehicleType.bev') },
 ]
+
+const NOTIFICATION_CATEGORY_LABEL_KEYS: Record<NotificationCategoryId, string> = {
+  'low-tyre': 'lowTyre',
+  'high-tyre': 'highTyre',
+  'low-ev': 'lowEv',
+  'charging-complete': 'chargingComplete',
+  'engine-start': 'engineStart',
+  'unlocked-parked': 'unlockedParked',
+  'doors-open-parked': 'doorsOpenParked',
+  'windows-open-parked': 'windowsOpenParked',
+  maintenance: 'maintenance',
+}
+
+const notificationTypeOptions = computed(() =>
+  NOTIFICATION_CATEGORY_IDS.map((id) => ({
+    value: id,
+    label: t(`notifications.categories.${NOTIFICATION_CATEGORY_LABEL_KEYS[id]}`),
+  })),
+)
 
 const isLightTheme = computed({
   get: () => settings.theme === 'light',
@@ -201,12 +225,41 @@ function refresh() {
         </div>
         <div class="vehicle-type-override">
           <label class="text-muted">{{ t('settings.vehicleType.override') }}</label>
-          <select v-model="settings.vehicleTypeOverride" class="form-select form-select-sm">
-            <option v-for="opt in typeOptions" :key="opt.value" :value="opt.value">
-              {{ opt.label }}
-            </option>
-          </select>
+          <Multiselect
+            v-model="settings.vehicleTypeOverride"
+            :options="typeOptions"
+            :searchable="false"
+            :can-clear="false"
+            :can-deselect="false"
+            append-to="body"
+            class="vehicle-type-select"
+          />
         </div>
+      </div>
+    </div>
+
+    <!-- Notification types -->
+    <div class="detail-modal__section">
+      <div class="detail-modal__section-title">{{ t('settings.notificationTypes.title') }}</div>
+      <div class="notif-type-filter">
+        <div class="notif-type-filter__header">
+          <div class="settings-toggle__info">
+            <span class="settings-toggle__label">{{ t('notifications.typeFilter') }}</span>
+            <span class="settings-toggle__desc">{{ t('notifications.typeFilterDesc') }}</span>
+          </div>
+        </div>
+        <Multiselect
+          v-model="settings.notificationTypeFilter"
+          :options="notificationTypeOptions"
+          :placeholder="t('notifications.typeFilterPlaceholder')"
+          :searchable="true"
+          :close-on-select="false"
+          :clear-on-select="false"
+          mode="tags"
+          :no-results-text="t('notifications.typeFilterNoMatch')"
+          append-to="body"
+          class="notif-type-multiselect"
+        />
       </div>
     </div>
 

--- a/frontend/src/components/NotificationPanel.vue
+++ b/frontend/src/components/NotificationPanel.vue
@@ -9,7 +9,9 @@ const PAGE_SIZE = 10
 
 const CATEGORY_ICONS: Record<string, string[]> = {
   'low-tyre': ['fas', 'circle-exclamation'],
+  'high-tyre': ['fas', 'circle-exclamation'],
   'low-ev': ['fas', 'battery-quarter'],
+  'charging-complete': ['fas', 'plug-circle-check'],
   'engine-start': ['fas', 'car'],
   'unlocked-parked': ['fas', 'lock-open'],
   'doors-open-parked': ['fas', 'door-open'],

--- a/frontend/src/components/StatusCard.vue
+++ b/frontend/src/components/StatusCard.vue
@@ -25,6 +25,7 @@ function valueTitle(): string {
   <div
     class="status-card"
     :class="[variant ? `status-card--${variant}` : '', clickable ? 'status-card--clickable' : '']"
+    :title="subtitle"
     :role="clickable ? 'button' : undefined"
     :tabindex="clickable ? 0 : undefined"
     @click="emitClickIfClickable(clickable)"
@@ -40,7 +41,6 @@ function valueTitle(): string {
         {{ value ?? '-'
         }}<span v-if="unit && value !== null" class="status-card__unit"> {{ unit }}</span>
       </span>
-      <span v-if="subtitle" class="status-card__subtitle" :title="subtitle">{{ subtitle }}</span>
     </div>
     <font-awesome-icon
       v-if="clickable"

--- a/frontend/src/composables/__tests__/useNotifications.spec.ts
+++ b/frontend/src/composables/__tests__/useNotifications.spec.ts
@@ -131,6 +131,72 @@ describe('useNotifications', () => {
     expect(unreadCount.value).toBe(2)
   })
 
+  it('shows every notification when notificationTypeFilter is empty (no filter set)', async () => {
+    vi.mocked(notificationsApi.list).mockResolvedValue([
+      makeNotification({ id: 1, category: 'low-tyre' }),
+      makeNotification({ id: 2, category: 'engine-start' }),
+    ])
+
+    const { useNotifications } = await import('@/composables/useNotifications')
+    const { fetchNotifications, notifications } = useNotifications()
+    await fetchNotifications()
+
+    expect(notifications.value).toHaveLength(2)
+  })
+
+  it('only shows notifications whose category is in notificationTypeFilter', async () => {
+    localStorage.setItem(
+      'garagestack-settings-ui',
+      JSON.stringify({ notificationTypeFilter: ['low-tyre'] }),
+    )
+    vi.mocked(notificationsApi.list).mockResolvedValue([
+      makeNotification({ id: 1, category: 'low-tyre' }),
+      makeNotification({ id: 2, category: 'engine-start' }),
+    ])
+
+    const { useNotifications } = await import('@/composables/useNotifications')
+    const { fetchNotifications, notifications } = useNotifications()
+    await fetchNotifications()
+
+    expect(notifications.value).toHaveLength(1)
+    expect(notifications.value[0]?.id).toBe(1)
+  })
+
+  it('groups dynamic maintenance-<id> categories under the "maintenance" filter entry', async () => {
+    localStorage.setItem(
+      'garagestack-settings-ui',
+      JSON.stringify({ notificationTypeFilter: ['maintenance'] }),
+    )
+    vi.mocked(notificationsApi.list).mockResolvedValue([
+      makeNotification({ id: 1, category: 'maintenance-42' }),
+      makeNotification({ id: 2, category: 'low-tyre' }),
+    ])
+
+    const { useNotifications } = await import('@/composables/useNotifications')
+    const { fetchNotifications, notifications } = useNotifications()
+    await fetchNotifications()
+
+    expect(notifications.value).toHaveLength(1)
+    expect(notifications.value[0]?.id).toBe(1)
+  })
+
+  it('unreadCount only counts non-archived notifications that pass the type filter', async () => {
+    localStorage.setItem(
+      'garagestack-settings-ui',
+      JSON.stringify({ notificationTypeFilter: ['low-tyre'] }),
+    )
+    vi.mocked(notificationsApi.list).mockResolvedValue([
+      makeNotification({ id: 1, category: 'low-tyre', isArchived: false }),
+      makeNotification({ id: 2, category: 'engine-start', isArchived: false }),
+    ])
+
+    const { useNotifications } = await import('@/composables/useNotifications')
+    const { fetchNotifications, unreadCount } = useNotifications()
+    await fetchNotifications()
+
+    expect(unreadCount.value).toBe(1)
+  })
+
   it('fetchNotifications() populates the notifications list', async () => {
     const items = [makeNotification({ id: 10 }), makeNotification({ id: 11 })]
     vi.mocked(notificationsApi.list).mockResolvedValue(items)

--- a/frontend/src/composables/useNotifications.ts
+++ b/frontend/src/composables/useNotifications.ts
@@ -1,6 +1,8 @@
 import { ref, computed, watch, onUnmounted, getCurrentInstance } from 'vue'
 import { notificationsApi, type AppNotification } from '@/services/notificationsApi'
 import { useAuthStore } from '@/stores/auth'
+import { useUiSettingsStore } from '@/stores/settingsUi'
+import { notificationCategoryId } from '@/utils/notificationCategories'
 
 const notifications = ref<AppNotification[]>([])
 
@@ -28,7 +30,20 @@ const actionError = ref<string | null>(null)
 
 export function useNotifications() {
   const auth = useAuthStore()
-  const unreadCount = computed(() => notifications.value.filter((n) => !n.isArchived).length)
+  const uiSettings = useUiSettingsStore()
+
+  // Empty selection means "no filter" (show every type), matching the fuel-brand-filter
+  // convention used elsewhere in settings.
+  const visibleNotifications = computed(() => {
+    const selected = uiSettings.notificationTypeFilter
+    if (selected.length === 0) return notifications.value
+    return notifications.value.filter((n) => {
+      const categoryId = notificationCategoryId(n.category)
+      return categoryId !== null && selected.includes(categoryId)
+    })
+  })
+
+  const unreadCount = computed(() => visibleNotifications.value.filter((n) => !n.isArchived).length)
 
   async function fetchNotifications() {
     loading.value = true
@@ -130,7 +145,7 @@ export function useNotifications() {
   }
 
   return {
-    notifications,
+    notifications: visibleNotifications,
     unreadCount,
     panelOpen,
     loading,

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -281,7 +281,22 @@
     "confirmDeleteAll": "Permanently delete all notifications?",
     "justNow": "Just now",
     "minutesAgo": "{n} min ago",
-    "hoursAgo": "{n}h ago"
+    "hoursAgo": "{n}h ago",
+    "typeFilter": "Type filter",
+    "typeFilterDesc": "Only show notifications of the selected types. Leave empty to show all types.",
+    "typeFilterPlaceholder": "Filter types...",
+    "typeFilterNoMatch": "No matching types.",
+    "categories": {
+      "lowTyre": "Low tyre pressure",
+      "highTyre": "High tyre pressure",
+      "lowEv": "Low EV battery",
+      "chargingComplete": "Charging complete",
+      "engineStart": "Engine start",
+      "unlockedParked": "Unlocked while parked",
+      "doorsOpenParked": "Doors open while parked",
+      "windowsOpenParked": "Windows open while parked",
+      "maintenance": "Maintenance reminders"
+    }
   },
   "auth": {
     "subtitle": "Sign in with your MG account credentials",
@@ -358,6 +373,9 @@
       "hev": "HEV (Hybrid, no plug)",
       "phev": "PHEV (Plug-in Hybrid)",
       "bev": "BEV (Full Electric)"
+    },
+    "notificationTypes": {
+      "title": "Notification types"
     }
   },
   "common": {

--- a/frontend/src/locales/nl.json
+++ b/frontend/src/locales/nl.json
@@ -281,7 +281,22 @@
     "confirmDeleteAll": "Alle meldingen definitief verwijderen?",
     "justNow": "Zojuist",
     "minutesAgo": "{n} min geleden",
-    "hoursAgo": "{n}u geleden"
+    "hoursAgo": "{n}u geleden",
+    "typeFilter": "Typefilter",
+    "typeFilterDesc": "Toon alleen meldingen van de geselecteerde typen. Laat leeg om alle typen te tonen.",
+    "typeFilterPlaceholder": "Typen filteren...",
+    "typeFilterNoMatch": "Geen overeenkomende typen.",
+    "categories": {
+      "lowTyre": "Lage bandenspanning",
+      "highTyre": "Hoge bandenspanning",
+      "lowEv": "Lage EV-accustand",
+      "chargingComplete": "Laden voltooid",
+      "engineStart": "Motor gestart",
+      "unlockedParked": "Ontgrendeld terwijl geparkeerd",
+      "doorsOpenParked": "Portier open terwijl geparkeerd",
+      "windowsOpenParked": "Raam open terwijl geparkeerd",
+      "maintenance": "Onderhoudsherinneringen"
+    }
   },
   "auth": {
     "subtitle": "Log in met je MG-accountgegevens",
@@ -358,6 +373,9 @@
       "hev": "HEV (Hybride, geen stekker)",
       "phev": "PHEV (Plug-in hybride)",
       "bev": "BEV (Volledig elektrisch)"
+    },
+    "notificationTypes": {
+      "title": "Meldingstypen"
     }
   },
   "common": {

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -107,6 +107,8 @@ import {
   faGripLines,
   faTag,
   faScrewdriverWrench,
+  faCircleExclamation,
+  faBatteryQuarter,
 } from '@fortawesome/free-solid-svg-icons'
 
 import App from './App.vue'
@@ -191,6 +193,8 @@ library.add(
   faGripLines,
   faTag,
   faScrewdriverWrench,
+  faCircleExclamation,
+  faBatteryQuarter,
 )
 
 const i18n = createI18n({

--- a/frontend/src/stores/__tests__/settings.spec.ts
+++ b/frontend/src/stores/__tests__/settings.spec.ts
@@ -124,6 +124,26 @@ describe('useUiSettingsStore', () => {
     expect(store.vehicleTypeOverride).toBe('bev')
     expect(store.filterDays).toBe(14)
   })
+
+  it('defaults notificationTypeFilter to an empty array (no filter, show all)', () => {
+    const store = useUiSettingsStore()
+    expect(store.notificationTypeFilter).toEqual([])
+  })
+
+  it('persists notificationTypeFilter changes to its own localStorage key', async () => {
+    const store = useUiSettingsStore()
+    store.notificationTypeFilter = ['low-tyre', 'maintenance']
+    await nextTick()
+    vi.advanceTimersByTime(SAVE_DEBOUNCE_MS)
+    const saved = JSON.parse(localStorage.getItem(UI_KEY)!)
+    expect(saved.notificationTypeFilter).toEqual(['low-tyre', 'maintenance'])
+  })
+
+  it('loads notificationTypeFilter from its own localStorage key on init', () => {
+    localStorage.setItem(UI_KEY, JSON.stringify({ notificationTypeFilter: ['charging-complete'] }))
+    const store = useUiSettingsStore()
+    expect(store.notificationTypeFilter).toEqual(['charging-complete'])
+  })
 })
 
 describe('useMapSettingsStore', () => {

--- a/frontend/src/stores/settingsUi.ts
+++ b/frontend/src/stores/settingsUi.ts
@@ -21,6 +21,7 @@ interface UiSettings {
   carColorScheme: string
   vehicleTypeOverride: VehicleTypeOverride
   filterDays: number
+  notificationTypeFilter: string[]
 }
 
 function defaultsFor(): UiSettings {
@@ -31,6 +32,7 @@ function defaultsFor(): UiSettings {
     carColorScheme: 'orange',
     vehicleTypeOverride: 'auto',
     filterDays: 7,
+    notificationTypeFilter: [],
   }
 }
 
@@ -43,6 +45,9 @@ function parseUiFields(parsed: Record<string, unknown>, fallback: UiSettings): U
     vehicleTypeOverride:
       (parsed.vehicleTypeOverride as VehicleTypeOverride) ?? fallback.vehicleTypeOverride,
     filterDays: (parsed.filterDays as number) ?? fallback.filterDays,
+    notificationTypeFilter: Array.isArray(parsed.notificationTypeFilter)
+      ? (parsed.notificationTypeFilter as string[])
+      : fallback.notificationTypeFilter,
   }
 }
 
@@ -73,6 +78,7 @@ export const useUiSettingsStore = defineStore('settingsUi', () => {
   const carColorScheme = ref<string>(loaded.carColorScheme)
   const vehicleTypeOverride = ref<VehicleTypeOverride>(loaded.vehicleTypeOverride)
   const filterDays = ref<number>(loaded.filterDays)
+  const notificationTypeFilter = ref<string[]>(loaded.notificationTypeFilter)
 
   document.documentElement.dataset.theme = theme.value
   applyCarColors(carColorScheme.value)
@@ -87,6 +93,7 @@ export const useUiSettingsStore = defineStore('settingsUi', () => {
         carColorScheme: carColorScheme.value,
         vehicleTypeOverride: vehicleTypeOverride.value,
         filterDays: filterDays.value,
+        notificationTypeFilter: notificationTypeFilter.value,
       }),
     )
   }
@@ -96,6 +103,7 @@ export const useUiSettingsStore = defineStore('settingsUi', () => {
   watch(vehicleTypeOverride, scheduleSave)
   watch(locale, scheduleSave)
   watch(filterDays, scheduleSave)
+  watch(notificationTypeFilter, scheduleSave, { deep: true })
   watch(theme, (val) => {
     document.documentElement.dataset.theme = val
     scheduleSave()
@@ -112,5 +120,6 @@ export const useUiSettingsStore = defineStore('settingsUi', () => {
     carColorScheme,
     vehicleTypeOverride,
     filterDays,
+    notificationTypeFilter,
   }
 })

--- a/frontend/src/utils/__tests__/notificationCategories.spec.ts
+++ b/frontend/src/utils/__tests__/notificationCategories.spec.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest'
+import { notificationCategoryId, NOTIFICATION_CATEGORY_IDS } from '@/utils/notificationCategories'
+
+describe('notificationCategoryId', () => {
+  it('returns null for a null category', () => {
+    expect(notificationCategoryId(null)).toBeNull()
+  })
+
+  it('returns null for an unrecognised category', () => {
+    expect(notificationCategoryId('some-future-category')).toBeNull()
+  })
+
+  it('groups any maintenance-<id> category under "maintenance"', () => {
+    expect(notificationCategoryId('maintenance-42')).toBe('maintenance')
+    expect(notificationCategoryId('maintenance-oil-change')).toBe('maintenance')
+  })
+
+  it.each(NOTIFICATION_CATEGORY_IDS.filter((id) => id !== 'maintenance'))(
+    'maps the fixed backend category "%s" to itself',
+    (id) => {
+      expect(notificationCategoryId(id)).toBe(id)
+    },
+  )
+})

--- a/frontend/src/utils/notificationCategories.ts
+++ b/frontend/src/utils/notificationCategories.ts
@@ -1,0 +1,23 @@
+export const NOTIFICATION_CATEGORY_IDS = [
+  'low-tyre',
+  'high-tyre',
+  'low-ev',
+  'charging-complete',
+  'engine-start',
+  'unlocked-parked',
+  'doors-open-parked',
+  'windows-open-parked',
+  'maintenance',
+] as const
+
+export type NotificationCategoryId = (typeof NOTIFICATION_CATEGORY_IDS)[number]
+
+// Maintenance notifications carry a dynamic per-item suffix (maintenance-<id>) rather than a
+// single fixed string, so they're grouped under one "maintenance" id here.
+export function notificationCategoryId(category: string | null): NotificationCategoryId | null {
+  if (!category) return null
+  if (category.startsWith('maintenance-')) return 'maintenance'
+  return (NOTIFICATION_CATEGORY_IDS as readonly string[]).includes(category)
+    ? (category as NotificationCategoryId)
+    : null
+}

--- a/frontend/src/views/MapView.vue
+++ b/frontend/src/views/MapView.vue
@@ -844,7 +844,6 @@ onUnmounted(() => {
 
 <style>
 @import '@vueform/slider/themes/default.css';
-@import '@vueform/multiselect/themes/default.css';
 
 /* Leaflet injects divIcon HTML outside Vue's rendering pipeline so these cannot be scoped */
 
@@ -955,74 +954,9 @@ onUnmounted(() => {
   --slider-handle-ring-color: rgba(34, 197, 94, 0.2);
 }
 
-/* --ms-* vars set on :root so they cascade to the body-teleported dropdown too */
-:root {
-  --ms-bg: var(--color-surface-2);
-  --ms-bg-disabled: var(--color-surface);
-  --ms-border-color: var(--color-border);
-  --ms-border-width: 1px;
-  --ms-radius: 6px;
-  --ms-py: 0.375rem;
-  --ms-px: 0.625rem;
-  --ms-font-size: 0.875rem;
-  --ms-line-height: 1.375;
-  --ms-spinner-color: var(--color-primary);
-  --ms-caret-color: var(--color-text-muted);
-  --ms-clear-color: var(--color-text-muted);
-  --ms-clear-color-hover: var(--color-text);
-
-  --ms-tag-font-size: 0.8rem;
-  --ms-tag-font-weight: 500;
-  --ms-tag-line-height: 1.25;
-  --ms-tag-py: 0.2rem;
-  --ms-tag-px: 0.5rem;
-  --ms-tag-my: 0.2rem;
-  --ms-tag-mx: 0.2rem;
-  --ms-tag-bg: var(--color-primary);
-  --ms-tag-bg-disabled: var(--color-surface);
-  --ms-tag-color: #fff;
-  --ms-tag-color-disabled: var(--color-text-muted);
-  --ms-tag-radius: 4px;
-  --ms-tag-remove-radius: 3px;
-  --ms-tag-remove-py: 0.2rem;
-  --ms-tag-remove-px: 0.2rem;
-
-  --ms-dropdown-bg: var(--color-surface);
-  --ms-dropdown-border-color: var(--color-border);
-  --ms-dropdown-border-width: 1px;
-  --ms-dropdown-radius: 6px;
-
-  --ms-placeholder-color: var(--color-text-muted);
-
-  --ms-option-font-size: 0.875rem;
-  --ms-option-bg-pointed: var(--color-surface-2);
-  --ms-option-color-pointed: var(--color-text);
-  --ms-option-bg-selected: var(--color-primary);
-  --ms-option-color-selected: #fff;
-  --ms-option-bg-selected-pointed: color-mix(in srgb, var(--color-primary) 85%, #000);
-  --ms-option-color-selected-pointed: #fff;
-  --ms-option-bg-disabled: transparent;
-  --ms-option-color-disabled: var(--color-text-muted);
-  --ms-option-py: 0.5rem;
-  --ms-option-px: 0.75rem;
-
-  --ms-empty-color: var(--color-text-muted);
-
-  --ms-ring-width: 2px;
-  --ms-ring-color: color-mix(in srgb, var(--color-primary) 30%, transparent);
-}
-
-/* Teleported dropdown must sit above the modal (z-index 1100) */
-.multiselect-dropdown {
-  z-index: 1200;
-}
-
-/* Ensure the search input inside the multiselect also uses the theme background */
-.multiselect-search,
-.multiselect-tags-search {
-  background: var(--color-surface-2);
-  color: var(--color-text);
-}
+/* Multiselect theme vars, dropdown z-index, and search input styling now live globally in
+   main.css (moved there so the AppFooter settings-modal notification-type multiselect is
+   themed correctly even before this lazy-loaded view has ever been visited). */
 
 .fuel-brand-filter {
   padding: 0.25rem 0 0.5rem;


### PR DESCRIPTION
## Summary
- Adds a "Notification types" multiselect in the settings modal (same tag-style component as the map's fuel-brand filter), stored in `localStorage` alongside the other settings. Only notification types selected there show up in the bell panel and unread badge; leaving it empty shows everything (default, no behavior change out of the box).
- Switches the vehicle type override control to the same multiselect component (single-select) for visual/behavioral consistency, and lets it use the full row width.
- Fixes two notification category icons that referenced FontAwesome icons which were never registered in the icon library (`circle-exclamation`, `battery-quarter`), and adds icons for the two new filterable categories (`high-tyre`, `charging-complete`).
- Moves the multiselect's theme CSS from the lazy-loaded Map view into the global stylesheet, since the settings modal is mounted everywhere and needs correct styling without a prior visit to `/map`.
- Fixes the maintenance dashboard card being taller than every other status card (it was the only one rendering a third "subtitle" text line); the detail is now a hover tooltip instead.

## Test plan
- [x] `pnpm exec vitest run` — 232 tests pass, including new coverage for the category-grouping util, settings persistence, and notification filtering behavior
- [x] `pnpm run type-check` — clean
- [x] `pnpm run lint` — clean
- [x] Manually verified in a browser against the demo-mode dev server: settings modal multiselect renders correctly themed with all 9 category options, tag selection/removal works, vehicle type dropdown matches styling and selection works, maintenance card height now matches other cards

🤖 Generated with [Claude Code](https://claude.com/claude-code)