### PR TITLE
fix: sanitize poiType before logging (CWE-117 log forging)

### DIFF
--- a/src/GarageStack.Data/Repositories/PoiRepository.cs
+++ b/src/GarageStack.Data/Repositories/PoiRepository.cs
@@ -176,9 +176,12 @@ public class PoiRepository(AppDbContext db, IMemoryCache cache, ILogger<PoiRepos
             .ToListAsync(ct);
 
         if (pois.Count == MaxPoisPerBoundsQuery)
+        {
+            var safePoiType = poiType.Replace("\r", "").Replace("\n", "");
             logger?.LogWarning(
                 "GetPoisInBoundsAsync hit the {Cap}-row cap for source={Source} poiType={PoiType} bounds=({MinLat},{MinLng})-({MaxLat},{MaxLng})",
-                MaxPoisPerBoundsQuery, source, poiType, minLat, minLng, maxLat, maxLng);
+                MaxPoisPerBoundsQuery, source, safePoiType, minLat, minLng, maxLat, maxLng);
+        }
 
         return pois;
     }


### PR DESCRIPTION
## Summary
- Fixes [CodeQL alert #471](https://github.com/joszz/GarageStack/security/code-scanning/471) (`cs/log-forging`, CWE-117)
- `PoiRepository.GetPoisInBoundsAsync` logged the raw `poiType` value in its cap-warning message. `PoiService` already strips CR/LF from the same value before its own log call, but that sanitized copy wasn't the one passed down to the repository, so the repository's own log line was still built from the untouched value.
- Applies the same `.Replace("\r", "").Replace("\n", "")` sanitization used elsewhere in the codebase (`PoiService.cs`, `AuthEndpoints.SanitizeForLog`) at the repository log call site.

## Test plan
- [x] `dotnet test src/GarageStack.Tests --filter "FullyQualifiedName~PoiRepositoryTests|FullyQualifiedName~PoiServiceTests"` — 14/14 passed