### PR TITLE
fix: RELEASING.md doc drift, PoiRepository cap+index, frontend store-proxy dedup

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -137,9 +137,8 @@ The `codeql` workflow runs alongside CI on every PR, every push to `main`, and w
 
 The `auto-merge` workflow merges Dependabot PRs automatically when CI passes, covering:
 
-- **All patch updates** (any package, any ecosystem)
-- **Any GitHub Actions updates** (infrastructure, low-risk)
-- **Minor updates** for any named Dependabot group (the condition is `dependency-group != ''`)
+- **All patch updates** (any package, any ecosystem, including GitHub Actions)
+- **Minor updates** for any named Dependabot group (the condition is `dependency-group != ''`) -- this covers GitHub Actions too, via the `docker-actions`/`github-actions` groups below
 
 Named groups defined in `.github/dependabot.yml`:
 

--- a/frontend/src/composables/usePoiLayers.ts
+++ b/frontend/src/composables/usePoiLayers.ts
@@ -1,4 +1,5 @@
 import { computed, ref, watch, onUnmounted, type ComputedRef, type Ref } from 'vue'
+import { storeToRefs } from 'pinia'
 import { useI18n } from 'vue-i18n'
 import { L, type LeafletMap } from '@/utils/leaflet'
 import 'leaflet.markercluster'
@@ -92,43 +93,17 @@ export interface UsePoiLayersOptions {
 export function usePoiLayers({ mapInstance, vehicleType, isHev, isBev }: UsePoiLayersOptions) {
   const { t } = useI18n()
   const settingsStore = useMapSettingsStore()
-
-  const chargingStationsEnabled = computed({
-    get: () => settingsStore.chargingStationsEnabled,
-    set: (v: boolean) => {
-      settingsStore.chargingStationsEnabled = v
-    },
-  })
-  const fuelStationsEnabled = computed({
-    get: () => settingsStore.fuelStationsEnabled,
-    set: (v: boolean) => {
-      settingsStore.fuelStationsEnabled = v
-    },
-  })
-  const serviceAreasEnabled = computed({
-    get: () => settingsStore.serviceAreasEnabled,
-    set: (v: boolean) => {
-      settingsStore.serviceAreasEnabled = v
-    },
-  })
-  const fuelBrandFilter = computed({
-    get: () => settingsStore.fuelBrandFilter,
-    set: (v: string[]) => {
-      settingsStore.fuelBrandFilter = v
-    },
-  })
-  const chargingMinPowerKw = computed({
-    get: () => settingsStore.chargingMinPowerKw,
-    set: (v: number) => {
-      settingsStore.chargingMinPowerKw = v
-    },
-  })
-  const chargingMaxPowerKw = computed({
-    get: () => settingsStore.chargingMaxPowerKw,
-    set: (v: number) => {
-      settingsStore.chargingMaxPowerKw = v
-    },
-  })
+  // These are plain refs on the store already (Composition-API-style defineStore), so
+  // storeToRefs gives directly writable, reactive bindings with no wrapper needed - a
+  // computed({get, set}) proxy per field would only reproduce what storeToRefs already does.
+  const {
+    chargingStationsEnabled,
+    fuelStationsEnabled,
+    serviceAreasEnabled,
+    fuelBrandFilter,
+    chargingMinPowerKw,
+    chargingMaxPowerKw,
+  } = storeToRefs(settingsStore)
 
   // Slider value: [minKw, maxKw] where max=350 means "no upper limit" (stored as 0 in settings)
   const powerRangeSlider = computed({

--- a/frontend/src/views/MapView.vue
+++ b/frontend/src/views/MapView.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { onMounted, onUnmounted, computed, ref, watch, nextTick } from 'vue'
+import { storeToRefs } from 'pinia'
 import { useI18n } from 'vue-i18n'
 import { useRoute, useRouter } from 'vue-router'
 import { useVehicleStore } from '@/stores/vehicle'
@@ -43,33 +44,12 @@ const isBev = computed(() => vehicleType.value === 'bev')
 const vehicleTypeKnown = computed(() => vehicleType.value !== 'unknown')
 const displayLocale = computed(() => (uiSettingsStore.locale === 'nl' ? 'nl-NL' : 'en-US'))
 const selectedTripIndex = ref<number | null>(null)
-const heatmapEnabled = computed({
-  get: () => settingsStore.heatmapEnabled,
-  set: (v: boolean) => {
-    settingsStore.heatmapEnabled = v
-  },
-})
-const speedOverlayEnabled = computed({
-  get: () => settingsStore.speedOverlayEnabled,
-  set: (v: boolean) => {
-    settingsStore.speedOverlayEnabled = v
-  },
-})
-const routeOutlineEnabled = computed({
-  get: () => settingsStore.routeOutlineEnabled,
-  set: (v: boolean) => {
-    settingsStore.routeOutlineEnabled = v
-  },
-})
+// Plain refs on their stores already (Composition-API-style defineStore) - storeToRefs gives
+// directly writable, reactive bindings with no computed({get, set}) wrapper needed.
+const { heatmapEnabled, speedOverlayEnabled, routeOutlineEnabled } = storeToRefs(settingsStore)
+const { filterDays: dateRangeDays } = storeToRefs(uiSettingsStore)
 
 let shouldSelectLatest = route.query.selectLatest === '1'
-
-const dateRangeDays = computed({
-  get: () => uiSettingsStore.filterDays,
-  set: (v: number) => {
-    uiSettingsStore.filterDays = v
-  },
-})
 const LOAD_MORE_SIZE = 10
 
 const mapWrapperRef = ref<HTMLElement | null>(null)

--- a/frontend/src/views/StatisticsView.vue
+++ b/frontend/src/views/StatisticsView.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import '@/assets/statistics.css'
 import { onMounted, computed, ref, watch } from 'vue'
+import { storeToRefs } from 'pinia'
 import { useI18n } from 'vue-i18n'
 import { useVehicleStore } from '@/stores/vehicle'
 import { useDashboardSettingsStore } from '@/stores/settingsDashboard'
@@ -58,12 +59,9 @@ const editMode = ref(false)
 const loading = ref(false)
 const aggregateStats = ref<VehicleAggregateStats | null>(null)
 
-const days = computed({
-  get: () => uiSettings.filterDays,
-  set: (v: number) => {
-    uiSettings.filterDays = v
-  },
-})
+// Plain ref on the store already (Composition-API-style defineStore) - storeToRefs gives a
+// directly writable, reactive binding with no computed({get, set}) wrapper needed.
+const { filterDays: days } = storeToRefs(uiSettings)
 
 const vin = computed(() => store.vehicles[0]?.vin ?? null)
 const status = computed(() => store.currentStatus)

--- a/src/GarageStack.Data/AppDbContext.cs
+++ b/src/GarageStack.Data/AppDbContext.cs
@@ -62,6 +62,11 @@ public class AppDbContext(DbContextOptions<AppDbContext> options) : DbContext(op
              .HasDatabaseName("IX_PoiItems_Source_ExternalId");
             e.HasIndex(p => new { p.Source, p.PoiType, p.CellLat, p.CellLng })
              .HasDatabaseName("IX_PoiItems_Source_PoiType_CellLatLng");
+            // Backs GetPoisInBoundsAsync's lat/lng range query - without this, that query can
+            // only narrow to the Source+PoiType partition via the index above and then scans
+            // every row in it, since neither Latitude nor Longitude appear in any other index.
+            e.HasIndex(p => new { p.Source, p.PoiType, p.Latitude, p.Longitude })
+             .HasDatabaseName("IX_PoiItems_Source_PoiType_LatLon");
             e.Property(p => p.Source).HasMaxLength(32).IsRequired();
             e.Property(p => p.PoiType).HasMaxLength(32).IsRequired();
             e.Property(p => p.ExternalId).HasMaxLength(64).IsRequired();

--- a/src/GarageStack.Data/Migrations/20260717111244_AddPoiItemsLatLonIndex.Designer.cs
+++ b/src/GarageStack.Data/Migrations/20260717111244_AddPoiItemsLatLonIndex.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using GarageStack.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace GarageStack.Data.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260717111244_AddPoiItemsLatLonIndex")]
+    partial class AddPoiItemsLatLonIndex
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/GarageStack.Data/Migrations/20260717111244_AddPoiItemsLatLonIndex.cs
+++ b/src/GarageStack.Data/Migrations/20260717111244_AddPoiItemsLatLonIndex.cs
@@ -1,0 +1,27 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace GarageStack.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddPoiItemsLatLonIndex : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateIndex(
+                name: "IX_PoiItems_Source_PoiType_LatLon",
+                table: "PoiItems",
+                columns: new[] { "Source", "PoiType", "Latitude", "Longitude" });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_PoiItems_Source_PoiType_LatLon",
+                table: "PoiItems");
+        }
+    }
+}

--- a/src/GarageStack.Data/Repositories/PoiRepository.cs
+++ b/src/GarageStack.Data/Repositories/PoiRepository.cs
@@ -3,15 +3,25 @@ using GarageStack.Core.Interfaces;
 using GarageStack.Core.Models;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging;
 using Npgsql;
 
 namespace GarageStack.Data.Repositories;
 
-public class PoiRepository(AppDbContext db, IMemoryCache cache) : IPoiRepository
+// logger is optional (DI always supplies one) so existing tests can keep constructing this
+// directly with just a DbContext and cache.
+public class PoiRepository(AppDbContext db, IMemoryCache cache, ILogger<PoiRepository>? logger = null) : IPoiRepository
 {
     // Brand lists (charging network operators, fuel brands) change rarely, so a short cache
     // avoids re-deserializing every PoiItem's MetaJson on every map filter-panel open.
     private static readonly TimeSpan BrandsCacheTtl = TimeSpan.FromMinutes(15);
+
+    // Defensive cap on GetPoisInBoundsAsync. The map endpoint already bounds radiusKm to
+    // <= 200km (MapEndpoints.ValidateRadiusKm), and POI density is inherently bounded by
+    // real-world business counts (nowhere near TelemetryRepository's per-vehicle row growth),
+    // so this is far above any realistic result set - a safety net, not expected to affect
+    // normal queries.
+    private const int MaxPoisPerBoundsQuery = 10_000;
     // Used both for the on-demand API path (any tile not cached yet) and the Worker's
     // pre-cache path (tiles whose cache has since expired) - "uncached" and "expired or
     // missing" are the same query: anything outside the currently-valid (ExpiresAt > now) set.
@@ -157,12 +167,20 @@ public class PoiRepository(AppDbContext db, IMemoryCache cache) : IPoiRepository
         double maxLat, double maxLng,
         CancellationToken ct = default)
     {
-        return await db.PoiItems
+        var pois = await db.PoiItems
             .Where(p => p.Source == source && p.PoiType == poiType
                         && p.Latitude >= minLat && p.Latitude <= maxLat
                         && p.Longitude >= minLng && p.Longitude <= maxLng)
             .AsNoTracking()
+            .Take(MaxPoisPerBoundsQuery)
             .ToListAsync(ct);
+
+        if (pois.Count == MaxPoisPerBoundsQuery)
+            logger?.LogWarning(
+                "GetPoisInBoundsAsync hit the {Cap}-row cap for source={Source} poiType={PoiType} bounds=({MinLat},{MinLng})-({MaxLat},{MaxLng})",
+                MaxPoisPerBoundsQuery, source, poiType, minLat, minLng, maxLat, maxLng);
+
+        return pois;
     }
 
     public async Task<IReadOnlyList<string>> GetDistinctBrandsAsync(

--- a/src/GarageStack.Tests/PoiRepositoryTests.cs
+++ b/src/GarageStack.Tests/PoiRepositoryTests.cs
@@ -1,0 +1,77 @@
+using GarageStack.Core.Models;
+using GarageStack.Data;
+using GarageStack.Data.Repositories;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Caching.Memory;
+
+namespace GarageStack.Tests;
+
+public class PoiRepositoryTests
+{
+    private static AppDbContext CreateDb() =>
+        new(new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options);
+
+    private static PoiRepository CreateRepo(AppDbContext db) =>
+        new(db, new MemoryCache(new MemoryCacheOptions()));
+
+    private static PoiItem MakeItem(string source, string poiType, string externalId, double lat, double lng) => new()
+    {
+        Source = source,
+        PoiType = poiType,
+        ExternalId = externalId,
+        Latitude = lat,
+        Longitude = lng,
+        CellLat = (int)lat,
+        CellLng = (int)lng,
+    };
+
+    [Fact]
+    public async Task GetPoisInBoundsAsync_ReturnsOnlyItemsWithinBounds()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        await using var db = CreateDb();
+        db.PoiItems.AddRange(
+            MakeItem("overpass", "fuel", "inside", lat: 52.0, lng: 5.0),
+            MakeItem("overpass", "fuel", "outside-lat", lat: 60.0, lng: 5.0),
+            MakeItem("overpass", "fuel", "outside-lng", lat: 52.0, lng: 20.0));
+        await db.SaveChangesAsync(ct);
+
+        var result = await CreateRepo(db).GetPoisInBoundsAsync(
+            "overpass", "fuel", minLat: 51.0, minLng: 4.0, maxLat: 53.0, maxLng: 6.0, ct);
+
+        Assert.Single(result);
+        Assert.Equal("inside", result[0].ExternalId);
+    }
+
+    [Fact]
+    public async Task GetPoisInBoundsAsync_FiltersBySourceAndPoiType()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        await using var db = CreateDb();
+        db.PoiItems.AddRange(
+            MakeItem("overpass", "fuel", "match", lat: 52.0, lng: 5.0),
+            MakeItem("ocm", "charging", "wrong-source", lat: 52.0, lng: 5.0),
+            MakeItem("overpass", "service_area", "wrong-type", lat: 52.0, lng: 5.0));
+        await db.SaveChangesAsync(ct);
+
+        var result = await CreateRepo(db).GetPoisInBoundsAsync(
+            "overpass", "fuel", minLat: 51.0, minLng: 4.0, maxLat: 53.0, maxLng: 6.0, ct);
+
+        Assert.Single(result);
+        Assert.Equal("match", result[0].ExternalId);
+    }
+
+    [Fact]
+    public async Task GetPoisInBoundsAsync_NoMatches_ReturnsEmpty()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        await using var db = CreateDb();
+
+        var result = await CreateRepo(db).GetPoisInBoundsAsync(
+            "overpass", "fuel", minLat: 51.0, minLng: 4.0, maxLat: 53.0, maxLng: 6.0, ct);
+
+        Assert.Empty(result);
+    }
+}


### PR DESCRIPTION
## Summary

Three real, verified P1 fixes from a follow-up review (same criteria as prior rounds -- #273-#280 are all merged/open).

- **`RELEASING.md`** documented a pre-fix auto-merge exemption for GitHub Actions updates that no longer exists in `auto-merge.yml` (removed two rounds ago). Corrected the table to match the actual workflow logic.
- **`PoiRepository.GetPoisInBoundsAsync`** had no row cap (unlike the trip/history queries capped in an earlier round) and no index covering its lat/lng range filter -- the query could only narrow to the `Source`+`PoiType` partition via the existing tile index and then scanned every row in it. Added a defensive 10,000-row cap (far above any realistic POI density, even at the endpoint's max 200km radius) and a new index on `(Source, PoiType, Latitude, Longitude)` via a migration.
- **Frontend**: a new duplication pattern with 11 real occurrences across `usePoiLayers.ts`, `MapView.vue`, and `StatisticsView.vue` -- each wrapped a plain `ref` on a Composition-API Pinia store in an identical `computed({get, set})` just to re-expose it. Replaced with `storeToRefs()`, which provides the same writable/reactive binding with no wrapper. Left two components alone that use the same syntax but for real type-transforming logic (`AppFooter.vue`'s theme/locale toggles, `usePoiLayers.ts`'s power-range slider) -- `storeToRefs()` doesn't apply to those.

## Test plan
- [x] `dotnet build` / `dotnet test` -- 345/345 passing (3 new `PoiRepositoryTests` covering bounds filtering and source/type isolation)
- [x] `vue-tsc --build`, `oxlint`/`eslint`, `prettier --write` -- all clean
- [x] `pnpm test:unit` -- 249/249 passing
- [x] Migration generated via `dotnet ef migrations add` and reviewed -- a single, reversible `CREATE INDEX`/`DROP INDEX`
- [x] Manually verified in a real browser (demo mode): Map view's Filters panel (heatmap/route-outline/speed-overlay toggles, period selector) and Statistics view's period selector both render and reflect store state correctly after the `storeToRefs` refactor

🤖 Generated with [Claude Code](https://claude.com/claude-code)