### PR TITLE
Replace notification-type multiselect with a toggle checklist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ example_data.txt
 appsettings.Development.json
 .env.development
 .stfolder
+.claude
+\keys

--- a/frontend/src/assets/main.css
+++ b/frontend/src/assets/main.css
@@ -1571,6 +1571,56 @@ body,
 
 .notif-type-filter__header {
   margin-bottom: 0.5rem;
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.notif-type-filter__actions {
+  display: flex;
+  gap: 0.4rem;
+  flex-shrink: 0;
+}
+
+.notif-type-filter__denied {
+  display: block;
+  margin-bottom: 0.5rem;
+}
+
+/* Own internal scroll so a long category list never pushes the rest of the settings modal's
+   sections down. minmax(170px, 1fr) against .detail-modal's actual width budget: the mobile
+   bottom-sheet content is ~300-335px wide -> 1 column; the desktop dialog is capped at
+   max-width: 440px -> 2 columns, where all 9 categories fit in 5 rows with no scrollbar at all.
+   max-height keeps the 1-column mobile case to ~5-6 visible rows before scrolling. */
+.notif-type-checklist {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(170px, 1fr));
+  gap: 0.4rem 0.75rem;
+  max-height: 15rem;
+  overflow-y: auto;
+  margin-top: 0.5rem;
+  padding-right: 0.25rem;
+}
+
+.notif-type-checklist__item {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.3rem 0.4rem;
+  border-radius: 6px;
+  font-size: 0.85rem;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+
+.notif-type-checklist__item:hover {
+  background: var(--color-surface-2);
+}
+
+.notif-type-checklist__label {
+  line-height: 1.25;
 }
 
 /* ── Car colour picker ────────────────────────────────────── */

--- a/frontend/src/components/AppFooter.vue
+++ b/frontend/src/components/AppFooter.vue
@@ -7,7 +7,7 @@ import gbFlag from 'flag-icons/flags/4x3/gb.svg'
 import nlFlag from 'flag-icons/flags/4x3/nl.svg'
 import { useVehicleStore } from '@/stores/vehicle'
 import { useVehicleCommand } from '@/composables/useVehicleCommand'
-import { usePush } from '@/composables/usePush'
+import { useNotificationPushSync } from '@/composables/useNotificationPushSync'
 import { useModal } from '@/composables/useModal'
 import DetailModal from './DetailModal.vue'
 import SettingsToggle from './SettingsToggle.vue'
@@ -22,7 +22,7 @@ const { t } = useI18n()
 const settings = useUiSettingsStore()
 const vehicleStore = useVehicleStore()
 const { sending, send } = useVehicleCommand()
-const { pushSupported, pushState, togglePush } = usePush()
+const { showPermissionDeniedNotice } = useNotificationPushSync()
 const { isOpen: modalOpen, open: openModal, close: closeModal } = useModal()
 
 const vin = computed(() => vehicleStore.vehicles[0]?.vin ?? null)
@@ -78,6 +78,20 @@ const isNL = computed({
 function refresh() {
   if (!vin.value) return
   send(vin.value, 'refresh', 'force')
+}
+
+function selectAllNotificationTypes() {
+  settings.notificationTypeExclusions = []
+}
+
+function deselectAllNotificationTypes() {
+  settings.notificationTypeExclusions = [...NOTIFICATION_CATEGORY_IDS]
+}
+
+function toggleNotificationType(id: NotificationCategoryId, checked: boolean) {
+  settings.notificationTypeExclusions = checked
+    ? settings.notificationTypeExclusions.filter((excludedId) => excludedId !== id)
+    : [...settings.notificationTypeExclusions, id]
 }
 </script>
 
@@ -238,7 +252,8 @@ function refresh() {
       </div>
     </div>
 
-    <!-- Notification types -->
+    <!-- Notification types (also controls push subscription: deselecting every type
+         unsubscribes, selecting at least one (re)subscribes) -->
     <div class="detail-modal__section">
       <div class="detail-modal__section-title">{{ t('settings.notificationTypes.title') }}</div>
       <div class="notif-type-filter">
@@ -247,47 +262,49 @@ function refresh() {
             <span class="settings-toggle__label">{{ t('notifications.typeFilter') }}</span>
             <span class="settings-toggle__desc">{{ t('notifications.typeFilterDesc') }}</span>
           </div>
+          <div class="notif-type-filter__actions">
+            <button
+              type="button"
+              class="btn btn-sm btn-outline-secondary"
+              @click="selectAllNotificationTypes"
+            >
+              {{ t('notifications.selectAll') }}
+            </button>
+            <button
+              type="button"
+              class="btn btn-sm btn-outline-secondary"
+              @click="deselectAllNotificationTypes"
+            >
+              {{ t('notifications.deselectAll') }}
+            </button>
+          </div>
         </div>
-        <Multiselect
-          v-model="settings.notificationTypeFilter"
-          :options="notificationTypeOptions"
-          :placeholder="t('notifications.typeFilterPlaceholder')"
-          :searchable="true"
-          :close-on-select="false"
-          :clear-on-select="false"
-          mode="tags"
-          :no-results-text="t('notifications.typeFilterNoMatch')"
-          append-to="body"
-          class="notif-type-multiselect"
-        />
-      </div>
-    </div>
 
-    <!-- Push notifications -->
-    <div v-if="pushSupported" class="detail-modal__section">
-      <div class="detail-modal__section-title">{{ t('notifications.title') }}</div>
-      <div class="settings-toggles">
-        <SettingsToggle
-          :label="t('push.enable')"
-          :desc="t('push.desc')"
-          input-id="footer-toggle-push"
+        <div
+          v-if="showPermissionDeniedNotice"
+          class="notif-type-filter__denied text-danger text-sm"
         >
-          <template #control>
-            <span v-if="pushState === 'denied'" class="text-danger text-sm">{{
-              t('push.permissionDenied')
-            }}</span>
-            <div v-else class="form-check form-switch mb-0">
-              <input
-                id="footer-toggle-push"
-                :checked="pushState === 'subscribed'"
-                class="form-check-input"
-                type="checkbox"
-                role="switch"
-                @change="togglePush"
-              />
-            </div>
-          </template>
-        </SettingsToggle>
+          {{ t('push.permissionDenied') }}
+        </div>
+
+        <div class="notif-type-checklist">
+          <label
+            v-for="opt in notificationTypeOptions"
+            :key="opt.value"
+            class="form-check form-switch notif-type-checklist__item"
+          >
+            <input
+              class="form-check-input"
+              type="checkbox"
+              role="switch"
+              :checked="!settings.notificationTypeExclusions.includes(opt.value)"
+              @change="
+                toggleNotificationType(opt.value, ($event.target as HTMLInputElement).checked)
+              "
+            />
+            <span class="notif-type-checklist__label">{{ opt.label }}</span>
+          </label>
+        </div>
       </div>
     </div>
   </DetailModal>

--- a/frontend/src/composables/__tests__/useNotificationPushSync.spec.ts
+++ b/frontend/src/composables/__tests__/useNotificationPushSync.spec.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { ref, nextTick } from 'vue'
+import { setActivePinia, createPinia } from 'pinia'
+import { NOTIFICATION_CATEGORY_IDS } from '@/utils/notificationCategories'
+
+const mockTogglePush = vi.fn<() => Promise<void>>()
+const mockPushState = ref<'unknown' | 'subscribed' | 'unsubscribed' | 'denied'>('unknown')
+let mockPushSupported = true
+
+vi.mock('@/composables/usePush', () => ({
+  usePush: () => ({
+    pushSupported: mockPushSupported,
+    pushState: mockPushState,
+    togglePush: mockTogglePush,
+  }),
+}))
+
+describe('useNotificationPushSync', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    setActivePinia(createPinia())
+    localStorage.clear()
+    mockTogglePush.mockReset()
+    mockPushState.value = 'unknown'
+    mockPushSupported = true
+  })
+
+  it('does not call togglePush on initial mount, even if desired state disagrees with actual state', async () => {
+    mockPushState.value = 'unsubscribed'
+    const { useNotificationPushSync } = await import('@/composables/useNotificationPushSync')
+    useNotificationPushSync()
+    await nextTick()
+
+    expect(mockTogglePush).not.toHaveBeenCalled()
+  })
+
+  it('calls togglePush on the very first checklist interaction, regardless of which box', async () => {
+    mockPushState.value = 'unsubscribed'
+    const { useNotificationPushSync } = await import('@/composables/useNotificationPushSync')
+    const { useUiSettingsStore } = await import('@/stores/settingsUi')
+    useNotificationPushSync()
+    const settings = useUiSettingsStore()
+
+    settings.notificationTypeExclusions = ['low-tyre']
+    await nextTick()
+
+    expect(mockTogglePush).toHaveBeenCalledOnce()
+  })
+
+  it('does not call togglePush again for changes that keep the same exclusion count', async () => {
+    mockPushState.value = 'subscribed'
+    const { useNotificationPushSync } = await import('@/composables/useNotificationPushSync')
+    const { useUiSettingsStore } = await import('@/stores/settingsUi')
+    useNotificationPushSync()
+    const settings = useUiSettingsStore()
+
+    settings.notificationTypeExclusions = ['low-tyre']
+    await nextTick()
+    settings.notificationTypeExclusions = ['engine-start']
+    await nextTick()
+    settings.notificationTypeExclusions = ['low-tyre', 'engine-start']
+    await nextTick()
+
+    expect(mockTogglePush).not.toHaveBeenCalled()
+  })
+
+  it('calls togglePush to unsubscribe when deselecting every type', async () => {
+    mockPushState.value = 'subscribed'
+    const { useNotificationPushSync } = await import('@/composables/useNotificationPushSync')
+    const { useUiSettingsStore } = await import('@/stores/settingsUi')
+    useNotificationPushSync()
+    const settings = useUiSettingsStore()
+
+    settings.notificationTypeExclusions = [...NOTIFICATION_CATEGORY_IDS]
+    await nextTick()
+
+    expect(mockTogglePush).toHaveBeenCalledOnce()
+  })
+
+  it('calls togglePush to resubscribe when selecting at least one type after deselect-all', async () => {
+    localStorage.setItem(
+      'garagestack-settings-ui',
+      JSON.stringify({ notificationTypeExclusions: [...NOTIFICATION_CATEGORY_IDS] }),
+    )
+    mockPushState.value = 'unsubscribed'
+    const { useNotificationPushSync } = await import('@/composables/useNotificationPushSync')
+    const { useUiSettingsStore } = await import('@/stores/settingsUi')
+    useNotificationPushSync()
+    const settings = useUiSettingsStore()
+
+    settings.notificationTypeExclusions = []
+    await nextTick()
+
+    expect(mockTogglePush).toHaveBeenCalledOnce()
+  })
+
+  it('does not call togglePush while pushState is denied', async () => {
+    mockPushState.value = 'denied'
+    const { useNotificationPushSync } = await import('@/composables/useNotificationPushSync')
+    const { useUiSettingsStore } = await import('@/stores/settingsUi')
+    useNotificationPushSync()
+    const settings = useUiSettingsStore()
+
+    settings.notificationTypeExclusions = ['low-tyre']
+    await nextTick()
+
+    expect(mockTogglePush).not.toHaveBeenCalled()
+  })
+
+  it('registers no push side effects when pushSupported is false', async () => {
+    mockPushSupported = false
+    const { useNotificationPushSync } = await import('@/composables/useNotificationPushSync')
+    const { useUiSettingsStore } = await import('@/stores/settingsUi')
+    useNotificationPushSync()
+    const settings = useUiSettingsStore()
+
+    settings.notificationTypeExclusions = [...NOTIFICATION_CATEGORY_IDS]
+    await nextTick()
+
+    expect(mockTogglePush).not.toHaveBeenCalled()
+  })
+
+  it('showPermissionDeniedNotice is true only when push is supported and permission was denied', async () => {
+    mockPushSupported = true
+    mockPushState.value = 'denied'
+    const { useNotificationPushSync } = await import('@/composables/useNotificationPushSync')
+    expect(useNotificationPushSync().showPermissionDeniedNotice.value).toBe(true)
+
+    mockPushState.value = 'subscribed'
+    expect(useNotificationPushSync().showPermissionDeniedNotice.value).toBe(false)
+
+    mockPushSupported = false
+    mockPushState.value = 'denied'
+    expect(useNotificationPushSync().showPermissionDeniedNotice.value).toBe(false)
+  })
+
+  it('still attempts togglePush on first interaction if pushState is still unknown (async initPushState race)', async () => {
+    mockPushState.value = 'unknown'
+    const { useNotificationPushSync } = await import('@/composables/useNotificationPushSync')
+    const { useUiSettingsStore } = await import('@/stores/settingsUi')
+    useNotificationPushSync()
+    const settings = useUiSettingsStore()
+
+    settings.notificationTypeExclusions = ['low-tyre']
+    await nextTick()
+
+    expect(mockTogglePush).toHaveBeenCalledOnce()
+  })
+})

--- a/frontend/src/composables/__tests__/useNotifications.spec.ts
+++ b/frontend/src/composables/__tests__/useNotifications.spec.ts
@@ -131,7 +131,7 @@ describe('useNotifications', () => {
     expect(unreadCount.value).toBe(2)
   })
 
-  it('shows every notification when notificationTypeFilter is empty (no filter set)', async () => {
+  it('shows every notification when notificationTypeExclusions is empty (no exclusions)', async () => {
     vi.mocked(notificationsApi.list).mockResolvedValue([
       makeNotification({ id: 1, category: 'low-tyre' }),
       makeNotification({ id: 2, category: 'engine-start' }),
@@ -144,10 +144,10 @@ describe('useNotifications', () => {
     expect(notifications.value).toHaveLength(2)
   })
 
-  it('only shows notifications whose category is in notificationTypeFilter', async () => {
+  it('hides notifications whose category is in notificationTypeExclusions', async () => {
     localStorage.setItem(
       'garagestack-settings-ui',
-      JSON.stringify({ notificationTypeFilter: ['low-tyre'] }),
+      JSON.stringify({ notificationTypeExclusions: ['engine-start'] }),
     )
     vi.mocked(notificationsApi.list).mockResolvedValue([
       makeNotification({ id: 1, category: 'low-tyre' }),
@@ -162,10 +162,10 @@ describe('useNotifications', () => {
     expect(notifications.value[0]?.id).toBe(1)
   })
 
-  it('groups dynamic maintenance-<id> categories under the "maintenance" filter entry', async () => {
+  it('groups dynamic maintenance-<id> categories under the "maintenance" exclusion entry', async () => {
     localStorage.setItem(
       'garagestack-settings-ui',
-      JSON.stringify({ notificationTypeFilter: ['maintenance'] }),
+      JSON.stringify({ notificationTypeExclusions: ['maintenance'] }),
     )
     vi.mocked(notificationsApi.list).mockResolvedValue([
       makeNotification({ id: 1, category: 'maintenance-42' }),
@@ -177,13 +177,13 @@ describe('useNotifications', () => {
     await fetchNotifications()
 
     expect(notifications.value).toHaveLength(1)
-    expect(notifications.value[0]?.id).toBe(1)
+    expect(notifications.value[0]?.id).toBe(2)
   })
 
   it('unreadCount only counts non-archived notifications that pass the type filter', async () => {
     localStorage.setItem(
       'garagestack-settings-ui',
-      JSON.stringify({ notificationTypeFilter: ['low-tyre'] }),
+      JSON.stringify({ notificationTypeExclusions: ['engine-start'] }),
     )
     vi.mocked(notificationsApi.list).mockResolvedValue([
       makeNotification({ id: 1, category: 'low-tyre', isArchived: false }),
@@ -195,6 +195,25 @@ describe('useNotifications', () => {
     await fetchNotifications()
 
     expect(unreadCount.value).toBe(1)
+  })
+
+  it('never hides notifications with a null or unrecognized category, even while a filter is active', async () => {
+    localStorage.setItem(
+      'garagestack-settings-ui',
+      JSON.stringify({ notificationTypeExclusions: ['low-tyre'] }),
+    )
+    vi.mocked(notificationsApi.list).mockResolvedValue([
+      makeNotification({ id: 1, category: null }),
+      makeNotification({ id: 2, category: 'some-future-category' }),
+      makeNotification({ id: 3, category: 'low-tyre' }),
+    ])
+
+    const { useNotifications } = await import('@/composables/useNotifications')
+    const { fetchNotifications, notifications } = useNotifications()
+    await fetchNotifications()
+
+    expect(notifications.value).toHaveLength(2)
+    expect(notifications.value.map((n) => n.id).sort()).toEqual([1, 2])
   })
 
   it('fetchNotifications() populates the notifications list', async () => {

--- a/frontend/src/composables/useNotificationPushSync.ts
+++ b/frontend/src/composables/useNotificationPushSync.ts
@@ -1,0 +1,30 @@
+import { computed, watch } from 'vue'
+import { useUiSettingsStore } from '@/stores/settingsUi'
+import { usePush } from '@/composables/usePush'
+import { NOTIFICATION_CATEGORY_IDS } from '@/utils/notificationCategories'
+
+// Keeps the browser push subscription in sync with the notification-type checklist: deselecting
+// every type unsubscribes, (re)selecting at least one type resubscribes. Watching the exclusion
+// count (rather than the array with `deep: true`) means a plain, non-immediate watch never fires
+// on initial mount (no uninvited permission prompt on load), and swapping which single category
+// is excluded is a free no-op since the count doesn't change.
+export function useNotificationPushSync() {
+  const settings = useUiSettingsStore()
+  const { pushSupported, pushState, togglePush } = usePush()
+
+  const showPermissionDeniedNotice = computed(() => pushSupported && pushState.value === 'denied')
+
+  if (pushSupported) {
+    watch(
+      () => settings.notificationTypeExclusions.length,
+      (exclusionCount) => {
+        if (pushState.value === 'denied') return
+        const shouldBeSubscribed = exclusionCount < NOTIFICATION_CATEGORY_IDS.length
+        const isSubscribed = pushState.value === 'subscribed'
+        if (shouldBeSubscribed !== isSubscribed) togglePush()
+      },
+    )
+  }
+
+  return { showPermissionDeniedNotice }
+}

--- a/frontend/src/composables/useNotifications.ts
+++ b/frontend/src/composables/useNotifications.ts
@@ -32,14 +32,15 @@ export function useNotifications() {
   const auth = useAuthStore()
   const uiSettings = useUiSettingsStore()
 
-  // Empty selection means "no filter" (show every type), matching the fuel-brand-filter
-  // convention used elsewhere in settings.
+  // Empty exclusion list means "no filter" (show every type). A notification is hidden only
+  // when its category resolves to a known id AND that id is excluded - a null/unrecognized
+  // category (never selectable in the checklist) is always shown, even while a filter is active.
   const visibleNotifications = computed(() => {
-    const selected = uiSettings.notificationTypeFilter
-    if (selected.length === 0) return notifications.value
+    const excluded = uiSettings.notificationTypeExclusions
+    if (excluded.length === 0) return notifications.value
     return notifications.value.filter((n) => {
       const categoryId = notificationCategoryId(n.category)
-      return categoryId !== null && selected.includes(categoryId)
+      return categoryId === null || !excluded.includes(categoryId)
     })
   })
 

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -262,10 +262,8 @@
     }
   },
   "push": {
-    "enable": "Enable notifications",
     "enabled": "Notifications on",
-    "permissionDenied": "Permission denied — allow notifications in your browser settings",
-    "desc": "Receive a push notification on this device when important vehicle events occur, such as charging completing or a door left open."
+    "permissionDenied": "Permission denied — allow notifications in your browser settings"
   },
   "notifications": {
     "title": "Notifications",
@@ -283,9 +281,9 @@
     "minutesAgo": "{n} min ago",
     "hoursAgo": "{n}h ago",
     "typeFilter": "Type filter",
-    "typeFilterDesc": "Only show notifications of the selected types. Leave empty to show all types.",
-    "typeFilterPlaceholder": "Filter types...",
-    "typeFilterNoMatch": "No matching types.",
+    "typeFilterDesc": "Choose which notification types to show and receive push alerts for. Deselect all to turn push notifications off completely.",
+    "selectAll": "Select all",
+    "deselectAll": "Deselect all",
     "categories": {
       "lowTyre": "Low tyre pressure",
       "highTyre": "High tyre pressure",

--- a/frontend/src/locales/nl.json
+++ b/frontend/src/locales/nl.json
@@ -262,10 +262,8 @@
     }
   },
   "push": {
-    "enable": "Meldingen inschakelen",
     "enabled": "Meldingen aan",
-    "permissionDenied": "Toestemming geweigerd — sta meldingen toe in je browserinstellingen",
-    "desc": "Ontvang een pushmelding op dit apparaat wanneer belangrijke voertuigevents plaatsvinden, zoals het voltooien van het laden of een opengelaten portier."
+    "permissionDenied": "Toestemming geweigerd — sta meldingen toe in je browserinstellingen"
   },
   "notifications": {
     "title": "Meldingen",
@@ -283,9 +281,9 @@
     "minutesAgo": "{n} min geleden",
     "hoursAgo": "{n}u geleden",
     "typeFilter": "Typefilter",
-    "typeFilterDesc": "Toon alleen meldingen van de geselecteerde typen. Laat leeg om alle typen te tonen.",
-    "typeFilterPlaceholder": "Typen filteren...",
-    "typeFilterNoMatch": "Geen overeenkomende typen.",
+    "typeFilterDesc": "Kies voor welke meldingstypen je meldingen in de app en pushmeldingen wilt ontvangen. Deselecteer alles om pushmeldingen volledig uit te schakelen.",
+    "selectAll": "Alles selecteren",
+    "deselectAll": "Alles deselecteren",
     "categories": {
       "lowTyre": "Lage bandenspanning",
       "highTyre": "Hoge bandenspanning",

--- a/frontend/src/stores/__tests__/settings.spec.ts
+++ b/frontend/src/stores/__tests__/settings.spec.ts
@@ -5,6 +5,7 @@ import { defaultCards } from '@/stores/settingsShared'
 import { useUiSettingsStore } from '@/stores/settingsUi'
 import { useDashboardSettingsStore } from '@/stores/settingsDashboard'
 import { useMapSettingsStore } from '@/stores/settingsMap'
+import { NOTIFICATION_CATEGORY_IDS } from '@/utils/notificationCategories'
 
 // Settings persistence is debounced (see createDebouncedSave in settingsShared.ts) so a burst of
 // ref changes coalesces into one localStorage write - advance fake timers past the debounce
@@ -125,24 +126,63 @@ describe('useUiSettingsStore', () => {
     expect(store.filterDays).toBe(14)
   })
 
-  it('defaults notificationTypeFilter to an empty array (no filter, show all)', () => {
+  it('defaults notificationTypeExclusions to an empty array (no exclusions, show all)', () => {
     const store = useUiSettingsStore()
-    expect(store.notificationTypeFilter).toEqual([])
+    expect(store.notificationTypeExclusions).toEqual([])
   })
 
-  it('persists notificationTypeFilter changes to its own localStorage key', async () => {
+  it('persists notificationTypeExclusions changes to its own localStorage key', async () => {
     const store = useUiSettingsStore()
-    store.notificationTypeFilter = ['low-tyre', 'maintenance']
+    store.notificationTypeExclusions = ['low-tyre', 'maintenance']
     await nextTick()
     vi.advanceTimersByTime(SAVE_DEBOUNCE_MS)
     const saved = JSON.parse(localStorage.getItem(UI_KEY)!)
-    expect(saved.notificationTypeFilter).toEqual(['low-tyre', 'maintenance'])
+    expect(saved.notificationTypeExclusions).toEqual(['low-tyre', 'maintenance'])
   })
 
-  it('loads notificationTypeFilter from its own localStorage key on init', () => {
-    localStorage.setItem(UI_KEY, JSON.stringify({ notificationTypeFilter: ['charging-complete'] }))
+  it('loads notificationTypeExclusions from its own localStorage key on init', () => {
+    localStorage.setItem(
+      UI_KEY,
+      JSON.stringify({ notificationTypeExclusions: ['charging-complete'] }),
+    )
     const store = useUiSettingsStore()
-    expect(store.notificationTypeFilter).toEqual(['charging-complete'])
+    expect(store.notificationTypeExclusions).toEqual(['charging-complete'])
+  })
+})
+
+describe('notificationTypeExclusions migration from legacy notificationTypeFilter', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    localStorage.clear()
+  })
+
+  it('converts a non-empty legacy whitelist into the inverse exclusion list', () => {
+    localStorage.setItem(
+      UI_KEY,
+      JSON.stringify({ notificationTypeFilter: ['low-tyre', 'maintenance'] }),
+    )
+    const store = useUiSettingsStore()
+    expect(store.notificationTypeExclusions).toEqual(
+      NOTIFICATION_CATEGORY_IDS.filter((id) => !['low-tyre', 'maintenance'].includes(id)),
+    )
+  })
+
+  it('treats an empty legacy whitelist as no exclusions', () => {
+    localStorage.setItem(UI_KEY, JSON.stringify({ notificationTypeFilter: [] }))
+    const store = useUiSettingsStore()
+    expect(store.notificationTypeExclusions).toEqual([])
+  })
+
+  it('prefers the new field over the legacy one when both are present', () => {
+    localStorage.setItem(
+      UI_KEY,
+      JSON.stringify({
+        notificationTypeFilter: ['low-tyre'],
+        notificationTypeExclusions: ['engine-start'],
+      }),
+    )
+    const store = useUiSettingsStore()
+    expect(store.notificationTypeExclusions).toEqual(['engine-start'])
   })
 })
 

--- a/frontend/src/stores/settingsUi.ts
+++ b/frontend/src/stores/settingsUi.ts
@@ -8,6 +8,7 @@ import {
   readLegacyBlob,
   createDebouncedSave,
 } from './settingsShared'
+import { NOTIFICATION_CATEGORY_IDS } from '@/utils/notificationCategories'
 
 export type { Theme, Locale, VehicleTypeOverride, CarColorScheme } from './settingsShared'
 export { CAR_COLOR_SCHEMES }
@@ -21,7 +22,7 @@ interface UiSettings {
   carColorScheme: string
   vehicleTypeOverride: VehicleTypeOverride
   filterDays: number
-  notificationTypeFilter: string[]
+  notificationTypeExclusions: string[]
 }
 
 function defaultsFor(): UiSettings {
@@ -32,8 +33,28 @@ function defaultsFor(): UiSettings {
     carColorScheme: 'orange',
     vehicleTypeOverride: 'auto',
     filterDays: 7,
-    notificationTypeFilter: [],
+    notificationTypeExclusions: [],
   }
+}
+
+// One-time migration: an earlier version stored `notificationTypeFilter` with whitelist
+// semantics (empty = show all, non-empty = show only listed types). It was replaced by
+// `notificationTypeExclusions` (blacklist semantics: empty = show all, non-empty = hide listed
+// types) - a much better fit for "everything on, opt a couple out" - before seeing meaningful
+// adoption, but it already shipped, so convert any stored whitelist into the equivalent
+// exclusion list so a user's effective visible-category set doesn't change under them.
+function migrateNotificationTypeExclusions(
+  parsed: Record<string, unknown>,
+  fallback: string[],
+): string[] {
+  if (Array.isArray(parsed.notificationTypeExclusions)) {
+    return parsed.notificationTypeExclusions as string[]
+  }
+  if (Array.isArray(parsed.notificationTypeFilter) && parsed.notificationTypeFilter.length > 0) {
+    const oldWhitelist = parsed.notificationTypeFilter as string[]
+    return NOTIFICATION_CATEGORY_IDS.filter((id) => !oldWhitelist.includes(id))
+  }
+  return fallback
 }
 
 function parseUiFields(parsed: Record<string, unknown>, fallback: UiSettings): UiSettings {
@@ -45,9 +66,10 @@ function parseUiFields(parsed: Record<string, unknown>, fallback: UiSettings): U
     vehicleTypeOverride:
       (parsed.vehicleTypeOverride as VehicleTypeOverride) ?? fallback.vehicleTypeOverride,
     filterDays: (parsed.filterDays as number) ?? fallback.filterDays,
-    notificationTypeFilter: Array.isArray(parsed.notificationTypeFilter)
-      ? (parsed.notificationTypeFilter as string[])
-      : fallback.notificationTypeFilter,
+    notificationTypeExclusions: migrateNotificationTypeExclusions(
+      parsed,
+      fallback.notificationTypeExclusions,
+    ),
   }
 }
 
@@ -78,7 +100,7 @@ export const useUiSettingsStore = defineStore('settingsUi', () => {
   const carColorScheme = ref<string>(loaded.carColorScheme)
   const vehicleTypeOverride = ref<VehicleTypeOverride>(loaded.vehicleTypeOverride)
   const filterDays = ref<number>(loaded.filterDays)
-  const notificationTypeFilter = ref<string[]>(loaded.notificationTypeFilter)
+  const notificationTypeExclusions = ref<string[]>(loaded.notificationTypeExclusions)
 
   document.documentElement.dataset.theme = theme.value
   applyCarColors(carColorScheme.value)
@@ -93,7 +115,7 @@ export const useUiSettingsStore = defineStore('settingsUi', () => {
         carColorScheme: carColorScheme.value,
         vehicleTypeOverride: vehicleTypeOverride.value,
         filterDays: filterDays.value,
-        notificationTypeFilter: notificationTypeFilter.value,
+        notificationTypeExclusions: notificationTypeExclusions.value,
       }),
     )
   }
@@ -103,7 +125,7 @@ export const useUiSettingsStore = defineStore('settingsUi', () => {
   watch(vehicleTypeOverride, scheduleSave)
   watch(locale, scheduleSave)
   watch(filterDays, scheduleSave)
-  watch(notificationTypeFilter, scheduleSave, { deep: true })
+  watch(notificationTypeExclusions, scheduleSave, { deep: true })
   watch(theme, (val) => {
     document.documentElement.dataset.theme = val
     scheduleSave()
@@ -120,6 +142,6 @@ export const useUiSettingsStore = defineStore('settingsUi', () => {
     carColorScheme,
     vehicleTypeOverride,
     filterDays,
-    notificationTypeFilter,
+    notificationTypeExclusions,
   }
 })


### PR DESCRIPTION
## Summary
- Replaces the tag-based multiselect for picking notification types with a scrollable, responsive grid of toggle switches (all on by default, matching the same switch style used elsewhere in the settings modal), plus "Select all" / "Deselect all" quick actions. Better fits the common case of leaving almost everything on and occasionally turning off a couple of types.
- Merges the type checklist with the previously-separate "Enable notifications" push toggle: deselecting every type now unsubscribes from browser push, and (re)selecting at least one type resubscribes, via a new `useNotificationPushSync` composable. A "permission denied" notice surfaces inline when relevant.
- Flips the underlying setting from whitelist to blacklist semantics (`notificationTypeFilter` -> `notificationTypeExclusions`), since "everything on, opt a few out" is a much better fit for a blacklist. Includes a one-time migration for anyone who already saved the old whitelist format.
- Also fixes a related display bug: notifications with a null/unrecognized category are no longer hidden while a filter is active.
- Bumps the checklist container's max-height so all 9 categories fit without a scrollbar on desktop (2-column layout); mobile still scrolls in its single-column layout as intended.
- gitignores `.claude/` (local Claude Code tooling config) and `src/GarageStack.Api/keys/` (ASP.NET Data Protection key storage created by local dev runs), both of which were leaking into `git status` as untracked artifacts.

## Test plan
- [x] `pnpm exec vitest run` - 245 tests pass, including new coverage for the migration, blacklist filtering semantics, and the push-sync composable
- [x] `pnpm run type-check` - clean
- [x] `pnpm run lint` - clean
- [x] Manually verified in a browser against the demo-mode dev server: all 9 toggles on by default, select-all/deselect-all, single-toggle interaction, responsive 2-column desktop / 1-column mobile layout, no scrollbar on desktop, and confirmed a real push-subscribe attempt fires on the first checklist interaction (surfaced the "permission denied" notice in headless Chromium, which has no notification permission)

🤖 Generated with [Claude Code](https://claude.com/claude-code)