### PR TITLE
refactor: dedupe notification/format logic and fix a merge-state race

### DIFF
--- a/frontend/src/components/ChargingSessionCard.vue
+++ b/frontend/src/components/ChargingSessionCard.vue
@@ -3,6 +3,7 @@ import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import ExpandableStatusCard from './ExpandableStatusCard.vue'
 import DetailListItem from './DetailListItem.vue'
+import { formatNumber } from '@/utils/format'
 
 const { t } = useI18n()
 
@@ -24,7 +25,7 @@ const obcPower = computed(() => props.obcPowerThreePhase ?? props.obcPowerSingle
 
 const summaryValue = computed((): string | null => {
   const parts: string[] = []
-  if (obcPower.value !== null) parts.push(`${obcPower.value.toFixed(1)} kW`)
+  if (obcPower.value !== null) parts.push(`${formatNumber(obcPower.value)} kW`)
   if (props.remainingChargingTime !== null)
     parts.push(`${props.remainingChargingTime} ${t('common.min')}`)
   if (parts.length) return parts.join(' · ')
@@ -67,19 +68,19 @@ const lastEndFormatted = computed((): string | null => {
       <DetailListItem
         v-if="obcPower !== null"
         icon="bolt-lightning"
-        :value="`${obcPower.toFixed(1)} kW`"
+        :value="`${formatNumber(obcPower)} kW`"
         :label="t('vehicle.chargingSession.power')"
       />
       <DetailListItem
         v-if="obcPowerThreePhase !== null"
         icon="plug"
-        :value="`${obcPowerThreePhase.toFixed(1)} kW`"
+        :value="`${formatNumber(obcPowerThreePhase)} kW`"
         :label="t('vehicle.chargingSession.power3phase')"
       />
       <DetailListItem
         v-if="obcPowerSinglePhase !== null"
         icon="plug"
-        :value="`${obcPowerSinglePhase.toFixed(1)} kW`"
+        :value="`${formatNumber(obcPowerSinglePhase)} kW`"
         :label="t('vehicle.chargingSession.power1phase')"
       />
       <DetailListItem
@@ -124,7 +125,7 @@ const lastEndFormatted = computed((): string | null => {
       <DetailListItem
         v-if="lastChargeEndingPower !== null"
         icon="percent"
-        :value="`${lastChargeEndingPower.toFixed(1)}%`"
+        :value="`${formatNumber(lastChargeEndingPower)}%`"
         :label="t('vehicle.chargingSession.lastEndSoc')"
       />
       <DetailListItem

--- a/frontend/src/components/ClimateDetailCard.vue
+++ b/frontend/src/components/ClimateDetailCard.vue
@@ -4,6 +4,7 @@ import { useI18n } from 'vue-i18n'
 import ExpandableStatusCard from './ExpandableStatusCard.vue'
 import DetailListItem from './DetailListItem.vue'
 import { useVehicleCommand } from '@/composables/useVehicleCommand'
+import { formatNumber } from '@/utils/format'
 
 const { t } = useI18n()
 
@@ -52,7 +53,7 @@ const summaryValue = computed((): string | null => {
   const parts: string[] = []
   if (props.climateOn !== null)
     parts.push(props.climateOn ? t('vehicle.climateOn') : t('vehicle.climateOff'))
-  if (props.interiorTemperature !== null) parts.push(`${props.interiorTemperature.toFixed(1)}°C`)
+  if (props.interiorTemperature !== null) parts.push(`${formatNumber(props.interiorTemperature)}°C`)
   return parts.length ? parts.join(' · ') : null
 })
 
@@ -231,7 +232,7 @@ function onSeatRightChange(e: Event) {
       <DetailListItem
         v-if="interiorTemperature !== null"
         icon="thermometer-half"
-        :value="`${interiorTemperature.toFixed(1)} °C`"
+        :value="`${formatNumber(interiorTemperature)} °C`"
         :label="t('vehicle.temperature.interior')"
       />
 
@@ -239,7 +240,7 @@ function onSeatRightChange(e: Event) {
       <DetailListItem
         v-if="exteriorTemperature !== null"
         icon="temperature-low"
-        :value="`${exteriorTemperature.toFixed(1)} °C`"
+        :value="`${formatNumber(exteriorTemperature)} °C`"
         :label="t('vehicle.temperature.exterior')"
       />
 

--- a/frontend/src/components/DashboardCardContent.vue
+++ b/frontend/src/components/DashboardCardContent.vue
@@ -16,6 +16,7 @@ import LightsCard from './LightsCard.vue'
 import ChargingSessionCard from './ChargingSessionCard.vue'
 import BatteryHeatingCard from './BatteryHeatingCard.vue'
 import MaintenanceSummaryCard from './MaintenanceSummaryCard.vue'
+import { formatNumber } from '@/utils/format'
 
 const props = defineProps<{ cardId: CardId }>()
 
@@ -122,7 +123,7 @@ const simpleCards = computed((): SimpleCardConfig[] => {
       match: true,
       icon: 'battery-three-quarters',
       label: t('vehicle.battery'),
-      value: s.batteryVoltage !== null ? s.batteryVoltage.toFixed(1) : null,
+      value: s.batteryVoltage !== null ? formatNumber(s.batteryVoltage) : null,
       unit: 'V',
       variant: s.batteryVoltage !== null && s.batteryVoltage < 12 ? 'danger' : 'success',
     },
@@ -139,7 +140,7 @@ const simpleCards = computed((): SimpleCardConfig[] => {
       match: s.mileageOfTheDay !== null,
       icon: 'route',
       label: t('vehicle.efficiency.todayDistance'),
-      value: s.mileageOfTheDay !== null ? s.mileageOfTheDay.toFixed(1) : null,
+      value: s.mileageOfTheDay !== null ? formatNumber(s.mileageOfTheDay) : null,
       unit: t('common.km'),
     },
     {
@@ -147,7 +148,7 @@ const simpleCards = computed((): SimpleCardConfig[] => {
       match: s.powerUsageOfDay !== null,
       icon: 'plug-circle-bolt',
       label: t('vehicle.efficiency.todayEnergy'),
-      value: s.powerUsageOfDay !== null ? s.powerUsageOfDay.toFixed(0) : null,
+      value: s.powerUsageOfDay !== null ? formatNumber(s.powerUsageOfDay, 0) : null,
       unit: t('common.wh'),
     },
     {
@@ -155,7 +156,7 @@ const simpleCards = computed((): SimpleCardConfig[] => {
       match: s.mileageSinceLastCharge !== null && !isHev.value,
       icon: 'battery-full',
       label: t('vehicle.efficiency.sinceCharge'),
-      value: s.mileageSinceLastCharge !== null ? s.mileageSinceLastCharge.toFixed(1) : null,
+      value: s.mileageSinceLastCharge !== null ? formatNumber(s.mileageSinceLastCharge) : null,
       unit: t('common.km'),
     },
     // efficiencyRatio - Wh/km when driving data is available
@@ -166,7 +167,7 @@ const simpleCards = computed((): SimpleCardConfig[] => {
       label: t('vehicle.efficiency.efficiency'),
       value:
         s.powerUsageOfDay !== null && s.mileageOfTheDay !== null
-          ? (s.powerUsageOfDay / s.mileageOfTheDay).toFixed(0)
+          ? formatNumber(s.powerUsageOfDay / s.mileageOfTheDay, 0)
           : null,
       unit: `${t('common.wh')}/${t('common.km')}`,
     },
@@ -182,7 +183,7 @@ const simpleCards = computed((): SimpleCardConfig[] => {
       label: t('vehicle.efficiency.fuelEconomy'),
       value:
         s.fuelRangeKm !== null && s.fuelLevelPercent !== null
-          ? (s.fuelRangeKm / (s.fuelLevelPercent / 100) / 100).toFixed(1)
+          ? formatNumber(s.fuelRangeKm / (s.fuelLevelPercent / 100) / 100)
           : null,
       unit: 'km/%',
     },
@@ -307,9 +308,9 @@ const activeSimpleCard = computed(
       "
       :value="
         status.currentJourneyDistance !== null && status.currentJourneyDistance > 0
-          ? status.currentJourneyDistance.toFixed(1)
+          ? formatNumber(status.currentJourneyDistance)
           : latestTrip
-            ? latestTrip.distanceKm.toFixed(1)
+            ? formatNumber(latestTrip.distanceKm)
             : t('vehicle.noTrips')
       "
       :unit="

--- a/frontend/src/components/HvBatteryCard.vue
+++ b/frontend/src/components/HvBatteryCard.vue
@@ -5,6 +5,7 @@ import ExpandableStatusCard from './ExpandableStatusCard.vue'
 import DetailListItem from './DetailListItem.vue'
 import CommandButton from './CommandButton.vue'
 import { useVehicleCommand } from '@/composables/useVehicleCommand'
+import { formatNumber } from '@/utils/format'
 
 const { t } = useI18n()
 
@@ -36,7 +37,7 @@ const socPercent = computed(() => {
 const summaryValue = computed((): string | null => {
   const parts: string[] = []
   if (socPercent.value !== null) parts.push(`${socPercent.value}%`)
-  else if (props.hvSocKwh !== null) parts.push(`${props.hvSocKwh.toFixed(1)} kWh`)
+  else if (props.hvSocKwh !== null) parts.push(`${formatNumber(props.hvSocKwh)} kWh`)
   if (props.hvBatteryActive !== null)
     parts.push(props.hvBatteryActive ? t('vehicle.hvBattery.active') : t('vehicle.hvBattery.idle'))
   return parts.length ? parts.join(' · ') : null
@@ -70,13 +71,13 @@ function setChargeLimit(value: string) {
       <DetailListItem
         v-if="hvSocKwh !== null"
         icon="bolt"
-        :value="`${hvSocKwh.toFixed(1)} kWh`"
+        :value="`${formatNumber(hvSocKwh)} kWh`"
         :label="t('vehicle.hvBattery.socKwh')"
       />
       <DetailListItem
         v-if="hvTotalCapacityKwh !== null"
         icon="database"
-        :value="`${hvTotalCapacityKwh.toFixed(1)} kWh`"
+        :value="`${formatNumber(hvTotalCapacityKwh)} kWh`"
         :label="t('vehicle.hvBattery.capacity')"
       />
       <DetailListItem
@@ -88,25 +89,25 @@ function setChargeLimit(value: string) {
       <DetailListItem
         v-if="hvVoltage !== null"
         icon="plug"
-        :value="`${hvVoltage.toFixed(0)} V`"
+        :value="`${formatNumber(hvVoltage, 0)} V`"
         :label="t('vehicle.hvBattery.voltage')"
       />
       <DetailListItem
         v-if="hvCurrent !== null"
         icon="wave-square"
-        :value="`${hvCurrent.toFixed(1)} A`"
+        :value="`${formatNumber(hvCurrent)} A`"
         :label="t('vehicle.hvBattery.current')"
       />
       <DetailListItem
         v-if="hvPower !== null"
         icon="bolt-lightning"
-        :value="`${hvPower.toFixed(1)} kW`"
+        :value="`${formatNumber(hvPower)} kW`"
         :label="t('vehicle.hvBattery.power')"
       />
       <DetailListItem
         v-if="powerUsageSinceLastCharge !== null"
         icon="chart-line"
-        :value="`${powerUsageSinceLastCharge.toFixed(1)} kWh`"
+        :value="`${formatNumber(powerUsageSinceLastCharge)} kWh`"
         :label="t('vehicle.hvBattery.usedSinceCharge')"
       />
       <DetailListItem

--- a/frontend/src/utils/format.ts
+++ b/frontend/src/utils/format.ts
@@ -1,0 +1,7 @@
+// Centralizes numeric-to-string formatting so every display value goes through one function.
+// Today this just replaces ~20 duplicated toFixed() call sites; it's also a single place to
+// switch to locale-aware formatting (Intl.NumberFormat) later, since toFixed() always renders
+// with a '.' decimal separator regardless of the active locale (en/nl).
+export function formatNumber(value: number, decimals = 1): string {
+  return value.toFixed(decimals)
+}

--- a/frontend/src/views/StatisticsView.vue
+++ b/frontend/src/views/StatisticsView.vue
@@ -21,6 +21,7 @@ import SkeletonCard from '@/components/SkeletonCard.vue'
 import SkeletonChart from '@/components/SkeletonChart.vue'
 import StatusCard from '@/components/StatusCard.vue'
 import EditableCardSlot from '@/components/EditableCardSlot.vue'
+import { formatNumber } from '@/utils/format'
 import {
   Chart as ChartJS,
   CategoryScale,
@@ -254,7 +255,7 @@ const batteryVoltageTrend = computed(() => {
 const batteryVoltageDisplay = computed(() => {
   if (batteryVoltageTrend.value !== null) return batteryVoltageTrend.value
   const v = status.value?.batteryVoltage
-  return v != null ? `${v.toFixed(1)} V` : null
+  return v != null ? `${formatNumber(v)} V` : null
 })
 
 const avgSpeedKmh = computed(() => {

--- a/src/GarageStack.Core/Helpers/NotificationCooldownGate.cs
+++ b/src/GarageStack.Core/Helpers/NotificationCooldownGate.cs
@@ -1,0 +1,46 @@
+namespace GarageStack.Core.Helpers;
+
+/// <summary>
+/// Deduplicates repeated notifications for the same vehicle+category within a cooldown window.
+/// Checks an in-memory cache first (cheap, but reset on restart), then falls back to a
+/// caller-supplied DB check so a service restart, or another service's overlapping alert,
+/// still suppresses a duplicate.
+/// </summary>
+public sealed class NotificationCooldownGate(TimeSpan cooldown)
+{
+    public TimeSpan Cooldown { get; } = cooldown;
+
+    private readonly Dictionary<string, DateTime> _lastNotified = new();
+
+    // Guards _lastNotified: callers invoke ShouldNotifyAsync from a single BackgroundService
+    // loop today, but this class makes no assumption about that staying true.
+    private readonly object _lock = new();
+
+    /// <summary>
+    /// Returns true if a notification for <paramref name="vin"/>/<paramref name="category"/> should
+    /// be sent now. Marks the key as notified as a side effect whenever this returns false because
+    /// <paramref name="wasRecentlySentAsync"/> found a match, or true - so callers must send
+    /// immediately when this returns true and must not call it speculatively.
+    /// </summary>
+    public async Task<bool> ShouldNotifyAsync(string vin, string category, Func<Task<bool>> wasRecentlySentAsync)
+    {
+        var key = $"{vin}/{category}";
+
+        lock (_lock)
+        {
+            if (_lastNotified.TryGetValue(key, out var last) && DateTime.UtcNow - last < Cooldown)
+                return false;
+        }
+
+        // Cross-service dedup: check DB so a restart (which clears _lastNotified) or another
+        // service's alert for the same category doesn't cause a duplicate notification.
+        if (await wasRecentlySentAsync())
+        {
+            lock (_lock) { _lastNotified[key] = DateTime.UtcNow; }
+            return false;
+        }
+
+        lock (_lock) { _lastNotified[key] = DateTime.UtcNow; }
+        return true;
+    }
+}

--- a/src/GarageStack.Tests/MqttConsumerServiceTests.cs
+++ b/src/GarageStack.Tests/MqttConsumerServiceTests.cs
@@ -141,6 +141,40 @@ file sealed class TestableMqttConsumerService : MqttConsumerService
 }
 
 // ---------------------------------------------------------------------------
+// Fake ITelemetryRepository with a slow AddAsync -- used to widen the race
+// window in the merge-state concurrency test below.
+// ---------------------------------------------------------------------------
+
+file sealed class SlowFakeTelemetryRepository : ITelemetryRepository
+{
+    private long _nextId;
+    public int AddCount;
+    public int MergeCount;
+
+    public async Task<long> AddAsync(TelemetrySnapshot snapshot, CancellationToken ct = default)
+    {
+        Interlocked.Increment(ref AddCount);
+        // Without MqttConsumerService's per-vehicle gate, two concurrent callers would both
+        // read an empty _mergeState before either finishes this delay and writes back,
+        // and both would end up here instead of the second one merging into the first.
+        await Task.Delay(50, ct);
+        return Interlocked.Increment(ref _nextId);
+    }
+
+    public Task MergeIntoAsync(long rowId, TelemetrySnapshot patch, CancellationToken ct = default)
+    {
+        Interlocked.Increment(ref MergeCount);
+        return Task.CompletedTask;
+    }
+
+    public Task<TelemetrySnapshot?> GetLatestAsync(int vehicleId, CancellationToken ct = default) => throw new NotImplementedException();
+    public Task<TelemetrySnapshot?> GetMergedLatestAsync(int vehicleId, CancellationToken ct = default) => throw new NotImplementedException();
+    public Task<IReadOnlyList<TelemetrySnapshot>> GetHistoryAsync(int vehicleId, DateTime from, DateTime to, CancellationToken ct = default) => throw new NotImplementedException();
+    public Task<IReadOnlyList<TripDto>> GetTripsAsync(int vehicleId, DateTime from, DateTime to, CancellationToken ct = default) => throw new NotImplementedException();
+    public Task<VehicleAggregateStats> GetAggregateStatsAsync(int vehicleId, DateTime from, DateTime to, CancellationToken ct = default) => throw new NotImplementedException();
+}
+
+// ---------------------------------------------------------------------------
 // Engine-start notification tests (unchanged logic)
 // ---------------------------------------------------------------------------
 
@@ -152,6 +186,26 @@ public class MqttConsumerServiceTests
             Options.Create(new MqttOptions()),
             new FakeServiceScopeFactory(),
             push);
+
+    [Fact]
+    public async Task MergeOrAddTelemetryAsync_ConcurrentCallsSameVehicle_SecondCallMergesInsteadOfRacing()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var repo = new SlowFakeTelemetryRepository();
+        var svc = CreateService(new FakePushSender());
+
+        var now = DateTime.UtcNow;
+        var patch1 = new TelemetrySnapshot { VehicleId = 1, RecordedAt = now };
+        var patch2 = new TelemetrySnapshot { VehicleId = 1, RecordedAt = now.AddSeconds(1) }; // within the 15s merge window
+
+        // Fire both "concurrently", as two overlapping MQTT dispatches for the same vehicle would.
+        await Task.WhenAll(
+            svc.MergeOrAddTelemetryAsync(1, patch1, "saic/vin/topic1", repo, ct),
+            svc.MergeOrAddTelemetryAsync(1, patch2, "saic/vin/topic2", repo, ct));
+
+        Assert.Equal(1, repo.AddCount);
+        Assert.Equal(1, repo.MergeCount);
+    }
 
     [Fact]
     public async Task CheckEngineStartAsync_FirstObservationRunning_SeedsWithoutFiring()

--- a/src/GarageStack.Tests/NotificationCooldownGateTests.cs
+++ b/src/GarageStack.Tests/NotificationCooldownGateTests.cs
@@ -1,0 +1,93 @@
+using GarageStack.Core.Helpers;
+
+namespace GarageStack.Tests;
+
+public class NotificationCooldownGateTests
+{
+    [Fact]
+    public async Task ShouldNotify_FirstCall_NoDbMatch_ReturnsTrue()
+    {
+        var gate = new NotificationCooldownGate(TimeSpan.FromHours(1));
+
+        var result = await gate.ShouldNotifyAsync("VIN1", "low-tyre", () => Task.FromResult(false));
+
+        Assert.True(result);
+    }
+
+    [Fact]
+    public async Task ShouldNotify_SecondCallWithinCooldown_ReturnsFalse_WithoutCheckingDbAgain()
+    {
+        var gate = new NotificationCooldownGate(TimeSpan.FromHours(1));
+        var dbChecked = false;
+
+        await gate.ShouldNotifyAsync("VIN1", "low-tyre", () => Task.FromResult(false));
+        var result = await gate.ShouldNotifyAsync("VIN1", "low-tyre", () =>
+        {
+            dbChecked = true;
+            return Task.FromResult(false);
+        });
+
+        Assert.False(result);
+        Assert.False(dbChecked);
+    }
+
+    [Fact]
+    public async Task ShouldNotify_OutsideCooldown_ChecksDbAgain()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var gate = new NotificationCooldownGate(TimeSpan.FromMilliseconds(10));
+
+        await gate.ShouldNotifyAsync("VIN1", "low-tyre", () => Task.FromResult(false));
+        await Task.Delay(TimeSpan.FromMilliseconds(50), ct);
+        var result = await gate.ShouldNotifyAsync("VIN1", "low-tyre", () => Task.FromResult(false));
+
+        Assert.True(result);
+    }
+
+    [Fact]
+    public async Task ShouldNotify_DbHasRecentMatch_ReturnsFalse_AndCachesResultWithoutFurtherDbChecks()
+    {
+        var gate = new NotificationCooldownGate(TimeSpan.FromHours(1));
+        var dbCheckCount = 0;
+
+        var first = await gate.ShouldNotifyAsync("VIN1", "engine-start", () =>
+        {
+            dbCheckCount++;
+            return Task.FromResult(true);
+        });
+        var second = await gate.ShouldNotifyAsync("VIN1", "engine-start", () =>
+        {
+            dbCheckCount++;
+            return Task.FromResult(true);
+        });
+
+        Assert.False(first);
+        Assert.False(second);
+        // The DB hit on the first call is cached as if we'd notified, so the second call
+        // never re-checks the DB - this is what lets a restart avoid hammering the DB on
+        // every check for a condition another service already alerted on.
+        Assert.Equal(1, dbCheckCount);
+    }
+
+    [Fact]
+    public async Task ShouldNotify_DifferentCategories_AreIndependent()
+    {
+        var gate = new NotificationCooldownGate(TimeSpan.FromHours(1));
+
+        await gate.ShouldNotifyAsync("VIN1", "low-tyre", () => Task.FromResult(false));
+        var result = await gate.ShouldNotifyAsync("VIN1", "high-tyre", () => Task.FromResult(false));
+
+        Assert.True(result);
+    }
+
+    [Fact]
+    public async Task ShouldNotify_DifferentVins_AreIndependent()
+    {
+        var gate = new NotificationCooldownGate(TimeSpan.FromHours(1));
+
+        await gate.ShouldNotifyAsync("VIN1", "low-tyre", () => Task.FromResult(false));
+        var result = await gate.ShouldNotifyAsync("VIN2", "low-tyre", () => Task.FromResult(false));
+
+        Assert.True(result);
+    }
+}

--- a/src/GarageStack.Worker/Mqtt/MqttConsumerService.cs
+++ b/src/GarageStack.Worker/Mqtt/MqttConsumerService.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.Text.Json;
 using GarageStack.Core.Helpers;
 using GarageStack.Core.Interfaces;
@@ -31,13 +32,15 @@ public class MqttConsumerService(
     // each row represents a complete poll rather than a single field, reducing row
     // count by ~9x and ensuring all chart fields land in the same sample.
     //
-    // Unlike _engineRunningTracker, this dictionary is read, awaited on, then written back
-    // (see HandleMessageAsync), so a simple lock can't cover the whole critical section without
-    // blocking across an await. That's safe only because MQTTnet invokes
-    // ApplicationMessageReceivedAsync for one message at a time on this client; if that dispatch
-    // model ever changes, this needs an async-safe lock (e.g. SemaphoreSlim) around the read/await/write.
+    // Unlike _engineRunningTracker, this dictionary is read, awaited on (the DB call in
+    // MergeOrAddTelemetryAsync), then written back - a plain lock can't cover that critical
+    // section without blocking across an await. Each vehicle gets its own SemaphoreSlim instead
+    // (same pattern as VehicleCommandGate), rather than relying on MQTTnet invoking
+    // ApplicationMessageReceivedAsync for one message at a time on this client, which is an
+    // implementation detail this class shouldn't assume.
     private static readonly TimeSpan MergeWindow = TimeSpan.FromSeconds(15);
     internal readonly Dictionary<int, (long RowId, DateTime RecordedAt)> _mergeState = new();
+    private readonly ConcurrentDictionary<int, SemaphoreSlim> _mergeGates = new();
 
     protected virtual IMqttClient CreateMqttClient() => new MqttClientFactory().CreateMqttClient();
     protected virtual TimeSpan RetryDelay => TimeSpan.FromSeconds(5);
@@ -192,18 +195,7 @@ public class MqttConsumerService(
             patch.VehicleId = vehicle.Id;
             patch.RecordedAt = DateTime.UtcNow;
 
-            if (_mergeState.TryGetValue(vehicle.Id, out var last) &&
-                patch.RecordedAt - last.RecordedAt <= MergeWindow)
-            {
-                await telemetryRepo.MergeIntoAsync(last.RowId, patch, ct);
-                _mergeState[vehicle.Id] = (last.RowId, patch.RecordedAt);
-            }
-            else
-            {
-                patch.RawTopic = topic;
-                var newId = await telemetryRepo.AddAsync(patch, ct);
-                _mergeState[vehicle.Id] = (newId, patch.RecordedAt);
-            }
+            await MergeOrAddTelemetryAsync(vehicle.Id, patch, topic, telemetryRepo, ct);
 
             var tripCompleted = await CheckEngineStartAsync(vin, patch, ct);
             if (tripCompleted && patch.VehicleId > 0)
@@ -217,6 +209,34 @@ public class MqttConsumerService(
         catch (Exception ex)
         {
             logger.LogError(ex, "Failed to persist telemetry for VIN={Vin} topic={Topic}", vin, topic);
+        }
+    }
+
+    // Serializes read-await-write access to _mergeState per vehicle so two concurrently
+    // dispatched messages for the same vehicle can't race on which row they merge into.
+    internal async Task MergeOrAddTelemetryAsync(
+        int vehicleId, TelemetrySnapshot patch, string topic, ITelemetryRepository telemetryRepo, CancellationToken ct)
+    {
+        var gate = _mergeGates.GetOrAdd(vehicleId, static _ => new SemaphoreSlim(1, 1));
+        await gate.WaitAsync(ct);
+        try
+        {
+            if (_mergeState.TryGetValue(vehicleId, out var last) &&
+                patch.RecordedAt - last.RecordedAt <= MergeWindow)
+            {
+                await telemetryRepo.MergeIntoAsync(last.RowId, patch, ct);
+                _mergeState[vehicleId] = (last.RowId, patch.RecordedAt);
+            }
+            else
+            {
+                patch.RawTopic = topic;
+                var newId = await telemetryRepo.AddAsync(patch, ct);
+                _mergeState[vehicleId] = (newId, patch.RecordedAt);
+            }
+        }
+        finally
+        {
+            gate.Release();
         }
     }
 

--- a/src/GarageStack.Worker/Services/MaintenanceCheckService.cs
+++ b/src/GarageStack.Worker/Services/MaintenanceCheckService.cs
@@ -11,9 +11,8 @@ public class MaintenanceCheckService(
     IServiceScopeFactory scopeFactory,
     IPushSender pushSender) : BackgroundService
 {
-    private readonly Dictionary<string, DateTime> _lastNotified = new();
     private readonly TimeSpan _checkInterval = TimeSpan.FromHours(6);
-    private readonly TimeSpan _cooldown = TimeSpan.FromDays(7);
+    private readonly NotificationCooldownGate _cooldownGate = new(TimeSpan.FromDays(7));
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
@@ -63,21 +62,13 @@ public class MaintenanceCheckService(
                 var alert = BuildAlert(item, result);
                 if (alert is null) continue;
 
-                var notifKey = $"{vehicle.Vin}/{alert.Value.Category}";
-                if (_lastNotified.TryGetValue(notifKey, out var last) && DateTime.UtcNow - last < _cooldown)
-                    continue;
+                var cutoff = DateTime.UtcNow - _cooldownGate.Cooldown;
+                var shouldNotify = await _cooldownGate.ShouldNotifyAsync(vehicle.Vin, alert.Value.Category, () =>
+                    db.AppNotifications.AnyAsync(n => n.Category == alert.Value.Category && n.VehicleId == vehicle.Id && n.CreatedAt > cutoff, ct));
+                if (!shouldNotify) continue;
 
-                // Cross-service dedup: check DB so a restart doesn't forget the in-memory cooldown.
-                var cutoff = DateTime.UtcNow - _cooldown;
-                if (await db.AppNotifications.AnyAsync(n => n.Category == alert.Value.Category && n.VehicleId == vehicle.Id && n.CreatedAt > cutoff, ct))
-                {
-                    _lastNotified[notifKey] = DateTime.UtcNow;
-                    continue;
-                }
-
-                _lastNotified[notifKey] = DateTime.UtcNow;
                 await pushSender.SendToAllAsync(alert.Value.Title, alert.Value.Body, ct, alert.Value.Category, vehicle.Id);
-                logger.LogInformation("Maintenance push sent: {Key} - {Title}", notifKey, alert.Value.Title);
+                logger.LogInformation("Maintenance push sent: {Vin}/{Category} - {Title}", vehicle.Vin, alert.Value.Category, alert.Value.Title);
             }
         }
     }

--- a/src/GarageStack.Worker/Services/PushNotificationCheckService.cs
+++ b/src/GarageStack.Worker/Services/PushNotificationCheckService.cs
@@ -15,8 +15,7 @@ public class PushNotificationCheckService(
     IPushSender pushSender,
     TyrePressureThresholds tyrePressureThresholds) : BackgroundService
 {
-    private readonly Dictionary<string, DateTime> _lastNotified = new();
-    private readonly TimeSpan _cooldown = TimeSpan.FromHours(1);
+    private readonly NotificationCooldownGate _cooldownGate = new(TimeSpan.FromHours(1));
     internal readonly VinStateTracker<bool?> _engineRunningTracker = new();
     internal readonly VinStateTracker<bool?> _isChargingTracker = new();
     internal readonly Dictionary<string, DateTime> _lastParkedAt = new();
@@ -79,22 +78,17 @@ public class PushNotificationCheckService(
 
             foreach (var (key, title, body) in alerts)
             {
-                var notifKey = $"{vehicle.Vin}/{key}";
-                if (_lastNotified.TryGetValue(notifKey, out var last) && DateTime.UtcNow - last < _cooldown)
-                    continue;
+                // VehicleId is included in the DB check so one vehicle's alert cannot suppress
+                // another vehicle's same-category alert; this also lets MQTT-emitted notifications
+                // (e.g. engine-start, sent directly from MqttConsumerService) suppress a repeated
+                // checker alert for the same category.
+                var cutoff = DateTime.UtcNow - _cooldownGate.Cooldown;
+                var shouldNotify = await _cooldownGate.ShouldNotifyAsync(vehicle.Vin, key, () =>
+                    db.AppNotifications.AnyAsync(n => n.Category == key && n.VehicleId == vehicle.Id && n.CreatedAt > cutoff, ct));
+                if (!shouldNotify) continue;
 
-                // Cross-service dedup: check DB so MQTT-emitted notifications suppress repeated checker alerts.
-                // VehicleId is included so one vehicle's alert cannot suppress another vehicle's same-category alert.
-                var cutoff = DateTime.UtcNow - _cooldown;
-                if (await db.AppNotifications.AnyAsync(n => n.Category == key && n.VehicleId == vehicle.Id && n.CreatedAt > cutoff, ct))
-                {
-                    _lastNotified[notifKey] = DateTime.UtcNow;
-                    continue;
-                }
-
-                _lastNotified[notifKey] = DateTime.UtcNow;
                 await pushSender.SendToAllAsync(title, body, ct, key, vehicle.Id);
-                logger.LogInformation("Push sent: {Key} - {Title}", notifKey, title);
+                logger.LogInformation("Push sent: {Vin}/{Key} - {Title}", vehicle.Vin, key, title);
             }
         }
     }


### PR DESCRIPTION
## Summary
- **Backend dedup**: `MaintenanceCheckService` and `PushNotificationCheckService` each hand-rolled an identical in-memory-then-DB notification cooldown check. Extracted into `NotificationCooldownGate` (`GarageStack.Core.Helpers`) and both services now depend on it.
- **Concurrency fix**: `MqttConsumerService._mergeState` was read, awaited on (a DB call), then written back with no synchronization -- relying on MQTTnet dispatching one message at a time, an assumption `VinStateTracker` in the same codebase explicitly documents as unsafe to make. Extracted the merge into `MergeOrAddTelemetryAsync`, guarded by a per-vehicle `SemaphoreSlim` (same pattern as `VehicleCommandGate`), so two concurrently dispatched messages for the same vehicle can no longer race into two separate rows instead of one merged row. I verified the new regression test actually catches the bug by temporarily reverting the fix and confirming the test fails (2 `AddAsync` calls instead of 1) before restoring it.
- **Frontend dedup**: replaced ~20 duplicated `value.toFixed(n)` call sites across `HvBatteryCard`, `ChargingSessionCard`, `ClimateDetailCard`, `DashboardCardContent`, and `StatisticsView` with a single `formatNumber()` util (`frontend/src/utils/format.ts`). Behaviorally identical today; gives one place to add locale-aware number formatting later instead of ~20 (the app already fully supports en/nl locales, but `toFixed()` always uses a `.` decimal separator regardless of locale).

Skipped item from the same review tier: unifying `ChargingStationService`/`PoiService`'s near-duplicate tile-fetch orchestration -- the two services differ enough in filtering that collapsing them now would be premature abstraction; flagged as a follow-up only if either needs to grow.

These are the P2 (architecture/duplication) items from a broader codebase review; P0 (security, #273) and P1 (performance, #274) landed separately.

## Test plan
- [x] `dotnet build` -- 0 warnings/errors
- [x] `dotnet test` -- 333 backend tests passing, including 2 new `NotificationCooldownGate` behavior tests and 1 new `MqttConsumerService` concurrency regression test
- [x] `vue-tsc --build`, `oxlint`/`eslint`, `prettier --write` -- all clean on the frontend
- [x] `vitest` -- 245 frontend tests passing
- [x] Manually verified in a real browser (demo mode): logged in, screenshotted the dashboard summary cards and the HV Battery detail modal, confirmed every reformatted value (kWh, V, A, kW, °C, Wh/km, km) renders identically to before

🤖 Generated with [Claude Code](https://claude.com/claude-code)