### PR TITLE
fix: gate MqttConsumerService's engine-start push through the cooldown gate

### DIFF
--- a/src/GarageStack.Tests/MqttConsumerServiceTests.cs
+++ b/src/GarageStack.Tests/MqttConsumerServiceTests.cs
@@ -1,6 +1,8 @@
 using GarageStack.Core.Interfaces;
 using GarageStack.Core.Models;
+using GarageStack.Data;
 using GarageStack.Worker.Mqtt;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using MQTTnet;
@@ -187,6 +189,13 @@ public class MqttConsumerServiceTests
             new FakeServiceScopeFactory(),
             push);
 
+    // CheckEngineStartAsync's cooldown gate checks AppNotifications via this db - an empty
+    // in-memory context is enough for these tests since none of them pre-seed a notification row.
+    private static AppDbContext CreateTestDb() =>
+        new(new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options);
+
     [Fact]
     public async Task MergeOrAddTelemetryAsync_ConcurrentCallsSameVehicle_SecondCallMergesInsteadOfRacing()
     {
@@ -210,11 +219,13 @@ public class MqttConsumerServiceTests
     [Fact]
     public async Task CheckEngineStartAsync_FirstObservationRunning_SeedsWithoutFiring()
     {
+        var ct = TestContext.Current.CancellationToken;
         var push = new FakePushSender();
         var svc = CreateService(push);
+        await using var db = CreateTestDb();
 
         // On restart the car may already be running; the first observation must not fire.
-        await svc.CheckEngineStartAsync("VIN1", new TelemetrySnapshot { EngineRunning = true }, CancellationToken.None);
+        await svc.CheckEngineStartAsync("VIN1", new TelemetrySnapshot { EngineRunning = true }, db, ct);
 
         Assert.Empty(push.Sent);
     }
@@ -222,12 +233,14 @@ public class MqttConsumerServiceTests
     [Fact]
     public async Task CheckEngineStartAsync_GenuineTransition_SendsPushNotification()
     {
+        var ct = TestContext.Current.CancellationToken;
         var push = new FakePushSender();
         var svc = CreateService(push);
+        await using var db = CreateTestDb();
 
         // Seed the state with the engine off, then observe a start.
-        await svc.CheckEngineStartAsync("VIN1", new TelemetrySnapshot { EngineRunning = false }, CancellationToken.None);
-        await svc.CheckEngineStartAsync("VIN1", new TelemetrySnapshot { EngineRunning = true }, CancellationToken.None);
+        await svc.CheckEngineStartAsync("VIN1", new TelemetrySnapshot { EngineRunning = false }, db, ct);
+        await svc.CheckEngineStartAsync("VIN1", new TelemetrySnapshot { EngineRunning = true }, db, ct);
 
         Assert.Single(push.Sent);
         Assert.Equal("Engine started", push.Sent[0].Title);
@@ -236,13 +249,15 @@ public class MqttConsumerServiceTests
     [Fact]
     public async Task CheckEngineStartAsync_AlreadyRunning_DoesNotSendAgain()
     {
+        var ct = TestContext.Current.CancellationToken;
         var push = new FakePushSender();
         var svc = CreateService(push);
+        await using var db = CreateTestDb();
 
         var snap = new TelemetrySnapshot { EngineRunning = true };
         // First: seed. Second: no transition. Neither fires.
-        await svc.CheckEngineStartAsync("VIN1", snap, CancellationToken.None);
-        await svc.CheckEngineStartAsync("VIN1", snap, CancellationToken.None);
+        await svc.CheckEngineStartAsync("VIN1", snap, db, ct);
+        await svc.CheckEngineStartAsync("VIN1", snap, db, ct);
 
         Assert.Empty(push.Sent);
     }
@@ -250,10 +265,12 @@ public class MqttConsumerServiceTests
     [Fact]
     public async Task CheckEngineStartAsync_EngineOff_DoesNotSendNotification()
     {
+        var ct = TestContext.Current.CancellationToken;
         var push = new FakePushSender();
         var svc = CreateService(push);
+        await using var db = CreateTestDb();
 
-        await svc.CheckEngineStartAsync("VIN1", new TelemetrySnapshot { EngineRunning = false }, CancellationToken.None);
+        await svc.CheckEngineStartAsync("VIN1", new TelemetrySnapshot { EngineRunning = false }, db, ct);
 
         Assert.Empty(push.Sent);
     }
@@ -261,13 +278,15 @@ public class MqttConsumerServiceTests
     [Fact]
     public async Task CheckEngineStartAsync_StartStopStart_SendsOneNotification()
     {
+        var ct = TestContext.Current.CancellationToken;
         var push = new FakePushSender();
         var svc = CreateService(push);
+        await using var db = CreateTestDb();
 
         // Seed (no fire), stop, start -> exactly one notification.
-        await svc.CheckEngineStartAsync("VIN1", new TelemetrySnapshot { EngineRunning = true }, CancellationToken.None);
-        await svc.CheckEngineStartAsync("VIN1", new TelemetrySnapshot { EngineRunning = false }, CancellationToken.None);
-        await svc.CheckEngineStartAsync("VIN1", new TelemetrySnapshot { EngineRunning = true }, CancellationToken.None);
+        await svc.CheckEngineStartAsync("VIN1", new TelemetrySnapshot { EngineRunning = true }, db, ct);
+        await svc.CheckEngineStartAsync("VIN1", new TelemetrySnapshot { EngineRunning = false }, db, ct);
+        await svc.CheckEngineStartAsync("VIN1", new TelemetrySnapshot { EngineRunning = true }, db, ct);
 
         Assert.Single(push.Sent);
     }
@@ -275,10 +294,12 @@ public class MqttConsumerServiceTests
     [Fact]
     public async Task CheckEngineStartAsync_NullEngineRunning_SkipsCheck()
     {
+        var ct = TestContext.Current.CancellationToken;
         var push = new FakePushSender();
         var svc = CreateService(push);
+        await using var db = CreateTestDb();
 
-        await svc.CheckEngineStartAsync("VIN1", new TelemetrySnapshot { EngineRunning = null }, CancellationToken.None);
+        await svc.CheckEngineStartAsync("VIN1", new TelemetrySnapshot { EngineRunning = null }, db, ct);
 
         Assert.Empty(push.Sent);
     }
@@ -286,16 +307,40 @@ public class MqttConsumerServiceTests
     [Fact]
     public async Task CheckEngineStartAsync_MultipleVins_TracksStateIndependently()
     {
+        var ct = TestContext.Current.CancellationToken;
         var push = new FakePushSender();
         var svc = CreateService(push);
+        await using var db = CreateTestDb();
 
         // Seed both VINs as off, then start each one independently.
-        await svc.CheckEngineStartAsync("VIN1", new TelemetrySnapshot { EngineRunning = false }, CancellationToken.None);
-        await svc.CheckEngineStartAsync("VIN2", new TelemetrySnapshot { EngineRunning = false }, CancellationToken.None);
-        await svc.CheckEngineStartAsync("VIN1", new TelemetrySnapshot { EngineRunning = true }, CancellationToken.None);
-        await svc.CheckEngineStartAsync("VIN2", new TelemetrySnapshot { EngineRunning = true }, CancellationToken.None);
+        await svc.CheckEngineStartAsync("VIN1", new TelemetrySnapshot { EngineRunning = false }, db, ct);
+        await svc.CheckEngineStartAsync("VIN2", new TelemetrySnapshot { EngineRunning = false }, db, ct);
+        await svc.CheckEngineStartAsync("VIN1", new TelemetrySnapshot { EngineRunning = true }, db, ct);
+        await svc.CheckEngineStartAsync("VIN2", new TelemetrySnapshot { EngineRunning = true }, db, ct);
 
         Assert.Equal(2, push.Sent.Count);
+    }
+
+    [Fact]
+    public async Task CheckEngineStartAsync_RapidFlap_DoesNotSendDuplicateNotification()
+    {
+        // Regression test for the P0 fix: MqttConsumerService.CheckEngineStartAsync previously
+        // sent a push on every false->true transition _engineRunningTracker observed, with no
+        // cooldown at all - a flapping EngineRunning signal (MQTT reconnect/replay noise) could
+        // fire a burst of duplicate "Engine started" pushes. The cooldown gate must suppress the
+        // second genuine transition within its window even though the tracker itself sees it as
+        // a real state change.
+        var ct = TestContext.Current.CancellationToken;
+        var push = new FakePushSender();
+        var svc = CreateService(push);
+        await using var db = CreateTestDb();
+
+        await svc.CheckEngineStartAsync("VIN1", new TelemetrySnapshot { EngineRunning = false }, db, ct);
+        await svc.CheckEngineStartAsync("VIN1", new TelemetrySnapshot { EngineRunning = true }, db, ct); // genuine start - sends
+        await svc.CheckEngineStartAsync("VIN1", new TelemetrySnapshot { EngineRunning = false }, db, ct); // flap off
+        await svc.CheckEngineStartAsync("VIN1", new TelemetrySnapshot { EngineRunning = true }, db, ct); // flap back on - must not re-send
+
+        Assert.Single(push.Sent);
     }
 }
 

--- a/src/GarageStack.Worker/Mqtt/MqttConsumerService.cs
+++ b/src/GarageStack.Worker/Mqtt/MqttConsumerService.cs
@@ -4,6 +4,7 @@ using GarageStack.Core.Helpers;
 using GarageStack.Core.Interfaces;
 using GarageStack.Core.Models;
 using GarageStack.Data;
+using GarageStack.Data.Extensions;
 using GarageStack.Worker.Services;
 using MQTTnet;
 using MQTTnet.Protocol;
@@ -26,6 +27,15 @@ public class MqttConsumerService(
     // observation for a VIN only seeds the tracker; it never fires a notification,
     // preventing bogus "engine started" alerts after a deploy or crash.
     internal readonly VinStateTracker<bool> _engineRunningTracker = new();
+
+    // Same cooldown and "engine-start" category PushNotificationCheckService uses for its own
+    // (slower, polled) engine-start detection - this path fires immediately on the MQTT event
+    // for low-latency delivery, but still needs its own gate: a flapping EngineRunning signal
+    // (reconnect/replay noise) would otherwise send an ungated push on every observed
+    // false->true transition. The two services' gates are separate instances, but both check
+    // AppNotifications via the same category key, so either one seeing a recent send suppresses
+    // the other.
+    private readonly NotificationCooldownGate _engineStartCooldownGate = new(TimeSpan.FromHours(1));
 
     // MQTT polling cycles emit several messages within ~2 seconds (one per topic).
     // Messages arriving within this window are merged into the same DB row so that
@@ -197,7 +207,7 @@ public class MqttConsumerService(
 
             await MergeOrAddTelemetryAsync(vehicle.Id, patch, topic, telemetryRepo, ct);
 
-            var tripCompleted = await CheckEngineStartAsync(vin, patch, ct);
+            var tripCompleted = await CheckEngineStartAsync(vin, patch, db, ct);
             if (tripCompleted && patch.VehicleId > 0)
             {
                 var vid = patch.VehicleId.ToString();
@@ -240,7 +250,7 @@ public class MqttConsumerService(
         }
     }
 
-    internal async Task<bool> CheckEngineStartAsync(string vin, TelemetrySnapshot snapshot, CancellationToken ct)
+    internal async Task<bool> CheckEngineStartAsync(string vin, TelemetrySnapshot snapshot, AppDbContext db, CancellationToken ct)
     {
         if (snapshot.EngineRunning is null) return false;
 
@@ -252,8 +262,13 @@ public class MqttConsumerService(
         switch (BoolTransitionDetector.Detect(hadPrevious, wasRunning, current))
         {
             case StateTransition.TurnedOn:
-                logger.LogInformation("Engine started for VIN={Vin} - sending push notification", vin);
-                await pushSender.SendToAllAsync("Engine started", "Your car has been started.", ct, "engine-start", snapshot.VehicleId);
+                var shouldNotify = await _engineStartCooldownGate.ShouldNotifyAsync(vin, "engine-start", cutoff =>
+                    db.WasNotificationSentSinceAsync("engine-start", snapshot.VehicleId, cutoff, ct));
+                if (shouldNotify)
+                {
+                    logger.LogInformation("Engine started for VIN={Vin} - sending push notification", vin);
+                    await pushSender.SendToAllAsync("Engine started", "Your car has been started.", ct, "engine-start", snapshot.VehicleId);
+                }
                 return false;
 
             case StateTransition.TurnedOff:


### PR DESCRIPTION
## Summary

Found during a follow-up review (same criteria as prior rounds -- #273-#279 are all merged).

`MqttConsumerService.CheckEngineStartAsync` sent a push on **every** `false`->`true` `EngineRunning` transition its own `_engineRunningTracker` observed, with **no cooldown at all**. This is a separate, parallel path from `PushNotificationCheckService.CheckEngineStart`'s own (slower, 5-minute-polled) engine-start detection, which **is** routed through `NotificationCooldownGate` -- and even sends different title/body text (`"Engine started"` / `"Your car has been started."` vs `"Car Started"` / `"Your car engine has started"`).

Real-world MQTT telemetry can flap (`EngineRunning` bouncing during a broker reconnect/replay), and each observed `false->true` transition on the ungated path would fire another push. Fixed by adding a `NotificationCooldownGate` to `MqttConsumerService` with the same 1-hour cooldown and `"engine-start"` category `PushNotificationCheckService` already uses -- the first notification still fires immediately (this path exists specifically for lower latency than the poll cycle), only repeats within the window are now suppressed.

## Test plan
- [x] `dotnet build` -- 0 warnings/errors
- [x] `dotnet test` -- 343/343 passing, including a new regression test (`CheckEngineStartAsync_RapidFlap_DoesNotSendDuplicateNotification`) simulating an off->on->off->on flap
- [x] Verified the regression test actually catches the bug: temporarily bypassed the new gate and confirmed the test fails (asserts 2 duplicate pushes instead of 1) before restoring the fix
- [x] Confirmed the existing 7 `CheckEngineStartAsync` tests still pass unchanged in behavior (each uses a fresh in-memory `AppDbContext` with no pre-seeded `AppNotifications`, so the DB-fallback check never suppresses a first-time genuine transition)

🤖 Generated with [Claude Code](https://claude.com/claude-code)