### PR TITLE
docs: add ARCHITECTURE.md and XML docs on the Core abstraction boundary

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,88 @@
+# Architecture
+
+This is an overview of how GarageStack's services fit together, for contributors who need
+the map before their first PR. For end-user setup, see [README.md](README.md); for local dev
+without a real car, see [DEMO.md](DEMO.md).
+
+## Services
+
+```text
+                     ┌──────────────────────┐
+                     │   SAIC / MG cloud     │
+                     └──────────┬────────────┘
+                                │ polls
+                     ┌──────────▼────────────┐
+                     │  saic-mqtt-gateway     │  (third-party image, pinned version)
+                     └──────────┬────────────┘
+                                │ publishes telemetry / subscribes to commands
+                     ┌──────────▼────────────┐
+                     │      Mosquitto         │  MQTT broker
+                     └────┬─────────────┬─────┘
+                          │             │
+              subscribes  │             │  publishes commands
+                     ┌────▼───┐     ┌───▼────┐
+                     │ Worker │     │  Api   │◄──── frontend (Vue SPA, via nginx)
+                     └────┬───┘     └───┬────┘
+                          │  writes     │  reads/writes,
+                          │             │  LISTENs for pg_notify
+                     ┌────▼─────────────▼────┐
+                     │      PostgreSQL         │
+                     └─────────────────────────┘
+```
+
+- **saic-mqtt-gateway** (`saicismartapi/saic-python-mqtt-gateway`, pinned in `docker-compose.yml`) polls the SAIC/MG cloud API on GarageStack's behalf and publishes telemetry to MQTT, and relays commands published back to MQTT to the cloud API. This is the only piece of the stack that isn't part of this repo.
+- **Mosquitto** is the MQTT broker all telemetry and commands flow through. Requires auth; not exposed to the LAN by default.
+- **Worker** (`GarageStack.Worker`) subscribes to MQTT and writes telemetry to Postgres. Runs on its own, no inbound HTTP.
+- **Api** (`GarageStack.Api`) serves the REST API and SignalR hub the frontend talks to, and separately publishes outbound MQTT messages for remote commands (lock, climate, etc.).
+- **Postgres** is the only datastore. The Api also uses it as a pub/sub channel (`pg_notify`/`LISTEN`) to learn about writes the Worker makes, so it can push live updates without polling the DB.
+- **frontend** is a Vue 3 SPA built and served by nginx; the only service with a public port by default.
+
+## Data flow: a telemetry update reaching the browser
+
+1. `saic-mqtt-gateway` polls the SAIC cloud and publishes one MQTT message per changed field to a topic like `saic/{user}/vehicles/{vin}/drivetrain/soc`.
+2. `MqttConsumerService` ([src/GarageStack.Worker/Mqtt/MqttConsumerService.cs](src/GarageStack.Worker/Mqtt/MqttConsumerService.cs)) is subscribed to `saic/#`. It extracts the VIN and subtopic, maps the payload onto a `TelemetrySnapshot` field via `TelemetryMapper`, and writes it to Postgres. A single poll cycle produces several MQTT messages in quick succession, so messages arriving within a 15s window are merged into one row instead of one row per field (see the comments on `MergeOrAddTelemetryAsync` in that file for why this needs a per-vehicle lock).
+3. Each write calls `pg_notify('telemetry_updated', vehicleId)`.
+4. `TelemetryNotificationService` ([src/GarageStack.Api/Services/TelemetryNotificationService.cs](src/GarageStack.Api/Services/TelemetryNotificationService.cs)), a background service in the Api process, holds a `LISTEN telemetry_updated` connection. On notification it debounces briefly (to coalesce a poll cycle's several writes into one update), re-reads the merged latest snapshot, and broadcasts it over SignalR to browsers subscribed to that vehicle's group.
+5. The frontend's `useSignalR` composable ([frontend/src/composables/useSignalR.ts](frontend/src/composables/useSignalR.ts)) receives the `telemetryUpdated` event and updates the UI. There is no polling fallback - if the SignalR connection drops, the dashboard goes stale until it reconnects.
+
+The same `pg_notify`/`LISTEN`/SignalR pattern also carries `notification_created` (push/in-app alerts) and `trip_completed` events.
+
+## Sending a command to the car (the reverse path)
+
+The frontend calls `POST /api/vehicles/{vin}/commands/{command}` on the Api, which publishes an MQTT message via `MqttPublisher` ([src/GarageStack.Api/Services/MqttPublisher.cs](src/GarageStack.Api/Services/MqttPublisher.cs)) - a separate MQTT client from the Worker's, since the Api only ever publishes and the Worker only ever consumes. `saic-mqtt-gateway` picks the message up and relays it to the SAIC cloud API. `VehicleCommandGate` ([src/GarageStack.Api/VehicleCommandGate.cs](src/GarageStack.Api/VehicleCommandGate.cs)) serializes commands per VIN server-side, since the real gateway only processes one command at a time.
+
+## Projects under `src/`
+
+| Project | Contains | Depends on |
+| --- | --- | --- |
+| `GarageStack.Core` | Domain models (`Models/`), repository/service interfaces (`Interfaces/`), and pure helpers with no I/O (`Helpers/`) - the shared vocabulary every other project builds on. | nothing (leaf project) |
+| `GarageStack.Data` | EF Core: `AppDbContext`, migrations, concrete repository implementations, and `Demo/` (in-memory fakes used when `DEMO_MODE=true`). | `Core` |
+| `GarageStack.Worker` | The MQTT-ingestion process: `Mqtt/MqttConsumerService`, plus background services for maintenance reminders, POI pre-caching, and push-notification checks. | `Core`, `Data` |
+| `GarageStack.Api` | ASP.NET Core minimal APIs (`Endpoints/`), the SignalR hub (`Hubs/`), and Api-only services (outbound MQTT publishing, POI/charging-station lookups, the Postgres-LISTEN-to-SignalR bridge). | `Core`, `Data` |
+| `GarageStack.Tests` | xUnit tests across all of the above. | all four |
+
+## Caching
+
+There's no Redis (or other external cache) in the stack, by design rather than oversight: this
+is a single-instance, single-user deployment, so a distributed cache buys nothing a
+process-local one doesn't already provide. Two caches exist today:
+
+- `ITelemetryRepository.GetMergedLatestAsync` (the hot path behind `/status`, the homepage
+  widget, and every SignalR broadcast) uses a short-TTL `IMemoryCache` entry, invalidated
+  immediately on every telemetry write so it can never serve data older than the write that
+  triggered a SignalR broadcast.
+- Map POI tiles (charging stations, fuel stations, service areas) are cached in Postgres itself
+  (`PoiCacheTile`/`PoiItem`), not in memory, since that data needs to survive process restarts
+  and be queried by bounding box - a job a plain in-memory cache isn't suited for anyway.
+
+If GarageStack ever needs to run more than one Api/Worker instance, revisit this: per-vehicle
+in-memory state (this cache, `VehicleCommandGate`, the Overpass/OCM rate limiters) would all
+need to move to something shared.
+
+## Database
+
+Code-first EF Core migrations live in `src/GarageStack.Data/Migrations/`. `Program.cs` runs `db.Database.MigrateAsync()` on Api startup in normal operation; in `DEMO_MODE` it calls `EnsureCreated()` and seeds fake data instead, bypassing a real Postgres server entirely.
+
+## Frontend
+
+REST calls go through `frontend/src/services/` - `apiCore.ts` centralizes the `fetch` wrapper (cookie-based auth, shared 401 handling), and each domain area (`vehicleApi.ts`, `maintenanceApi.ts`, `notificationsApi.ts`, `mapApi.ts`, etc.) builds on it. Real-time updates use `useSignalR.ts` as described above, not polling.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,13 @@
 
 Thank you for your interest in contributing! This document explains how to get involved.
 
+See [ARCHITECTURE.md](ARCHITECTURE.md) for how the services (Worker, Api, Mosquitto, Postgres, frontend) fit together before diving into a change that spans more than one of them.
+
 ## Getting Started
+
+Don't have a real MG vehicle or SAIC account to test against? See [DEMO.md](DEMO.md) -- demo mode runs the full app against realistic fake data with no MG credentials, database, or MQTT broker required, and is the fastest way to get the frontend running locally.
+
+To work against the full stack (real or self-provided credentials):
 
 1. Fork the repository and clone it locally.
 2. Install prerequisites: .NET (latest LTS), Node.js, PNPM, PostgreSQL, Docker (optional).

--- a/src/GarageStack.Core/Interfaces/IMqttPublisher.cs
+++ b/src/GarageStack.Core/Interfaces/IMqttPublisher.cs
@@ -1,5 +1,11 @@
 namespace GarageStack.Core.Interfaces;
 
+/// <summary>
+/// Publishes a message to the MQTT broker that the SAIC gateway listens on, used by the Api
+/// to send remote vehicle commands (lock, climate, etc.) - the gateway picks the message up
+/// and relays it to the SAIC cloud API. Demo mode swaps in a no-op implementation since there
+/// is no real gateway to publish to.
+/// </summary>
 public interface IMqttPublisher
 {
     Task PublishAsync(string topic, string payload, CancellationToken ct = default);

--- a/src/GarageStack.Core/Interfaces/IPoiRepository.cs
+++ b/src/GarageStack.Core/Interfaces/IPoiRepository.cs
@@ -2,13 +2,25 @@ using GarageStack.Core.Models;
 
 namespace GarageStack.Core.Interfaces;
 
+/// <summary>
+/// Caches map points-of-interest (charging stations, fuel stations, service areas) in a
+/// tile-based grid so repeated map views don't re-hit the upstream API (Open Charge Map /
+/// Overpass). <paramref name="source"/> identifies the upstream provider and
+/// <paramref name="poiType"/> the category; tiles are addressed by integer
+/// <c>(CellLat, CellLng)</c> grid cell, not raw coordinates.
+/// </summary>
 public interface IPoiRepository
 {
+    /// <summary>
+    /// Of the given <paramref name="tiles"/>, returns the ones with no cached entry or whose
+    /// cache has passed its <c>ExpiresAt</c> - i.e. the tiles that need fetching from upstream.
+    /// </summary>
     Task<IReadOnlyList<(int CellLat, int CellLng)>> GetExpiredOrMissingTilesAsync(
         string source, string poiType,
         IReadOnlyList<(int CellLat, int CellLng)> tiles,
         CancellationToken ct = default);
 
+    /// <summary>Replaces the cached POIs for one tile with <paramref name="items"/>, valid for <paramref name="ttl"/>.</summary>
     Task UpsertTileAsync(
         string source, string poiType,
         int cellLat, int cellLng,
@@ -16,12 +28,14 @@ public interface IPoiRepository
         TimeSpan ttl,
         CancellationToken ct = default);
 
+    /// <summary>Returns cached POIs whose coordinates fall within the given lat/lng bounding box.</summary>
     Task<IReadOnlyList<PoiItem>> GetPoisInBoundsAsync(
         string source, string poiType,
         double minLat, double minLng,
         double maxLat, double maxLng,
         CancellationToken ct = default);
 
+    /// <summary>Returns the distinct brand/operator names present in cached POIs' metadata, for the map's filter panel.</summary>
     Task<IReadOnlyList<string>> GetDistinctBrandsAsync(
         string source, string poiType,
         CancellationToken ct = default);

--- a/src/GarageStack.Core/Interfaces/IPushSender.cs
+++ b/src/GarageStack.Core/Interfaces/IPushSender.cs
@@ -1,5 +1,12 @@
 namespace GarageStack.Core.Interfaces;
 
+/// <summary>
+/// Delivers a notification to every subscribed browser (Web Push/VAPID) and persists an
+/// <c>AppNotification</c> row so it also appears in the in-app bell, regardless of whether
+/// push is configured or delivery succeeds. <paramref name="category"/> is used by callers'
+/// own cooldown logic (see <c>NotificationCooldownGate</c>) to dedupe repeated alerts for the
+/// same condition; <paramref name="vehicleId"/> scopes an alert to one vehicle.
+/// </summary>
 public interface IPushSender
 {
     Task SendToAllAsync(string title, string body, CancellationToken ct = default, string? category = null, int? vehicleId = null);

--- a/src/GarageStack.Core/Interfaces/ITelemetryRepository.cs
+++ b/src/GarageStack.Core/Interfaces/ITelemetryRepository.cs
@@ -2,13 +2,50 @@ using GarageStack.Core.Models;
 
 namespace GarageStack.Core.Interfaces;
 
+/// <summary>
+/// Stores and queries raw and merged vehicle telemetry. Each MQTT message from the SAIC
+/// gateway carries only the field(s) for one topic, so a single "poll" of the vehicle
+/// arrives as several narrow rows within a short window - <see cref="AddAsync"/> and
+/// <see cref="MergeIntoAsync"/> exist so a caller (MqttConsumerService) can fold those rows
+/// into one, while the Get* methods present a merged view back out for the API/dashboard.
+/// </summary>
 public interface ITelemetryRepository
 {
+    /// <summary>Inserts <paramref name="snapshot"/> as a new row and returns its generated id.</summary>
     Task<long> AddAsync(TelemetrySnapshot snapshot, CancellationToken ct = default);
+
+    /// <summary>
+    /// Overwrites every field on the row identified by <paramref name="rowId"/> with the
+    /// corresponding non-null field from <paramref name="patch"/> (last-write-wins per field).
+    /// Used to fold a follow-up MQTT message into the same row an earlier message in the same
+    /// poll cycle already created.
+    /// </summary>
     Task MergeIntoAsync(long rowId, TelemetrySnapshot patch, CancellationToken ct = default);
+
+    /// <summary>Returns the single most recently recorded row for <paramref name="vehicleId"/>, unmerged.</summary>
     Task<TelemetrySnapshot?> GetLatestAsync(int vehicleId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Builds a single "current state" snapshot by merging the most recent rows for
+    /// <paramref name="vehicleId"/> field-by-field (first non-null value per field wins,
+    /// newest row first) - this is what the dashboard, widget endpoint, and SignalR live
+    /// updates all read, since no single MQTT message carries every field at once.
+    /// </summary>
     Task<TelemetrySnapshot?> GetMergedLatestAsync(int vehicleId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Returns chart-relevant snapshots between <paramref name="from"/> and <paramref name="to"/>
+    /// (GPS-only rows are excluded - see the Statistics/Map trip endpoints for route data),
+    /// downsampled per-day to a resolution appropriate for the requested range's length.
+    /// </summary>
     Task<IReadOnlyList<TelemetrySnapshot>> GetHistoryAsync(int vehicleId, DateTime from, DateTime to, CancellationToken ct = default);
+
+    /// <summary>
+    /// Reconstructs discrete trips from GPS rows between <paramref name="from"/> and
+    /// <paramref name="to"/>, splitting on data gaps and sustained parking periods.
+    /// </summary>
     Task<IReadOnlyList<TripDto>> GetTripsAsync(int vehicleId, DateTime from, DateTime to, CancellationToken ct = default);
+
+    /// <summary>Computes summary statistics (e.g. climate usage) over snapshots in the given date range.</summary>
     Task<VehicleAggregateStats> GetAggregateStatsAsync(int vehicleId, DateTime from, DateTime to, CancellationToken ct = default);
 }

--- a/src/GarageStack.Core/Interfaces/IVehicleRepository.cs
+++ b/src/GarageStack.Core/Interfaces/IVehicleRepository.cs
@@ -2,10 +2,24 @@ using GarageStack.Core.Models;
 
 namespace GarageStack.Core.Interfaces;
 
+/// <summary>Looks up and creates <see cref="Vehicle"/> records by VIN, and updates their capability metadata.</summary>
 public interface IVehicleRepository
 {
     Task<Vehicle?> GetByVinAsync(string vin, CancellationToken ct = default);
+
+    /// <summary>
+    /// Returns the existing vehicle for <paramref name="vin"/>, or creates one if this is the
+    /// first time it's been seen. The Api and Worker can both call this for a brand-new VIN at
+    /// nearly the same time (e.g. on startup); implementations must handle the resulting
+    /// unique-constraint race rather than let it surface as an error.
+    /// </summary>
     Task<Vehicle> GetOrCreateByVinAsync(string vin, string? saicUser = null, CancellationToken ct = default);
+
+    /// <summary>
+    /// Merges <paramref name="key"/>/<paramref name="value"/> into the vehicle's capability
+    /// config (parsed from MQTT <c>info/configuration/*</c> messages), leaving other keys intact.
+    /// </summary>
     Task SetConfigValueAsync(int vehicleId, string key, string value, CancellationToken ct = default);
+
     Task SetModelAsync(int vehicleId, string model, CancellationToken ct = default);
 }

--- a/src/GarageStack.Core/Models/AppNotification.cs
+++ b/src/GarageStack.Core/Models/AppNotification.cs
@@ -6,7 +6,10 @@ public class AppNotification
     public string Title { get; set; } = string.Empty;
     public string Body { get; set; } = string.Empty;
     public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+    // Archived: user dismissed it from the active list, but it's still visible in history
+    // (e.g. excluded from the unread count, included in the default notification-list query).
     public bool IsArchived { get; set; }
+    // Deleted: excluded from every query - a harder hide than archiving, with no way back via the UI.
     public bool IsDeleted { get; set; }
     public string? Category { get; set; }
     public int? VehicleId { get; set; }

--- a/src/GarageStack.Core/Models/TelemetrySnapshot.cs
+++ b/src/GarageStack.Core/Models/TelemetrySnapshot.cs
@@ -107,6 +107,9 @@ public class TelemetrySnapshot
     // Location extras
     public double? Elevation { get; set; }
 
+    // Only set on the row that starts a merge window (TelemetryRepository.AddAsync), never on
+    // rows folded into it via MergeIntoAsync - kept for troubleshooting which MQTT topic
+    // created a given row. Not serialized to the API response.
     [JsonIgnore]
     public string? RawTopic { get; set; }
 

--- a/src/GarageStack.Worker/Mqtt/TelemetryMapper.cs
+++ b/src/GarageStack.Worker/Mqtt/TelemetryMapper.cs
@@ -4,6 +4,16 @@ using GarageStack.Core.Models;
 
 namespace GarageStack.Worker.Mqtt;
 
+// Maps saic-mqtt-gateway MQTT subtopics onto TelemetrySnapshot fields. Several fields below
+// accept more than one subtopic name (e.g. FuelLevelPercent from both "drivetrain/fossilFuel/
+// percentage" and "drivetrain/fuelLevel"). Checked against the pinned gateway version's own
+// topic list (src/mqtt_topics.py in SAIC-iSmart-API/saic-python-mqtt-gateway): in every such
+// case, exactly one of the aliases matches a topic the current gateway actually publishes, and
+// the other(s) do not appear in it at all - e.g. "doors/boot"/"doors/bonnet" are current,
+// "doors/trunk"/"doors/hood" are not. These are compatibility names for an older gateway
+// version or a differently-configured/forked one, not topics the current gateway emits
+// alongside its canonical name. Safe to drop an alias only after confirming no supported
+// gateway version still uses it.
 public static class TelemetryMapper
 {
     /// <returns>true if the subtopic was recognised and a field was set; false for metadata/unknown topics.</returns>


### PR DESCRIPTION
## Summary
- **`ARCHITECTURE.md`** (new): service topology diagram, the telemetry-to-browser data flow (MQTT -> Worker -> Postgres -> pg_notify -> Api -> SignalR -> frontend), the reverse command-to-car flow, a project dependency table, and a "why no Redis" note reconciling `CLAUDE.md`'s caching suggestion with the actual design (short-TTL `IMemoryCache` for the telemetry hot path + Postgres-backed POI tiles, since this is a single-instance deployment). Linked from `CONTRIBUTING.md`, along with a pointer to `DEMO.md` for contributors without a real MG account/vehicle.
- **XML docs** on the five `GarageStack.Core` interfaces (`ITelemetryRepository`, `IVehicleRepository`, `IPoiRepository`, `IMqttPublisher`, `IPushSender`) -- the actual Api/Worker/Data abstraction boundary -- plus two models where the field semantics genuinely aren't obvious from the name alone (`AppNotification.IsArchived` vs `IsDeleted`, `TelemetrySnapshot.RawTopic`). Left self-descriptive properties alone rather than adding a one-line summary to every field, which would just be noise.
- **`TelemetryMapper.cs`** alias rationale: checked the pinned `saic-mqtt-gateway` version's own topic list (`src/mqtt_topics.py` upstream) and confirmed every alias that doesn't match its current schema (`doors/trunk`, `doors/hood`, `drivetrain/fuelLevel`, `drivetrain/odometer`, etc.) doesn't appear in it at all -- so a future contributor knows these are compatibility names for an older/different gateway version, not topics the current gateway also emits alongside its canonical name.

These are the P3 (documentation) items from a broader codebase review; P0 (#273), P1 (#274), and P2 (#275) are already merged.

## Test plan
- [x] `dotnet build` -- 0 warnings/errors
- [x] `dotnet test` -- 335/335 passing (no code behavior changed, only comments/docs)
- [x] Verified every file path linked from `ARCHITECTURE.md` actually exists, and the documented `POST /api/vehicles/{vin}/commands/{command}` route matches `VehicleEndpoints.cs`
- [x] Documentation only -- no runtime surface to exercise in a browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)