### PR TITLE
fix: close three P0 security gaps from codebase review

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,8 +25,8 @@ POSTGRES_HOST=postgres
 POSTGRES_PORT=5432
 POSTGRES_DB=garagestack
 POSTGRES_USER=garagestack
-# Optional when using the bundled postgres profile -- defaults to "garagestack".
-# Set explicitly if you want stronger credentials or connect from external tools.
+# Required when using the bundled postgres profile (docker compose refuses to
+# start otherwise). Generate a strong password: openssl rand -hex 32
 POSTGRES_PASSWORD=
 
 # ── MQTT ────────────────────────────────────────────────────────────────────
@@ -42,9 +42,8 @@ MQTT_EXTERNAL_PORT=1883
 MQTT_BIND_ADDRESS=127.0.0.1
 # Dedicated broker credentials -- decoupled from your SAIC/MG account so a
 # LAN-exposed broker does not leak your cloud account password.
-# Optional when using the bundled Mosquitto -- defaults to "garagestack".
-# Set explicitly if you expose port 1883 to the LAN or use an external broker.
-# Generate a strong password: openssl rand -hex 32
+# Required when using the bundled Mosquitto (docker compose refuses to start
+# otherwise). Generate a strong password: openssl rand -hex 32
 MQTT_BROKER_USERNAME=garagestack
 MQTT_BROKER_PASSWORD=
 

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -32,13 +32,12 @@ jobs:
       # Auto-merge:
       #   - all patch updates
       #   - all minor updates that belong to a defined group (CI still must pass)
-      #   - all GitHub Actions updates regardless of semver
-      # Major version bumps are left for manual review.
+      # Major version bumps are left for manual review, including GitHub Actions updates --
+      # Actions run with repo secrets, so they get no blanket exemption from this rule.
       - name: Auto-merge
         if: |
           steps.meta.outputs.update-type == 'version-update:semver-patch' ||
-          (steps.meta.outputs.update-type == 'version-update:semver-minor' && steps.meta.outputs.dependency-group != '') ||
-          steps.meta.outputs.package-ecosystem == 'github_actions'
+          (steps.meta.outputs.update-type == 'version-update:semver-minor' && steps.meta.outputs.dependency-group != '')
         run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # secrets
-.env
+.env*
+!.env*.example
 
 # dotnet
 bin/
@@ -11,7 +12,6 @@ logs/
 # node
 node_modules/
 frontend/dist/
-frontend/.env.local
 
 # local all-in-one container testing data (see docker/all-in-one/README.md)
 garagestack-data/
@@ -20,7 +20,6 @@ CLAUDE.md
 dev.ps1
 example_data.txt
 appsettings.Development.json
-.env.development
 .stfolder
 .claude
 \keys

--- a/README.md
+++ b/README.md
@@ -164,8 +164,10 @@ Then open `.env` and fill in at minimum:
 | `SAIC_REST_URI` | Optional, only needed for a region not listed above -- set directly to your gateway's endpoint |
 | `JWT_SECRET` | At least 32 random characters -- generate with `openssl rand -base64 32` |
 | `CORS_ORIGIN` | The URL you open in your browser, e.g. `http://192.168.1.100:8080` |
+| `POSTGRES_PASSWORD` | Generate with `openssl rand -hex 32`. Using an external Postgres server instead of the bundled one? Set this to match its existing password. |
+| `MQTT_BROKER_PASSWORD` | Generate with `openssl rand -hex 32`. Mosquitto always runs bundled, so this is required either way. |
 
-`POSTGRES_PASSWORD` and `MQTT_BROKER_PASSWORD` default to `garagestack` when using the bundled services. Set them explicitly if you want stronger credentials or need to connect to the database/broker from outside the stack.
+`docker compose up` refuses to start until both `POSTGRES_PASSWORD` and `MQTT_BROKER_PASSWORD` are set.
 
 `VAPID_PUBLIC_KEY` / `VAPID_PRIVATE_KEY` are optional; leave them empty to disable push notifications.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       -c "
       set -eu;
       rm -f /mosquitto/data/passwd /mosquitto/data/acl;
-      mosquitto_passwd -b -c /mosquitto/data/passwd \"${MQTT_BROKER_USERNAME:-garagestack}\" \"${MQTT_BROKER_PASSWORD:-garagestack}\";
+      mosquitto_passwd -b -c /mosquitto/data/passwd \"${MQTT_BROKER_USERNAME:-garagestack}\" \"${MQTT_BROKER_PASSWORD:?Set MQTT_BROKER_PASSWORD in your .env file, see .env.example}\";
       printf 'user %s\\ntopic readwrite #\\n' \"${MQTT_BROKER_USERNAME:-garagestack}\" > /mosquitto/data/acl;
       chown mosquitto:mosquitto /mosquitto/data/passwd /mosquitto/data/acl;
       chmod 600 /mosquitto/data/passwd /mosquitto/data/acl;
@@ -35,7 +35,7 @@ services:
       SAIC_PASSWORD: "${SAIC_PASSWORD}"
       MQTT_URI: "tcp://mosquitto:1883"
       MQTT_USER: "${MQTT_BROKER_USERNAME:-garagestack}"
-      MQTT_PASSWORD: "${MQTT_BROKER_PASSWORD:-garagestack}"
+      MQTT_PASSWORD: "${MQTT_BROKER_PASSWORD:?Set MQTT_BROKER_PASSWORD in your .env file, see .env.example}"
       SAIC_REGION: "${SAIC_REGION:-eu}"
       SAIC_REST_URI: "${SAIC_REST_URI:-}"
     volumes:
@@ -56,7 +56,7 @@ services:
     environment:
       POSTGRES_DB: "${POSTGRES_DB:-garagestack}"
       POSTGRES_USER: "${POSTGRES_USER:-garagestack}"
-      POSTGRES_PASSWORD: "${POSTGRES_PASSWORD:-garagestack}"
+      POSTGRES_PASSWORD: "${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD in your .env file, see .env.example}"
     volumes:
       - postgres_data:/var/lib/postgresql
     healthcheck:
@@ -87,11 +87,11 @@ services:
       - .env
     environment:
       ASPNETCORE_ENVIRONMENT: "Production"
-      ConnectionStrings__DefaultConnection: "Host=${POSTGRES_HOST:-postgres};Port=${POSTGRES_PORT:-5432};Database=${POSTGRES_DB:-garagestack};Username=${POSTGRES_USER:-garagestack};Password=${POSTGRES_PASSWORD:-garagestack}"
+      ConnectionStrings__DefaultConnection: "Host=${POSTGRES_HOST:-postgres};Port=${POSTGRES_PORT:-5432};Database=${POSTGRES_DB:-garagestack};Username=${POSTGRES_USER:-garagestack};Password=${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD in your .env file, see .env.example}"
       Mqtt__Host: "${MQTT_HOST:-mosquitto}"
       Mqtt__Port: "${MQTT_PORT:-1883}"
       Mqtt__Username: "${MQTT_BROKER_USERNAME:-garagestack}"
-      Mqtt__Password: "${MQTT_BROKER_PASSWORD:-garagestack}"
+      Mqtt__Password: "${MQTT_BROKER_PASSWORD:?Set MQTT_BROKER_PASSWORD in your .env file, see .env.example}"
       Vapid__PublicKey: "${VAPID_PUBLIC_KEY}"
       Vapid__PrivateKey: "${VAPID_PRIVATE_KEY}"
       Vapid__Subject: "mailto:${SAIC_USER}"
@@ -121,7 +121,7 @@ services:
       - .env
     environment:
       ASPNETCORE_ENVIRONMENT: "Production"
-      ConnectionStrings__DefaultConnection: "Host=${POSTGRES_HOST:-postgres};Port=${POSTGRES_PORT:-5432};Database=${POSTGRES_DB:-garagestack};Username=${POSTGRES_USER:-garagestack};Password=${POSTGRES_PASSWORD:-garagestack}"
+      ConnectionStrings__DefaultConnection: "Host=${POSTGRES_HOST:-postgres};Port=${POSTGRES_PORT:-5432};Database=${POSTGRES_DB:-garagestack};Username=${POSTGRES_USER:-garagestack};Password=${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD in your .env file, see .env.example}"
       Cors__Origins__0: "${CORS_ORIGIN:-http://localhost:8080}"
       Jwt__Secret: "${JWT_SECRET}"
       SAIC_USER: "${SAIC_USER}"
@@ -131,7 +131,7 @@ services:
       Mqtt__Host: "${MQTT_HOST:-mosquitto}"
       Mqtt__Port: "${MQTT_PORT:-1883}"
       Mqtt__Username: "${MQTT_BROKER_USERNAME:-garagestack}"
-      Mqtt__Password: "${MQTT_BROKER_PASSWORD:-garagestack}"
+      Mqtt__Password: "${MQTT_BROKER_PASSWORD:?Set MQTT_BROKER_PASSWORD in your .env file, see .env.example}"
       Vapid__PublicKey: "${VAPID_PUBLIC_KEY}"
       Vapid__PrivateKey: "${VAPID_PRIVATE_KEY}"
       Vapid__Subject: "mailto:${SAIC_USER}"


### PR DESCRIPTION
## Summary
- `.gitignore` only covered `.env`, not `.env.demo` or other `.env.*` variants -- `DEMO.md` instructs users to create `.env.demo`, which could be committed by mistake. Broadened to `.env*` with a negation for the `*.example` templates.
- `auto-merge.yml` auto-merged all GitHub Actions dependency bumps regardless of semver, contradicting its own "major bumps need manual review" comment. Actions run with repo secrets, so this closes a real supply-chain gap.
- `docker-compose.yml` silently defaulted `POSTGRES_PASSWORD` and `MQTT_BROKER_PASSWORD` to the literal string `"garagestack"`. Both are now required -- `docker compose` refuses to start until they're set explicitly. `.env.example` and `README.md` updated to match.

These are the P0 (highest priority) items from a broader codebase review; P1 (performance) items are being worked on separately.

## Test plan
- [x] `git check-ignore -v .env.demo` confirms it's now ignored; the three `.example` templates remain trackable
- [x] `docker compose config` fails with a clear error when `POSTGRES_PASSWORD`/`MQTT_BROKER_PASSWORD` are unset, succeeds once both are set
- [x] Manually traced the `auto-merge.yml` condition against patch/minor-grouped/major update-type combinations to confirm major bumps (including GitHub Actions) no longer auto-merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)