### PR TITLE
docs+perf: small polish (N+1 fix, doc corrections, JSDoc gaps)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -76,8 +76,8 @@ process-local one doesn't already provide. Two caches exist today:
   and be queried by bounding box - a job a plain in-memory cache isn't suited for anyway.
 
 If GarageStack ever needs to run more than one Api/Worker instance, revisit this: per-vehicle
-in-memory state (this cache, `VehicleCommandGate`, the Overpass/OCM rate limiters) would all
-need to move to something shared.
+in-memory state (this cache, `VehicleCommandGate`, `NotificationCooldownGate`, the Overpass/OCM
+rate limiters) would all need to move to something shared.
 
 ## Database
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -74,8 +74,7 @@ This project follows a coordinated vulnerability disclosure model. Good-faith se
 
 ### Frontend
 
-- Content Security Policy (CSP) headers are applied
-- Subresource Integrity (SRI) is used for third-party assets where supported
+- Content Security Policy (CSP) headers are applied, restricting scripts/styles to same-origin plus specific sha256 hashes (`script-src 'self' 'sha256-...'`) -- there are no third-party CDN assets to apply SRI to; everything is self-hosted and bundled at build time
 - No sensitive data is stored in `localStorage` or `sessionStorage`
 
 ### Database

--- a/frontend/src/composables/useNotifications.ts
+++ b/frontend/src/composables/useNotifications.ts
@@ -28,6 +28,15 @@ const loading = ref(false)
 const fetchError = ref<string | null>(null)
 const actionError = ref<string | null>(null)
 
+/**
+ * Owns the in-app notification list: fetching, the user's per-category exclusion filter,
+ * unread badge sync (both the PWA app badge and the bell icon), service-worker push wiring,
+ * and the archive/delete actions. The underlying state (`notifications`, `panelOpen`, etc.) is
+ * module-level, not per-call - every component calling this composable shares one list, so
+ * e.g. archiving a notification in one place updates it everywhere. Fetches automatically
+ * whenever auth state changes (via a watcher, not onMounted, since App.vue stays mounted
+ * across login rather than remounting).
+ */
 export function useNotifications() {
   const auth = useAuthStore()
   const uiSettings = useUiSettingsStore()

--- a/frontend/src/composables/useSignalR.ts
+++ b/frontend/src/composables/useSignalR.ts
@@ -11,6 +11,14 @@ export interface SignalRCallbacks {
   onTripCompleted: (vehicleId: number) => void
 }
 
+/**
+ * Owns the SignalR connection to the `/hubs/telemetry` hub: connecting, joining the given
+ * vehicle's group, automatic reconnection, and dispatching the three server-pushed events
+ * (telemetry, notifications, trip-completed) to caller-supplied callbacks. This is the app's
+ * only real-time channel - there is no REST-polling fallback, so if `start()` fails or the
+ * connection drops without reconnecting, the UI simply goes stale until `start()` is called
+ * again (next mount or a manual reload).
+ */
 export function useSignalR(callbacks: SignalRCallbacks) {
   const connected = ref(false)
   let connection: signalR.HubConnection | null = null

--- a/src/GarageStack.Api/Endpoints/WidgetEndpoints.cs
+++ b/src/GarageStack.Api/Endpoints/WidgetEndpoints.cs
@@ -144,6 +144,13 @@ public record WidgetStatusDto(
             return false;
         }
 
+        // Approximates "% of today's driving done on electric power" for PHEVs: the gateway
+        // has no direct electric-vs-fuel mileage split, so this uses MileageSinceLastCharge
+        // (distance covered since the last EV charge, a proxy for "electric-covered distance")
+        // against MileageOfTheDay (today's total distance, all power sources). Since the last
+        // charge can be several days ago while MileageOfTheDay only covers today, the ratio can
+        // exceed 100% (e.g. charged 3 days ago, driven a little each day since) - capped rather
+        // than treated as exact.
         double? electricShare = s.MileageSinceLastCharge.HasValue && s.MileageOfTheDay is > 0
             ? Math.Min(100, Math.Round(s.MileageSinceLastCharge.Value / s.MileageOfTheDay!.Value * 100))
             : null;

--- a/src/GarageStack.Core/Helpers/VehicleTypeHelper.cs
+++ b/src/GarageStack.Core/Helpers/VehicleTypeHelper.cs
@@ -8,6 +8,9 @@ public static class VehicleTypeHelper
     {
         var cfg = SafeJson.TryDeserialize<Dictionary<string, string>>(v.ConfigJson);
         var hw = (cfg?.GetValueOrDefault("hw_version") ?? "").ToUpperInvariant();
+        // Order is load-bearing, most-specific first: "PHEV".Contains("HEV") and
+        // "PHEV".Contains("EV") are both true, so checking HEV or EV before PHEV would
+        // misclassify every plug-in hybrid. Do not reorder or alphabetize these checks.
         if (hw.Contains("PHEV")) return "phev";
         if (hw.Contains("HEV")) return "hev";
         if (hw.Contains("EV")) return "bev";

--- a/src/GarageStack.Worker/Services/MaintenanceCheckService.cs
+++ b/src/GarageStack.Worker/Services/MaintenanceCheckService.cs
@@ -44,12 +44,15 @@ public class MaintenanceCheckService(
 
         var vehicles = await db.Vehicles.ToListAsync(ct);
 
+        // One query for every vehicle's items instead of one query per vehicle (mirrors the
+        // grouped-lookup pattern PoiPreCachingService already uses for latest-location data).
+        var itemsByVehicle = (await db.MaintenanceItems.AsNoTracking().ToListAsync(ct))
+            .GroupBy(m => m.VehicleId)
+            .ToDictionary(g => g.Key, g => g.ToList());
+
         foreach (var vehicle in vehicles)
         {
-            var items = await db.MaintenanceItems.AsNoTracking()
-                .Where(m => m.VehicleId == vehicle.Id)
-                .ToListAsync(ct);
-            if (items.Count == 0) continue;
+            if (!itemsByVehicle.TryGetValue(vehicle.Id, out var items) || items.Count == 0) continue;
 
             var snapshot = await telemetry.GetMergedLatestAsync(vehicle.Id, ct);
 


### PR DESCRIPTION
## Summary

Five small, low-risk items from a follow-up review (same criteria as prior rounds -- #273-#281 are all merged/open).

- **`MaintenanceCheckService`**: fixed an N+1 query (one `MaintenanceItems` query per vehicle instead of one grouped query total). Low real-world impact since this runs every 6h, but the fix is cheap and mirrors a pattern already used by `PoiPreCachingService`.
- **Two backend documentation gaps**: `VehicleTypeHelper.GetVehicleType`'s load-bearing check order (PHEV before HEV before EV -- reordering would silently misclassify every plug-in hybrid) and `WidgetEndpoints`' unexplained `electricShare` approximation (and why it's capped at 100% rather than exact).
- **`SECURITY.md`**: corrected a stale claim that SRI is used for third-party assets -- there are no third-party assets, everything is self-hosted and Vite-bundled; described what's actually enforced (CSP with same-origin + sha256-hash script/style restrictions) instead.
- **`ARCHITECTURE.md`**: added `NotificationCooldownGate` to the Caching section's list of per-process in-memory state that would need to move to shared storage under multi-instance scaling -- it was introduced/extended after that doc was first written and got missed.
- **Frontend JSDoc**: added the same "what this owns" header comment style other complex composables (`usePoiLayers`, `useLeafletMap`, `useBooleanStatusList`) already have to `useSignalR.ts` and `useNotifications.ts`.

## Test plan
- [x] `dotnet build` / `dotnet test` -- 343/343 passing (no behavior change from the N+1 fix; documentation-only elsewhere)
- [x] `vue-tsc --build`, `oxlint`/`eslint` -- clean
- [x] `pnpm test:unit` -- 249/249 passing
- [x] Cross-checked the SECURITY.md correction against the actual CSP header in `frontend/nginx.conf`/`docker/all-in-one/nginx.conf` and confirmed zero third-party `<script>`/`<link>` tags in the built output
- [x] Cross-checked the `electricShare` doc comment's description against README's existing description of the same metric for consistency

🤖 Generated with [Claude Code](https://claude.com/claude-code)