### PR TITLE
refactor: extract useBooleanStatusList and evict stale cooldown entries

### DIFF
--- a/frontend/src/components/DoorsCard.vue
+++ b/frontend/src/components/DoorsCard.vue
@@ -5,6 +5,7 @@ import ExpandableStatusCard from './ExpandableStatusCard.vue'
 import DetailListItem from './DetailListItem.vue'
 import CommandButton from './CommandButton.vue'
 import { useVehicleCommand } from '@/composables/useVehicleCommand'
+import { useBooleanStatusList } from '@/composables/useBooleanStatusList'
 
 const { t } = useI18n()
 
@@ -31,50 +32,39 @@ watch(
   },
 )
 
-type DoorItem = { key: string; label: string; icon: string; open: boolean }
-
-const doorList = computed((): DoorItem[] =>
-  (
-    [
-      {
-        key: 'driver',
-        label: t('vehicle.doors_detail.driver'),
-        icon: 'door-open',
-        open: props.driverDoorOpen,
-      },
-      {
-        key: 'passenger',
-        label: t('vehicle.doors_detail.passenger'),
-        icon: 'door-open',
-        open: props.passengerDoorOpen,
-      },
-      {
-        key: 'rearLeft',
-        label: t('vehicle.doors_detail.rearLeft'),
-        icon: 'door-open',
-        open: props.rearLeftDoorOpen,
-      },
-      {
-        key: 'rearRight',
-        label: t('vehicle.doors_detail.rearRight'),
-        icon: 'door-open',
-        open: props.rearRightDoorOpen,
-      },
-      {
-        key: 'bonnet',
-        label: t('vehicle.doors_detail.bonnet'),
-        icon: 'car-burst',
-        open: props.bonnetOpen,
-      },
-      {
-        key: 'boot',
-        label: t('vehicle.doors_detail.boot'),
-        icon: 'car-rear',
-        open: props.trunkOpen,
-      },
-    ] as { key: string; label: string; icon: string; open: boolean | null }[]
-  ).filter((d): d is DoorItem => d.open !== null),
-)
+const doorList = useBooleanStatusList(() => [
+  {
+    key: 'driver',
+    label: t('vehicle.doors_detail.driver'),
+    icon: 'door-open',
+    open: props.driverDoorOpen,
+  },
+  {
+    key: 'passenger',
+    label: t('vehicle.doors_detail.passenger'),
+    icon: 'door-open',
+    open: props.passengerDoorOpen,
+  },
+  {
+    key: 'rearLeft',
+    label: t('vehicle.doors_detail.rearLeft'),
+    icon: 'door-open',
+    open: props.rearLeftDoorOpen,
+  },
+  {
+    key: 'rearRight',
+    label: t('vehicle.doors_detail.rearRight'),
+    icon: 'door-open',
+    open: props.rearRightDoorOpen,
+  },
+  {
+    key: 'bonnet',
+    label: t('vehicle.doors_detail.bonnet'),
+    icon: 'car-burst',
+    open: props.bonnetOpen,
+  },
+  { key: 'boot', label: t('vehicle.doors_detail.boot'), icon: 'car-rear', open: props.trunkOpen },
+])
 
 const openDoors = computed(() => doorList.value.filter((d) => d.open))
 

--- a/frontend/src/components/LightsCard.vue
+++ b/frontend/src/components/LightsCard.vue
@@ -3,6 +3,7 @@ import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import ExpandableStatusCard from './ExpandableStatusCard.vue'
 import DetailListItem from './DetailListItem.vue'
+import { useBooleanStatusList } from '@/composables/useBooleanStatusList'
 
 const { t } = useI18n()
 
@@ -12,19 +13,13 @@ const props = defineProps<{
   side: boolean | null
 }>()
 
-type LightItem = { key: string; label: string; on: boolean }
+const lightList = useBooleanStatusList(() => [
+  { key: 'main', label: t('vehicle.lights.mainBeam'), open: props.mainBeam },
+  { key: 'dipped', label: t('vehicle.lights.dippedBeam'), open: props.dippedBeam },
+  { key: 'side', label: t('vehicle.lights.side'), open: props.side },
+])
 
-const lightList = computed((): LightItem[] =>
-  (
-    [
-      { key: 'main', label: t('vehicle.lights.mainBeam'), on: props.mainBeam },
-      { key: 'dipped', label: t('vehicle.lights.dippedBeam'), on: props.dippedBeam },
-      { key: 'side', label: t('vehicle.lights.side'), on: props.side },
-    ] as { key: string; label: string; on: boolean | null }[]
-  ).filter((l): l is LightItem => l.on !== null),
-)
-
-const activeLights = computed(() => lightList.value.filter((l) => l.on))
+const activeLights = computed(() => lightList.value.filter((l) => l.open))
 
 const summary = computed((): string | null => {
   if (lightList.value.length === 0) return null
@@ -47,11 +42,11 @@ const summary = computed((): string | null => {
         :key="light.key"
         icon="lightbulb"
         :label="light.label"
-        :alert="light.on"
+        :alert="light.open"
       >
         <template #value>
-          <span class="badge" :class="light.on ? 'badge-warning' : 'badge-secondary'">
-            {{ light.on ? t('common.on') : t('common.off') }}
+          <span class="badge" :class="light.open ? 'badge-warning' : 'badge-secondary'">
+            {{ light.open ? t('common.on') : t('common.off') }}
           </span>
         </template>
       </DetailListItem>

--- a/frontend/src/components/WindowsCard.vue
+++ b/frontend/src/components/WindowsCard.vue
@@ -3,6 +3,7 @@ import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import ExpandableStatusCard from './ExpandableStatusCard.vue'
 import DetailListItem from './DetailListItem.vue'
+import { useBooleanStatusList } from '@/composables/useBooleanStatusList'
 
 const { t } = useI18n()
 
@@ -13,30 +14,12 @@ const props = defineProps<{
   rearRightWindowOpen: boolean | null
 }>()
 
-type WinItem = { key: string; label: string; open: boolean }
-
-const windowList = computed((): WinItem[] =>
-  (
-    [
-      { key: 'driver', label: t('vehicle.doors_detail.driver'), open: props.driverWindowOpen },
-      {
-        key: 'passenger',
-        label: t('vehicle.doors_detail.passenger'),
-        open: props.passengerWindowOpen,
-      },
-      {
-        key: 'rearLeft',
-        label: t('vehicle.doors_detail.rearLeft'),
-        open: props.rearLeftWindowOpen,
-      },
-      {
-        key: 'rearRight',
-        label: t('vehicle.doors_detail.rearRight'),
-        open: props.rearRightWindowOpen,
-      },
-    ] as { key: string; label: string; open: boolean | null }[]
-  ).filter((w): w is WinItem => w.open !== null),
-)
+const windowList = useBooleanStatusList(() => [
+  { key: 'driver', label: t('vehicle.doors_detail.driver'), open: props.driverWindowOpen },
+  { key: 'passenger', label: t('vehicle.doors_detail.passenger'), open: props.passengerWindowOpen },
+  { key: 'rearLeft', label: t('vehicle.doors_detail.rearLeft'), open: props.rearLeftWindowOpen },
+  { key: 'rearRight', label: t('vehicle.doors_detail.rearRight'), open: props.rearRightWindowOpen },
+])
 
 const openWindows = computed(() => windowList.value.filter((w) => w.open))
 

--- a/frontend/src/composables/__tests__/useBooleanStatusList.spec.ts
+++ b/frontend/src/composables/__tests__/useBooleanStatusList.spec.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest'
+import { ref } from 'vue'
+import { useBooleanStatusList } from '../useBooleanStatusList'
+
+describe('useBooleanStatusList', () => {
+  it('drops candidates whose open value is null', () => {
+    const list = useBooleanStatusList(() => [
+      { key: 'a', label: 'A', open: true },
+      { key: 'b', label: 'B', open: null },
+      { key: 'c', label: 'C', open: false },
+    ])
+
+    expect(list.value).toEqual([
+      { key: 'a', label: 'A', open: true },
+      { key: 'c', label: 'C', open: false },
+    ])
+  })
+
+  it('returns an empty array when everything is null', () => {
+    const list = useBooleanStatusList(() => [
+      { key: 'a', label: 'A', open: null },
+      { key: 'b', label: 'B', open: null },
+    ])
+
+    expect(list.value).toEqual([])
+  })
+
+  it('preserves extra fields beyond key/label/open', () => {
+    const list = useBooleanStatusList(() => [
+      { key: 'a', label: 'A', icon: 'door-open', open: true },
+    ])
+
+    expect(list.value).toEqual([{ key: 'a', label: 'A', icon: 'door-open', open: true }])
+  })
+
+  it('is reactive to changes in the source candidates', () => {
+    // Mirrors real usage: candidates() closes over a Vue prop/ref, so the returned computed
+    // re-evaluates whenever that reactive dependency changes.
+    const open = ref<boolean | null>(null)
+    const list = useBooleanStatusList(() => [{ key: 'a', label: 'A', open: open.value }])
+
+    expect(list.value).toEqual([])
+
+    open.value = true
+    expect(list.value).toEqual([{ key: 'a', label: 'A', open: true }])
+  })
+})

--- a/frontend/src/composables/useBooleanStatusList.ts
+++ b/frontend/src/composables/useBooleanStatusList.ts
@@ -1,0 +1,17 @@
+import { computed, type ComputedRef } from 'vue'
+
+/** A candidate item before filtering - `open` is null when the vehicle hasn't reported this field. */
+export type BooleanStatusCandidate = { key: string; label: string; open: boolean | null }
+
+/**
+ * Builds a reactive list of {key, label, open, ...} items from candidates whose `open` may be
+ * null, dropping the null ones and narrowing `open` to `boolean` - the shared shape behind
+ * DoorsCard/WindowsCard/LightsCard's per-item status lists (doors, windows, lights).
+ */
+export function useBooleanStatusList<T extends BooleanStatusCandidate>(
+  candidates: () => T[],
+): ComputedRef<(T & { open: boolean })[]> {
+  return computed(() =>
+    candidates().filter((item): item is T & { open: boolean } => item.open !== null),
+  )
+}

--- a/src/GarageStack.Core/GarageStack.Core.csproj
+++ b/src/GarageStack.Core/GarageStack.Core.csproj
@@ -12,4 +12,8 @@
     <PackageReference Include="MinVer" Version="7.0.0" PrivateAssets="all" />
   </ItemGroup>
 
+  <ItemGroup>
+    <InternalsVisibleTo Include="GarageStack.Tests" />
+  </ItemGroup>
+
 </Project>

--- a/src/GarageStack.Core/Helpers/NotificationCooldownGate.cs
+++ b/src/GarageStack.Core/Helpers/NotificationCooldownGate.cs
@@ -10,7 +10,7 @@ public sealed class NotificationCooldownGate(TimeSpan cooldown)
 {
     public TimeSpan Cooldown { get; } = cooldown;
 
-    private readonly Dictionary<string, DateTime> _lastNotified = new();
+    internal readonly Dictionary<string, DateTime> _lastNotified = new();
 
     // Guards _lastNotified: callers invoke ShouldNotifyAsync from a single BackgroundService
     // loop today, but this class makes no assumption about that staying true.
@@ -28,6 +28,7 @@ public sealed class NotificationCooldownGate(TimeSpan cooldown)
 
         lock (_lock)
         {
+            EvictExpired();
             if (_lastNotified.TryGetValue(key, out var last) && DateTime.UtcNow - last < Cooldown)
                 return false;
         }
@@ -42,5 +43,26 @@ public sealed class NotificationCooldownGate(TimeSpan cooldown)
 
         lock (_lock) { _lastNotified[key] = DateTime.UtcNow; }
         return true;
+    }
+
+    // Called with _lock already held. An entry past Cooldown provides no further dedup value
+    // (the TryGetValue check above would ignore it anyway), so this is a pure memory-cleanup
+    // sweep with no behavioral effect - keeps a long-lived gate (e.g. maintenance items that
+    // get deleted and never checked again) from growing forever.
+    private void EvictExpired()
+    {
+        if (_lastNotified.Count == 0) return;
+
+        var now = DateTime.UtcNow;
+        List<string>? expired = null;
+        foreach (var (key, last) in _lastNotified)
+        {
+            if (now - last >= Cooldown)
+                (expired ??= []).Add(key);
+        }
+        if (expired is null) return;
+
+        foreach (var key in expired)
+            _lastNotified.Remove(key);
     }
 }

--- a/src/GarageStack.Tests/NotificationCooldownGateTests.cs
+++ b/src/GarageStack.Tests/NotificationCooldownGateTests.cs
@@ -90,4 +90,25 @@ public class NotificationCooldownGateTests
 
         Assert.True(result);
     }
+
+    [Fact]
+    public async Task ShouldNotify_ExpiredEntry_IsEvictedOnNextCall()
+    {
+        // Regression test for unbounded growth: a key that will never be queried again (e.g. a
+        // deleted maintenance item) must not linger in _lastNotified forever once its cooldown
+        // has passed - any later call (for any key) should sweep it out.
+        var ct = TestContext.Current.CancellationToken;
+        var gate = new NotificationCooldownGate(TimeSpan.FromMilliseconds(10));
+
+        await gate.ShouldNotifyAsync("VIN1", "maintenance-overdue-1", () => Task.FromResult(false));
+        Assert.Single(gate._lastNotified);
+
+        await Task.Delay(TimeSpan.FromMilliseconds(50), ct);
+        await gate.ShouldNotifyAsync("VIN1", "maintenance-overdue-2", () => Task.FromResult(false));
+
+        // The expired "maintenance-overdue-1" entry was evicted, leaving only the fresh one.
+        Assert.Single(gate._lastNotified);
+        Assert.DoesNotContain("VIN1/maintenance-overdue-1", gate._lastNotified.Keys);
+        Assert.Contains("VIN1/maintenance-overdue-2", gate._lastNotified.Keys);
+    }
 }


### PR DESCRIPTION
## Summary

Two optional polish items from a follow-up review (same criteria as the prior review, whose fixes are merged: #273-#278):

- **`useBooleanStatusList` composable**: the "build a `{key, label, open}` list from nullable boolean props, dropping the nulls" pattern was independently duplicated in `DoorsCard.vue` and `WindowsCard.vue`; a prior review left this as minor/optional. `LightsCard.vue` has since grown the same pattern as its own third, independent copy -- three occurrences tipped this from "not worth it yet" to worth extracting. `LightsCard`'s internal `on` field is renamed to `open` to share the same shape (a private computed's field name, not observable outside the component).
- **`NotificationCooldownGate` eviction**: `_lastNotified` was only ever added to, never pruned. `MaintenanceCheckService`'s cooldown key embeds the maintenance item's DB id, so deleting and re-adding an item leaked one never-evicted entry per occurrence for the life of the process. An expired entry provides no further dedup value anyway (the existing `TryGetValue` check already ignores it once its cooldown has passed), so sweeping it out is a pure memory-cleanup change with zero behavioral effect -- confirmed by a new regression test that checks the internal dictionary shrinks back down after a sweep.

## Test plan
- [x] `dotnet build` / `dotnet test` -- 336/336 passing (1 new eviction regression test)
- [x] `vue-tsc --build`, `oxlint`/`eslint`, `prettier --write` -- all clean
- [x] `pnpm test:unit` -- 249/249 passing (4 new tests for `useBooleanStatusList`, including a reactivity check)
- [x] Manually verified in a real browser (demo mode): opened the Doors, Windows, and Lights card modals and confirmed all render identically to before the refactor

🤖 Generated with [Claude Code](https://claude.com/claude-code)