### PR TITLE
fix: i18n gaps, DEMO.md accuracy, Worker healthcheck, and cooldown-gate dedup

### DIFF
--- a/DEMO.md
+++ b/DEMO.md
@@ -97,8 +97,8 @@ No PostgreSQL, Mosquitto, Worker, or SAIC gateway containers are started.
 | Variable | Default | Description |
 | --- | --- | --- |
 | `DEMO_MODE` | `false` | Set to `true` to activate demo mode |
-| `AUTH_USERNAME` | _(required)_ | Login username |
-| `AUTH_PASSWORD` | _(required)_ | Login password |
+| `AUTH_USERNAME` | `demo` | Login username |
+| `AUTH_PASSWORD` | `demo` | Login password |
 | `JWT_SECRET` | _(required)_ | Min 32 chars, used to sign tokens |
 | `FRONTEND_PORT` | `8080` | Host port for the frontend container |
 | `API_PORT` | `5001` | Host port for the API container |

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -165,7 +165,12 @@ watch(
 
     <!-- Mobile topbar -->
     <header class="mobile-topbar">
-      <button class="hamburger" :aria-expanded="menuOpen" aria-label="Menu" @click="toggleMenu">
+      <button
+        class="hamburger"
+        :aria-expanded="menuOpen"
+        :aria-label="t('nav.menuLabel')"
+        @click="toggleMenu"
+      >
         <font-awesome-icon :icon="menuOpen ? 'xmark' : 'bars'" />
       </button>
       <RouterLink to="/" class="mobile-brand">

--- a/frontend/src/components/CarDiagram.vue
+++ b/frontend/src/components/CarDiagram.vue
@@ -261,7 +261,7 @@ const activeLightKey = computed(() => {
             viewBox="-40 0 420 480"
             xmlns="http://www.w3.org/2000/svg"
             class="tyre-diagram__svg"
-            aria-label="Vehicle status diagram"
+            :aria-label="t('vehicle.diagramLabel')"
           >
             <defs>
               <!--

--- a/frontend/src/composables/__tests__/useVehicleAlerts.spec.ts
+++ b/frontend/src/composables/__tests__/useVehicleAlerts.spec.ts
@@ -1,7 +1,34 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { ref, nextTick } from 'vue'
+import { createI18n } from 'vue-i18n'
 import { getOpenItems, getTyrePressureAlerts, useVehicleAlerts } from '../useVehicleAlerts'
 import type { TelemetrySnapshot } from '@/services/vehicleApi'
+
+const i18n = createI18n({
+  legacy: false,
+  locale: 'en',
+  messages: {
+    en: {
+      vehicle: {
+        alerts: {
+          openWhileParked: 'Open while parked: {items}',
+          tyrePressure: 'Tyre pressure: {items}',
+          driverDoor: 'driver door',
+          passengerDoor: 'passenger door',
+          rearLeftDoor: 'rear left door',
+          rearRightDoor: 'rear right door',
+          boot: 'boot',
+          bonnet: 'bonnet',
+          driverWindow: 'driver window',
+          passengerWindow: 'passenger window',
+          rearLeftWindow: 'rear left window',
+          rearRightWindow: 'rear right window',
+        },
+      },
+    },
+  },
+})
+const t = i18n.global.t
 
 function makeSnapshot(overrides: Partial<TelemetrySnapshot> = {}): TelemetrySnapshot {
   return {
@@ -85,7 +112,7 @@ function makeSnapshot(overrides: Partial<TelemetrySnapshot> = {}): TelemetrySnap
 
 describe('getOpenItems', () => {
   it('returns empty array when all values are null', () => {
-    expect(getOpenItems(makeSnapshot())).toEqual([])
+    expect(getOpenItems(makeSnapshot(), t)).toEqual([])
   })
 
   it('returns empty array when all items are closed', () => {
@@ -96,26 +123,27 @@ describe('getOpenItems', () => {
           passengerDoorOpen: false,
           sunRoofOpen: false,
         }),
+        t,
       ),
     ).toEqual([])
   })
 
   it('detects open driver door', () => {
-    expect(getOpenItems(makeSnapshot({ driverDoorOpen: true }))).toContain('driver door')
+    expect(getOpenItems(makeSnapshot({ driverDoorOpen: true }), t)).toContain('driver door')
   })
 
   it('detects open passenger door', () => {
-    expect(getOpenItems(makeSnapshot({ passengerDoorOpen: true }))).toContain('passenger door')
+    expect(getOpenItems(makeSnapshot({ passengerDoorOpen: true }), t)).toContain('passenger door')
   })
 
   it('detects open rear doors', () => {
-    const items = getOpenItems(makeSnapshot({ rearLeftDoorOpen: true, rearRightDoorOpen: true }))
+    const items = getOpenItems(makeSnapshot({ rearLeftDoorOpen: true, rearRightDoorOpen: true }), t)
     expect(items).toContain('rear left door')
     expect(items).toContain('rear right door')
   })
 
   it('detects open boot and bonnet', () => {
-    const items = getOpenItems(makeSnapshot({ trunkOpen: true, bonnetOpen: true }))
+    const items = getOpenItems(makeSnapshot({ trunkOpen: true, bonnetOpen: true }), t)
     expect(items).toContain('boot')
     expect(items).toContain('bonnet')
   })
@@ -128,6 +156,7 @@ describe('getOpenItems', () => {
         rearLeftWindowOpen: true,
         rearRightWindowOpen: true,
       }),
+      t,
     )
     expect(items).toContain('driver window')
     expect(items).toContain('passenger window')
@@ -136,7 +165,7 @@ describe('getOpenItems', () => {
   })
 
   it('returns only open items when mixed', () => {
-    const items = getOpenItems(makeSnapshot({ driverDoorOpen: true, passengerDoorOpen: false }))
+    const items = getOpenItems(makeSnapshot({ driverDoorOpen: true, passengerDoorOpen: false }), t)
     expect(items).toHaveLength(1)
     expect(items).toContain('driver door')
   })
@@ -244,14 +273,14 @@ describe('useVehicleAlerts', () => {
 
   it('does not fire when status is null', async () => {
     const status = ref<TelemetrySnapshot | null>(null)
-    useVehicleAlerts(status)
+    useVehicleAlerts(status, t)
     await nextTick()
     expect(notificationMock).not.toHaveBeenCalled()
   })
 
   it('fires open-while-parked notification when door is open and engine off', async () => {
     const status = ref<TelemetrySnapshot | null>(null)
-    useVehicleAlerts(status)
+    useVehicleAlerts(status, t)
     status.value = makeSnapshot({ engineRunning: false, driverDoorOpen: true })
     await nextTick()
     expect(notificationMock).toHaveBeenCalledWith(
@@ -262,7 +291,7 @@ describe('useVehicleAlerts', () => {
 
   it('does not fire open notification when engine is running', async () => {
     const status = ref<TelemetrySnapshot | null>(null)
-    useVehicleAlerts(status)
+    useVehicleAlerts(status, t)
     status.value = makeSnapshot({ engineRunning: true, driverDoorOpen: true })
     await nextTick()
     expect(notificationMock).not.toHaveBeenCalled()
@@ -270,7 +299,7 @@ describe('useVehicleAlerts', () => {
 
   it('does not repeat open notification on subsequent polls while still open', async () => {
     const status = ref<TelemetrySnapshot | null>(null)
-    useVehicleAlerts(status)
+    useVehicleAlerts(status, t)
     status.value = makeSnapshot({ engineRunning: false, driverDoorOpen: true })
     await nextTick()
     status.value = makeSnapshot({ engineRunning: false, driverDoorOpen: true })
@@ -280,7 +309,7 @@ describe('useVehicleAlerts', () => {
 
   it('resets and re-fires open alert after door closes then reopens', async () => {
     const status = ref<TelemetrySnapshot | null>(null)
-    useVehicleAlerts(status)
+    useVehicleAlerts(status, t)
     status.value = makeSnapshot({ engineRunning: false, driverDoorOpen: true })
     await nextTick()
     status.value = makeSnapshot({ engineRunning: false, driverDoorOpen: false })
@@ -292,7 +321,7 @@ describe('useVehicleAlerts', () => {
 
   it('fires tyre pressure notification when pressure is low', async () => {
     const status = ref<TelemetrySnapshot | null>(null)
-    useVehicleAlerts(status)
+    useVehicleAlerts(status, t)
     status.value = makeSnapshot({ tyrePressureFrontLeft: 1.5 })
     await nextTick()
     expect(notificationMock).toHaveBeenCalledWith(
@@ -303,7 +332,7 @@ describe('useVehicleAlerts', () => {
 
   it('does not repeat tyre alert on subsequent polls while still low', async () => {
     const status = ref<TelemetrySnapshot | null>(null)
-    useVehicleAlerts(status)
+    useVehicleAlerts(status, t)
     status.value = makeSnapshot({ tyrePressureFrontLeft: 1.5 })
     await nextTick()
     status.value = makeSnapshot({ tyrePressureFrontLeft: 1.5 })
@@ -313,7 +342,7 @@ describe('useVehicleAlerts', () => {
 
   it('does not fire open notification when engineRunning is null (unknown state)', async () => {
     const status = ref<TelemetrySnapshot | null>(null)
-    useVehicleAlerts(status)
+    useVehicleAlerts(status, t)
     status.value = makeSnapshot({ engineRunning: null, driverDoorOpen: true })
     await nextTick()
     expect(notificationMock).not.toHaveBeenCalled()
@@ -326,7 +355,7 @@ describe('useVehicleAlerts', () => {
       configurable: true,
     })
     const status = ref<TelemetrySnapshot | null>(null)
-    useVehicleAlerts(status)
+    useVehicleAlerts(status, t)
     status.value = makeSnapshot({ engineRunning: false, driverDoorOpen: true })
     await nextTick()
     expect(notificationMock).not.toHaveBeenCalled()

--- a/frontend/src/composables/useVehicleAlerts.ts
+++ b/frontend/src/composables/useVehicleAlerts.ts
@@ -7,18 +7,25 @@ import {
   type TyrePressureThresholds,
 } from '@/composables/useTyrePressureThresholds'
 
-export function getOpenItems(s: TelemetrySnapshot): string[] {
+// `t` is injected rather than obtained via useI18n() here so these stay plain, directly
+// testable functions - useI18n() requires an active component setup context, which these
+// don't have when called from useVehicleAlerts's own unit tests. A minimal structural type
+// (rather than vue-i18n's own ComposerTranslation) avoids coupling to a specific locale's
+// message-key generics, which differ between the app's real i18n instance and a test one.
+type Translate = (key: string, named?: Record<string, unknown>) => string
+
+export function getOpenItems(s: TelemetrySnapshot, t: Translate): string[] {
   const open: string[] = []
-  if (s.driverDoorOpen) open.push('driver door')
-  if (s.passengerDoorOpen) open.push('passenger door')
-  if (s.rearLeftDoorOpen) open.push('rear left door')
-  if (s.rearRightDoorOpen) open.push('rear right door')
-  if (s.trunkOpen) open.push('boot')
-  if (s.bonnetOpen) open.push('bonnet')
-  if (s.driverWindowOpen) open.push('driver window')
-  if (s.passengerWindowOpen) open.push('passenger window')
-  if (s.rearLeftWindowOpen) open.push('rear left window')
-  if (s.rearRightWindowOpen) open.push('rear right window')
+  if (s.driverDoorOpen) open.push(t('vehicle.alerts.driverDoor'))
+  if (s.passengerDoorOpen) open.push(t('vehicle.alerts.passengerDoor'))
+  if (s.rearLeftDoorOpen) open.push(t('vehicle.alerts.rearLeftDoor'))
+  if (s.rearRightDoorOpen) open.push(t('vehicle.alerts.rearRightDoor'))
+  if (s.trunkOpen) open.push(t('vehicle.alerts.boot'))
+  if (s.bonnetOpen) open.push(t('vehicle.alerts.bonnet'))
+  if (s.driverWindowOpen) open.push(t('vehicle.alerts.driverWindow'))
+  if (s.passengerWindowOpen) open.push(t('vehicle.alerts.passengerWindow'))
+  if (s.rearLeftWindowOpen) open.push(t('vehicle.alerts.rearLeftWindow'))
+  if (s.rearRightWindowOpen) open.push(t('vehicle.alerts.rearRightWindow'))
   return open
 }
 
@@ -62,20 +69,26 @@ function useStickyAlert<T>(notify: (issues: T[]) => void) {
   }
 }
 
-export function useVehicleAlerts(status: Ref<TelemetrySnapshot | null>) {
+export function useVehicleAlerts(status: Ref<TelemetrySnapshot | null>, t: Translate) {
   const tyreThresholds = useTyrePressureThresholds()
   const checkOpenAlert = useStickyAlert<string>((open) =>
-    showNotification('GarageStack', `Open while parked: ${open.join(', ')}`),
+    showNotification(
+      'GarageStack',
+      t('vehicle.alerts.openWhileParked', { items: open.join(', ') }),
+    ),
   )
   const checkTyreAlert = useStickyAlert<string>((tyreIssues) =>
-    showNotification('GarageStack', `Tyre pressure: ${tyreIssues.join(', ')}`),
+    showNotification(
+      'GarageStack',
+      t('vehicle.alerts.tyrePressure', { items: tyreIssues.join(', ') }),
+    ),
   )
 
   watch(status, (s) => {
     if (!s) return
 
     if (s.engineRunning === false) {
-      checkOpenAlert(getOpenItems(s))
+      checkOpenAlert(getOpenItems(s, t))
     } else if (s.engineRunning === true) {
       checkOpenAlert([])
     }

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -3,7 +3,8 @@
     "dashboard": "Dashboard",
     "statistics": "Statistics",
     "map": "Map",
-    "maintenance": "Maintenance"
+    "maintenance": "Maintenance",
+    "menuLabel": "Menu"
   },
   "dashboard": {
     "title": "Dashboard",
@@ -46,6 +47,7 @@
     }
   },
   "statistics": {
+    "insightsSectionLabel": "Statistics insights",
     "insights": {
       "distanceInRange": "Distance in period",
       "monthlyMileage": "Monthly mileage",
@@ -77,6 +79,7 @@
     "dailyKwhChart": "Daily Electric Usage (kWh)"
   },
   "vehicle": {
+    "diagramLabel": "Vehicle status diagram",
     "wentOnline": "Vehicle is online",
     "wentOffline": "Vehicle went offline",
     "fuel": "Fuel",
@@ -127,6 +130,20 @@
       "rearRight": "Rear right",
       "bonnet": "Bonnet",
       "boot": "Boot"
+    },
+    "alerts": {
+      "openWhileParked": "Open while parked: {items}",
+      "tyrePressure": "Tyre pressure: {items}",
+      "driverDoor": "driver door",
+      "passengerDoor": "passenger door",
+      "rearLeftDoor": "rear left door",
+      "rearRightDoor": "rear right door",
+      "boot": "boot",
+      "bonnet": "bonnet",
+      "driverWindow": "driver window",
+      "passengerWindow": "passenger window",
+      "rearLeftWindow": "rear left window",
+      "rearRightWindow": "rear right window"
     },
     "efficiency": {
       "todayDistance": "Dist. today",
@@ -297,6 +314,7 @@
     }
   },
   "auth": {
+    "formLabel": "Login form",
     "subtitle": "Sign in with your MG account credentials",
     "username": "Username",
     "password": "Password",

--- a/frontend/src/locales/nl.json
+++ b/frontend/src/locales/nl.json
@@ -3,7 +3,8 @@
     "dashboard": "Dashboard",
     "statistics": "Statistieken",
     "map": "Kaart",
-    "maintenance": "Onderhoud"
+    "maintenance": "Onderhoud",
+    "menuLabel": "Menu"
   },
   "dashboard": {
     "title": "Dashboard",
@@ -46,6 +47,7 @@
     }
   },
   "statistics": {
+    "insightsSectionLabel": "Statistiekoverzicht",
     "insights": {
       "distanceInRange": "Afstand in periode",
       "monthlyMileage": "Maandkilometrage",
@@ -77,6 +79,7 @@
     "dailyKwhChart": "Dagelijks elektrisch verbruik (kWh)"
   },
   "vehicle": {
+    "diagramLabel": "Voertuigstatusdiagram",
     "wentOnline": "Voertuig is online",
     "wentOffline": "Voertuig is offline gegaan",
     "fuel": "Brandstof",
@@ -127,6 +130,20 @@
       "rearRight": "Achter rechts",
       "bonnet": "Motorkap",
       "boot": "Kofferruimte"
+    },
+    "alerts": {
+      "openWhileParked": "Open terwijl geparkeerd: {items}",
+      "tyrePressure": "Bandenspanning: {items}",
+      "driverDoor": "bestuurdersdeur",
+      "passengerDoor": "passagiersdeur",
+      "rearLeftDoor": "linkerachterdeur",
+      "rearRightDoor": "rechterachterdeur",
+      "boot": "kofferbak",
+      "bonnet": "motorkap",
+      "driverWindow": "bestuurdersraam",
+      "passengerWindow": "passagiersraam",
+      "rearLeftWindow": "linkerachterraam",
+      "rearRightWindow": "rechterachterraam"
     },
     "efficiency": {
       "todayDistance": "Afst. vandaag",
@@ -297,6 +314,7 @@
     }
   },
   "auth": {
+    "formLabel": "Inlogformulier",
     "subtitle": "Log in met je MG-accountgegevens",
     "username": "Gebruikersnaam",
     "password": "Wachtwoord",

--- a/frontend/src/views/DashboardView.vue
+++ b/frontend/src/views/DashboardView.vue
@@ -114,7 +114,7 @@ watch(
   },
 )
 
-useVehicleAlerts(status)
+useVehicleAlerts(status, t)
 
 function toggleEditMode() {
   editMode.value = !editMode.value

--- a/frontend/src/views/LoginView.vue
+++ b/frontend/src/views/LoginView.vue
@@ -41,7 +41,7 @@ async function submitLogin() {
 
 <template>
   <div class="login-page">
-    <section class="login-card" aria-label="Login form">
+    <section class="login-card" :aria-label="t('auth.formLabel')">
       <div class="login-card__brand">
         <div class="login-card__brand-icon">
           <font-awesome-icon icon="car" />

--- a/frontend/src/views/StatisticsView.vue
+++ b/frontend/src/views/StatisticsView.vue
@@ -672,7 +672,7 @@ const skeletonChartCount = computed(
     </div>
 
     <template v-if="loading">
-      <section class="stats-insights" aria-label="Statistics insights">
+      <section class="stats-insights" :aria-label="t('statistics.insightsSectionLabel')">
         <div class="status-grid">
           <SkeletonCard
             v-for="item in skeletonInsights"
@@ -699,7 +699,7 @@ const skeletonChartCount = computed(
 
       <template v-else>
         <!-- ── Insights ──────────────────────────────────── -->
-        <section class="stats-insights" aria-label="Statistics insights">
+        <section class="stats-insights" :aria-label="t('statistics.insightsSectionLabel')">
           <!-- Edit mode: draggable card slots -->
           <VueDraggable
             v-if="editMode"

--- a/src/GarageStack.Core/Helpers/NotificationCooldownGate.cs
+++ b/src/GarageStack.Core/Helpers/NotificationCooldownGate.cs
@@ -43,4 +43,13 @@ public sealed class NotificationCooldownGate(TimeSpan cooldown)
         lock (_lock) { _lastNotified[key] = DateTime.UtcNow; }
         return true;
     }
+
+    /// <summary>
+    /// Convenience overload: computes the cutoff from <see cref="Cooldown"/> and passes it to
+    /// <paramref name="wasRecentlySentSinceAsync"/>, so callers only need to supply the DB
+    /// check itself (e.g. <c>AppDbContext.WasNotificationSentSinceAsync</c>) instead of also
+    /// managing the cutoff calculation at every call site.
+    /// </summary>
+    public Task<bool> ShouldNotifyAsync(string vin, string category, Func<DateTime, Task<bool>> wasRecentlySentSinceAsync) =>
+        ShouldNotifyAsync(vin, category, () => wasRecentlySentSinceAsync(DateTime.UtcNow - Cooldown));
 }

--- a/src/GarageStack.Data/Extensions/NotificationHistoryExtensions.cs
+++ b/src/GarageStack.Data/Extensions/NotificationHistoryExtensions.cs
@@ -1,0 +1,17 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace GarageStack.Data.Extensions;
+
+public static class NotificationHistoryExtensions
+{
+    /// <summary>
+    /// Checks whether an <c>AppNotification</c> matching <paramref name="category"/> and
+    /// <paramref name="vehicleId"/> was created after <paramref name="cutoff"/> - the standard
+    /// "is this a duplicate" query behind <c>NotificationCooldownGate.ShouldNotifyAsync</c>'s
+    /// DB fallback, kept here in one place so both notification-check services query it the
+    /// same way.
+    /// </summary>
+    public static Task<bool> WasNotificationSentSinceAsync(
+        this AppDbContext db, string category, int vehicleId, DateTime cutoff, CancellationToken ct = default) =>
+        db.AppNotifications.AnyAsync(n => n.Category == category && n.VehicleId == vehicleId && n.CreatedAt > cutoff, ct);
+}

--- a/src/GarageStack.Tests/NotificationCooldownGateTests.cs
+++ b/src/GarageStack.Tests/NotificationCooldownGateTests.cs
@@ -90,4 +90,38 @@ public class NotificationCooldownGateTests
 
         Assert.True(result);
     }
+
+    // ── Cutoff-computing overload (used by MaintenanceCheckService/PushNotificationCheckService
+    // via AppDbContext.WasNotificationSentSinceAsync) ──────────────────────────────────────────
+
+    [Fact]
+    public async Task ShouldNotifyWithCutoff_PassesCooldownDerivedCutoff_ToCallback()
+    {
+        var cooldown = TimeSpan.FromHours(1);
+        var gate = new NotificationCooldownGate(cooldown);
+        var before = DateTime.UtcNow;
+
+        DateTime? receivedCutoff = null;
+        await gate.ShouldNotifyAsync("VIN1", "low-tyre", cutoff =>
+        {
+            receivedCutoff = cutoff;
+            return Task.FromResult(false);
+        });
+
+        Assert.NotNull(receivedCutoff);
+        // The cutoff passed to the callback is "now minus cooldown", computed at call time -
+        // assert it falls within the window this test itself ran in, rather than pinning an
+        // exact timestamp.
+        Assert.InRange(receivedCutoff!.Value, before - cooldown, DateTime.UtcNow - cooldown);
+    }
+
+    [Fact]
+    public async Task ShouldNotifyWithCutoff_DbHasRecentMatch_ReturnsFalse()
+    {
+        var gate = new NotificationCooldownGate(TimeSpan.FromHours(1));
+
+        var result = await gate.ShouldNotifyAsync("VIN1", "engine-start", _ => Task.FromResult(true));
+
+        Assert.False(result);
+    }
 }

--- a/src/GarageStack.Tests/NotificationHistoryExtensionsTests.cs
+++ b/src/GarageStack.Tests/NotificationHistoryExtensionsTests.cs
@@ -1,0 +1,94 @@
+using GarageStack.Core.Models;
+using GarageStack.Data;
+using GarageStack.Data.Extensions;
+using Microsoft.EntityFrameworkCore;
+
+namespace GarageStack.Tests;
+
+public class NotificationHistoryExtensionsTests
+{
+    private static AppDbContext CreateDb() =>
+        new(new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options);
+
+    [Fact]
+    public async Task WasNotificationSentSinceAsync_MatchingRecentNotification_ReturnsTrue()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        await using var db = CreateDb();
+        db.AppNotifications.Add(new AppNotification
+        {
+            Category = "low-tyre",
+            VehicleId = 1,
+            CreatedAt = DateTime.UtcNow.AddMinutes(-5),
+            Title = "Low Tyre Pressure",
+            Body = "...",
+        });
+        await db.SaveChangesAsync(ct);
+
+        var result = await db.WasNotificationSentSinceAsync("low-tyre", 1, DateTime.UtcNow.AddMinutes(-10), ct);
+
+        Assert.True(result);
+    }
+
+    [Fact]
+    public async Task WasNotificationSentSinceAsync_NotificationBeforeCutoff_ReturnsFalse()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        await using var db = CreateDb();
+        db.AppNotifications.Add(new AppNotification
+        {
+            Category = "low-tyre",
+            VehicleId = 1,
+            CreatedAt = DateTime.UtcNow.AddHours(-2),
+            Title = "Low Tyre Pressure",
+            Body = "...",
+        });
+        await db.SaveChangesAsync(ct);
+
+        var result = await db.WasNotificationSentSinceAsync("low-tyre", 1, DateTime.UtcNow.AddHours(-1), ct);
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public async Task WasNotificationSentSinceAsync_DifferentVehicle_ReturnsFalse()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        await using var db = CreateDb();
+        db.AppNotifications.Add(new AppNotification
+        {
+            Category = "low-tyre",
+            VehicleId = 2,
+            CreatedAt = DateTime.UtcNow.AddMinutes(-5),
+            Title = "Low Tyre Pressure",
+            Body = "...",
+        });
+        await db.SaveChangesAsync(ct);
+
+        var result = await db.WasNotificationSentSinceAsync("low-tyre", 1, DateTime.UtcNow.AddMinutes(-10), ct);
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public async Task WasNotificationSentSinceAsync_DifferentCategory_ReturnsFalse()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        await using var db = CreateDb();
+        db.AppNotifications.Add(new AppNotification
+        {
+            Category = "high-tyre",
+            VehicleId = 1,
+            CreatedAt = DateTime.UtcNow.AddMinutes(-5),
+            Title = "High Tyre Pressure",
+            Body = "...",
+        });
+        await db.SaveChangesAsync(ct);
+
+        var result = await db.WasNotificationSentSinceAsync("low-tyre", 1, DateTime.UtcNow.AddMinutes(-10), ct);
+
+        Assert.False(result);
+    }
+}

--- a/src/GarageStack.Worker/Dockerfile
+++ b/src/GarageStack.Worker/Dockerfile
@@ -19,9 +19,14 @@ ARG OS_PATCH_DATE=0
 RUN echo "os patch date: ${OS_PATCH_DATE}" \
 	&& apt-get update \
 	&& apt-get upgrade -y \
-	&& apt-get install -y --no-install-recommends libgssapi-krb5-2 gosu \
+	&& apt-get install -y --no-install-recommends libgssapi-krb5-2 gosu procps \
 	&& rm -rf /var/lib/apt/lists/*
 COPY --from=build /app .
 COPY src/GarageStack.Worker/docker-entrypoint.sh /docker-entrypoint.sh
 RUN chmod +x /docker-entrypoint.sh
+# The Worker has no HTTP listener to probe (unlike Api/frontend), so this only checks the
+# dotnet process is still alive - weaker than a real liveness signal (can't detect a hang),
+# but still correctly flips unhealthy if the process crashes or exits.
+HEALTHCHECK --interval=30s --timeout=5s --start-period=15s --retries=3 \
+	CMD pgrep -f GarageStack.Worker.dll || exit 1
 ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/src/GarageStack.Worker/Services/MaintenanceCheckService.cs
+++ b/src/GarageStack.Worker/Services/MaintenanceCheckService.cs
@@ -2,6 +2,7 @@ using GarageStack.Core.Helpers;
 using GarageStack.Core.Interfaces;
 using GarageStack.Core.Models;
 using GarageStack.Data;
+using GarageStack.Data.Extensions;
 using Microsoft.EntityFrameworkCore;
 
 namespace GarageStack.Worker.Services;
@@ -62,9 +63,8 @@ public class MaintenanceCheckService(
                 var alert = BuildAlert(item, result);
                 if (alert is null) continue;
 
-                var cutoff = DateTime.UtcNow - _cooldownGate.Cooldown;
-                var shouldNotify = await _cooldownGate.ShouldNotifyAsync(vehicle.Vin, alert.Value.Category, () =>
-                    db.AppNotifications.AnyAsync(n => n.Category == alert.Value.Category && n.VehicleId == vehicle.Id && n.CreatedAt > cutoff, ct));
+                var shouldNotify = await _cooldownGate.ShouldNotifyAsync(vehicle.Vin, alert.Value.Category, cutoff =>
+                    db.WasNotificationSentSinceAsync(alert.Value.Category, vehicle.Id, cutoff, ct));
                 if (!shouldNotify) continue;
 
                 await pushSender.SendToAllAsync(alert.Value.Title, alert.Value.Body, ct, alert.Value.Category, vehicle.Id);

--- a/src/GarageStack.Worker/Services/PushNotificationCheckService.cs
+++ b/src/GarageStack.Worker/Services/PushNotificationCheckService.cs
@@ -2,6 +2,7 @@ using GarageStack.Core.Configuration;
 using GarageStack.Core.Helpers;
 using GarageStack.Core.Interfaces;
 using GarageStack.Data;
+using GarageStack.Data.Extensions;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -82,9 +83,8 @@ public class PushNotificationCheckService(
                 // another vehicle's same-category alert; this also lets MQTT-emitted notifications
                 // (e.g. engine-start, sent directly from MqttConsumerService) suppress a repeated
                 // checker alert for the same category.
-                var cutoff = DateTime.UtcNow - _cooldownGate.Cooldown;
-                var shouldNotify = await _cooldownGate.ShouldNotifyAsync(vehicle.Vin, key, () =>
-                    db.AppNotifications.AnyAsync(n => n.Category == key && n.VehicleId == vehicle.Id && n.CreatedAt > cutoff, ct));
+                var shouldNotify = await _cooldownGate.ShouldNotifyAsync(vehicle.Vin, key, cutoff =>
+                    db.WasNotificationSentSinceAsync(key, vehicle.Id, cutoff, ct));
                 if (!shouldNotify) continue;
 
                 await pushSender.SendToAllAsync(title, body, ct, key, vehicle.Id);


### PR DESCRIPTION
## Summary

Four small, independent fixes found during a follow-up review (same criteria as the prior review whose fixes are merged: #273, #274, #275, #276, #277):

- **i18n gaps**: `useVehicleAlerts.ts` bypassed vue-i18n entirely for native browser Notification text (the one place in an otherwise fully-translated app where Dutch users got English text), and four hardcoded `aria-label`s (`CarDiagram`, `LoginView`, `StatisticsView`, `App.vue`'s hamburger menu) meant Dutch-locale screen-reader users got English announcements. Both wired through `t()` with new locale keys in `en.json`/`nl.json`.
- **`DEMO.md`**: fixed a table listing `AUTH_USERNAME`/`AUTH_PASSWORD` as `(required)` when `docker-compose.demo.yml` actually defaults both to `demo`/`demo`.
- **Worker `Dockerfile`**: added a `HEALTHCHECK`, matching the Api/frontend/all-in-one images. The Worker has no HTTP listener to probe, so this checks the `dotnet` process is alive via `pgrep` -- weaker than a real liveness signal, but still correctly flips unhealthy if the process crashes.
- **`NotificationCooldownGate`**: an earlier PR (#275) unified the cooldown logic itself, but the "compute cutoff, then query `AppNotifications`" glue around it was still copy-pasted in both callers. Added a cutoff-computing overload plus a `WasNotificationSentSinceAsync` extension on `AppDbContext` (in `GarageStack.Data`, since `Core` can't reference the DB context) so the actual duplicate-check query lives in one place.

## Test plan
- [x] `dotnet build` / `dotnet test` -- 341/341 passing (6 new tests for the cooldown-gate overload and the new extension method)
- [x] `vue-tsc --build`, `oxlint`/`eslint`, `prettier --write` -- all clean
- [x] `pnpm test:unit` -- 245/245 passing (test file updated for `useVehicleAlerts`'s new injected-`t` signature)
- [x] Built the Worker image locally, ran it, and confirmed `docker inspect` reports `healthy` once the process is up and `unhealthy`-capable via `pgrep`
- [x] Manually verified in a real browser (demo mode, Dutch locale seeded via the app's own settings storage): dashboard renders correctly with translated section labels (`Statistiekoverzicht`), confirmed no vue-i18n missing-key console warnings anywhere

🤖 Generated with [Claude Code](https://claude.com/claude-code)